### PR TITLE
cmake: Change version to 1.0.1 for next release

### DIFF
--- a/BasisProject.cmake
+++ b/BasisProject.cmake
@@ -52,7 +52,7 @@ basis_project (
   # --------------------------------------------------------------------------
   # meta-data
   NAME         "MIRTK"
-  VERSION      "1.0.0" # Version of core (+ external) modules
+  VERSION      "1.0.1" # Version of core (+ external) modules
   SOVERSION    "0"     # API yet unstable
   AUTHORS      "Andreas Schuh"
   DESCRIPTION  "Medical Image Registration ToolKit"


### PR DESCRIPTION
To avoid confusion with the tagged release version, change version number of master branch after first bugfix commit after the release.