### PR TITLE
Fix resampling filter

### DIFF
--- a/Modules/Image/src/mirtkImageToImage.cc
+++ b/Modules/Image/src/mirtkImageToImage.cc
@@ -136,7 +136,7 @@ template <class VoxelType>
 void ImageToImage<VoxelType>::Finalize()
 {
   if (_Buffer) {
-    _Buffer->CopyFrom(_Output->Data());
+    *_Buffer = *_Output;
     swap(_Buffer, _Output);
     Delete(_Buffer);
   }

--- a/Modules/Image/src/mirtkResampling.cc
+++ b/Modules/Image/src/mirtkResampling.cc
@@ -72,7 +72,7 @@ template <class VoxelType>
 void Resampling<VoxelType>::Initialize()
 {
   // Initialize base class
-  ImageToImage<VoxelType>::Initialize();
+  ImageToImage<VoxelType>::Initialize(false);
 
   // Set up interpolator
   if (_Interpolator == NULL) {


### PR DESCRIPTION
The ```ImageToImage::Finalize``` function only copies the image content from the temporary output image, but not the image attributes. Secondly, it is not necessary to allocate the output image in the base class in case of ```Resampling::Initialize``` as it will be re-allocated by this function then again.