### PR TITLE
enh: Define and use own constants for \pi

### DIFF
--- a/Applications/extract-pointset-surface.cc
+++ b/Applications/extract-pointset-surface.cc
@@ -393,7 +393,7 @@ int main(int argc, char *argv[])
         if (d > rmax) rmax = d;
       }
       double r = (type == OutputBoundingSphere ? rmax : rmin);
-      const double l = 2.0 * M_PI * r;
+      const double l = two_pi * r;
       if (IsNaN(resolution)) resolution = r / 8;
       vtkNew<vtkSphereSource> sphere;
       sphere->SetCenter(c);

--- a/Applications/smooth-surface.cc
+++ b/Applications/smooth-surface.cc
@@ -304,7 +304,7 @@ void AreaWeightedLaplacianSmoothing(vtkPolyData *input,
     area = surfaceArea(input);
 
     // The L_2 norm using the Tosun formulation (MedIA 2004)
-    h2norm = sqrt(E_H2 * area / 4.0 / M_PI);
+    h2norm = sqrt(E_H2 * area / 4.0 / pi);
     if (h2norm < smoothnessThreshold) break;
     if (verbose > 1) cout << h2norm << endl;
 

--- a/Modules/Common/include/mirtkCommon.h
+++ b/Modules/Common/include/mirtkCommon.h
@@ -43,6 +43,7 @@
 
 // Standard functions/types
 #include <mirtkAssert.h>
+#include <mirtkMath.h>
 #include <mirtkMemory.h>
 #include <mirtkString.h>
 #include <mirtkPath.h>

--- a/Modules/Common/include/mirtkMath.h
+++ b/Modules/Common/include/mirtkMath.h
@@ -35,6 +35,25 @@ namespace mirtk {
 
 
 // =============================================================================
+// Constants
+// =============================================================================
+
+/// Constant value of \f$ \pi \f$
+extern const double pi;
+
+/// Constant value of \f$ 2\pi \f$
+extern const double two_pi;
+
+/// Constant value of \f$ \pi / 2 \f$
+extern const double pi_half;
+
+/// Radians per degree, i.e., \f$ \pi / 180 \f$
+extern const double rad_per_deg;
+
+/// Degree per radian, i.e., \f$ 180 / \pi \f$
+extern const double deg_per_rad;
+
+// =============================================================================
 // C/C++ library functions
 // =============================================================================
 

--- a/Modules/Common/src/CMakeLists.txt
+++ b/Modules/Common/src/CMakeLists.txt
@@ -80,6 +80,7 @@ set(SOURCES
   mirtkCifstream.cc
   mirtkCofstream.cc
   mirtkConfigurable.cc
+  mirtkMath.cc
   mirtkMemory.cc
   mirtkObserver.cc
   mirtkOptions.cc

--- a/Modules/Common/src/mirtkMath.cc
+++ b/Modules/Common/src/mirtkMath.cc
@@ -1,0 +1,36 @@
+/*
+ * Medical Image Registration ToolKit (MIRTK)
+ *
+ * Copyright 2016 Imperial College London
+ * Copyright 2016 Andreas Schuh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define _USE_MATH_DEFINES
+#include <cmath>
+
+#include <mirtkMath.h>
+
+
+namespace mirtk {
+
+
+const double pi          = double(M_PI);
+const double pi_half     = 0.5 * pi;
+const double two_pi      = 2.0 * pi;
+const double rad_per_deg = pi / 180.0;
+const double deg_per_rad = 180.0 / pi;
+
+
+} // namespace mirtk

--- a/Modules/Numerics/src/mirtkArith.cc
+++ b/Modules/Numerics/src/mirtkArith.cc
@@ -16,9 +16,8 @@
  * limitations under the License.
  */
 
-#include <cmath>
-#include <cstdlib>
 
+#include <mirtkMath.h>
 #include <mirtkArith.h>
 
 using namespace std;
@@ -66,7 +65,7 @@ double ACos(double fValue)
     else
       return 0.0;
   } else {
-    return M_PI;
+    return pi;
   }
 }
 
@@ -77,9 +76,9 @@ double ASin(double fValue)
     if ( fValue < 1.0 )
       return double(asin(fValue));
     else
-      return -M_PI/2.0;
+      return -pi_half;
   } else {
-    return M_PI/2.0;
+    return pi_half;
   }
 }
 

--- a/Modules/Numerics/src/mirtkMatrix3x3.cc
+++ b/Modules/Numerics/src/mirtkMatrix3x3.cc
@@ -1083,7 +1083,7 @@ void Matrix3x3::ToAxisAngle (Vector3& rkAxis, double& rfRadians) const
   rfRadians = ACos(fCos);  // in [0,PI]
 
   if ( rfRadians > 0.0 ) {
-    if ( rfRadians < M_PI ) {
+    if ( rfRadians < pi ) {
       rkAxis.x = m_aafEntry[2][1]-m_aafEntry[1][2];
       rkAxis.y = m_aafEntry[0][2]-m_aafEntry[2][0];
       rkAxis.z = m_aafEntry[1][0]-m_aafEntry[0][1];
@@ -1172,8 +1172,8 @@ bool Matrix3x3::ToEulerAnglesXYZ (float& rfYAngle, float& rfPAngle,
   //       -cx*cz*sy+sx*sz  cz*sx+cx*sy*sz  cx*cy
 
   rfPAngle = ASin(m_aafEntry[0][2]);
-  if ( rfPAngle < M_PI/2.0 ) {
-    if ( rfPAngle > -M_PI/2.0 ) {
+  if ( rfPAngle < pi_half ) {
+    if ( rfPAngle > -pi_half ) {
       rfYAngle = ATan2(-m_aafEntry[1][2],m_aafEntry[2][2]);
       rfRAngle = ATan2(-m_aafEntry[0][1],m_aafEntry[0][0]);
       return true;
@@ -1202,8 +1202,8 @@ bool Matrix3x3::ToEulerAnglesXZY (float& rfYAngle, float& rfPAngle,
   //       -cx*sy+cy*sx*sz  cz*sx           cx*cy+sx*sy*sz
 
   rfPAngle = ASin(-m_aafEntry[0][1]);
-  if ( rfPAngle < M_PI/2.0 ) {
-    if ( rfPAngle > -M_PI/2.0 ) {
+  if ( rfPAngle < pi_half ) {
+    if ( rfPAngle > -pi_half ) {
       rfYAngle = ATan2(m_aafEntry[2][1],m_aafEntry[1][1]);
       rfRAngle = ATan2(m_aafEntry[0][2],m_aafEntry[0][0]);
       return true;
@@ -1232,8 +1232,8 @@ bool Matrix3x3::ToEulerAnglesYXZ (float& rfYAngle, float& rfPAngle,
   //       -cz*sy+cy*sx*sz  cy*cz*sx+sy*sz  cx*cy
 
   rfPAngle = ASin(-m_aafEntry[1][2]);
-  if ( rfPAngle < M_PI/2.0 ) {
-    if ( rfPAngle > -M_PI/2.0 ) {
+  if ( rfPAngle < pi_half ) {
+    if ( rfPAngle > -pi_half ) {
       rfYAngle = ATan2(m_aafEntry[0][2],m_aafEntry[2][2]);
       rfRAngle = ATan2(m_aafEntry[1][0],m_aafEntry[1][1]);
       return true;
@@ -1262,8 +1262,8 @@ bool Matrix3x3::ToEulerAnglesYZX (float& rfYAngle, float& rfPAngle,
   //       -cz*sy           cy*sx+cx*sy*sz  cx*cy-sx*sy*sz
 
   rfPAngle = ASin(m_aafEntry[1][0]);
-  if ( rfPAngle < M_PI/2.0 ) {
-    if ( rfPAngle > -M_PI/2.0 ) {
+  if ( rfPAngle < pi_half ) {
+    if ( rfPAngle > -pi_half ) {
       rfYAngle = ATan2(-m_aafEntry[2][0],m_aafEntry[0][0]);
       rfRAngle = ATan2(-m_aafEntry[1][2],m_aafEntry[1][1]);
       return true;
@@ -1292,8 +1292,8 @@ bool Matrix3x3::ToEulerAnglesZXY (float& rfYAngle, float& rfPAngle,
   //       -cx*sy           sx              cx*cy
 
   rfPAngle = ASin(m_aafEntry[2][1]);
-  if ( rfPAngle < M_PI/2.0 ) {
-    if ( rfPAngle > -M_PI/2.0 ) {
+  if ( rfPAngle < pi_half ) {
+    if ( rfPAngle > -pi_half ) {
       rfYAngle = ATan2(-m_aafEntry[0][1],m_aafEntry[1][1]);
       rfRAngle = ATan2(-m_aafEntry[2][0],m_aafEntry[2][2]);
       return true;
@@ -1321,8 +1321,8 @@ bool Matrix3x3::ToEulerAnglesZYX(float& rfYAngle, float& rfPAngle, float& rfRAng
   //       -sy              cy*sx           cx*cy
 
   rfPAngle = ASin(-m_aafEntry[2][0]);
-  if ( rfPAngle < M_PI/2.0 ) {
-    if ( rfPAngle > -M_PI/2.0 ) {
+  if ( rfPAngle < pi_half ) {
+    if ( rfPAngle > -pi_half ) {
       rfYAngle = ATan2(m_aafEntry[1][0],m_aafEntry[0][0]);
       rfRAngle = ATan2(m_aafEntry[2][1],m_aafEntry[2][2]);
       return true;

--- a/Modules/Numerics/src/mirtkPointSamples.cc
+++ b/Modules/Numerics/src/mirtkPointSamples.cc
@@ -297,14 +297,14 @@ void PointSamples::SampleRegularHalfSphere(double cx, double cy, double cz,
     // On the equator, we only need half of the directions
     else if (theta >= (M_PI_2 - epsilon)) {
       dPhi  [i] = min(M_PI_2, dTheta / sinf( theta ) );
-      maxPhi[i] = max(1, static_cast<int>(M_PI / dPhi[i]) - 1);
-      dPhi  [i] = M_PI / (maxPhi[i] + 1);
+      maxPhi[i] = max(1, static_cast<int>(pi / dPhi[i]) - 1);
+      dPhi  [i] = pi / (maxPhi[i] + 1);
     }
     // Otherwise, let's sample the entire circle parallel to the equator
     else {
       dPhi  [i] = min(M_PI_2, dTheta / sin(theta));
-      maxPhi[i] = max(3, 2 * static_cast<int>(M_PI / dPhi[i]) - 1);
-      dPhi  [i] = 2.0 * M_PI / (maxPhi[i] + 1);
+      maxPhi[i] = max(3, 2 * static_cast<int>(pi / dPhi[i]) - 1);
+      dPhi  [i] = two_pi / (maxPhi[i] + 1);
     }
     n += maxPhi[i] + 1;
   }

--- a/Modules/Numerics/src/mirtkScalarGaussian.cc
+++ b/Modules/Numerics/src/mirtkScalarGaussian.cc
@@ -32,10 +32,10 @@ namespace mirtk {
 // -----------------------------------------------------------------------------
 void ScalarGaussian::ComputeNorm()
 {
-  _Norm[0] = (_Variance._x > .0 ? (1.0      / sqrt(2.0 * M_PI * _Variance._x)) : 1.0);
-  _Norm[1] = (_Variance._y > .0 ? (_Norm[0] / sqrt(2.0 * M_PI * _Variance._y)) : 1.0);
-  _Norm[2] = (_Variance._z > .0 ? (_Norm[1] / sqrt(2.0 * M_PI * _Variance._z)) : 1.0);
-  _Norm[3] = (_Variance._t > .0 ? (_Norm[2] / sqrt(2.0 * M_PI * _Variance._t)) : 1.0);
+  _Norm[0] = (_Variance._x > .0 ? (1.0      / sqrt(two_pi * _Variance._x)) : 1.0);
+  _Norm[1] = (_Variance._y > .0 ? (_Norm[0] / sqrt(two_pi * _Variance._y)) : 1.0);
+  _Norm[2] = (_Variance._z > .0 ? (_Norm[1] / sqrt(two_pi * _Variance._z)) : 1.0);
+  _Norm[3] = (_Variance._t > .0 ? (_Norm[2] / sqrt(two_pi * _Variance._t)) : 1.0);
   if (_Variance._x <= .0) _Variance._x = 1.0;
   if (_Variance._y <= .0) _Variance._y = 1.0;
   if (_Variance._z <= .0) _Variance._z = 1.0;

--- a/Modules/Numerics/src/mirtkSinc.cc
+++ b/Modules/Numerics/src/mirtkSinc.cc
@@ -41,7 +41,7 @@ void Sinc<TReal>::Initialize()
     // Fill remaining fields (symmetric, so we only use positive distances)
     TReal alpha;
     for (int i = 1; i < N; ++i) {
-      alpha          = M_PI * TReal(i) / LookupTableSize;
+      alpha          = pi * TReal(i) / LookupTableSize;
       LookupTable[i] = TReal(0.5) * (TReal(1) + cos(alpha/Radius)) * sin(alpha) / alpha;
     }
   }

--- a/Modules/PointSet/include/mirtkImplicitSurfaceUtils.h
+++ b/Modules/PointSet/include/mirtkImplicitSurfaceUtils.h
@@ -768,14 +768,14 @@ inline void EvaluateTangential(DistanceMeasurement &d,
       dirs(3) = (Point(e1) - Point(e2)) / sqrt2;
     } break;
     default:
-      double alpha = .0, delta = M_PI / ndirs;
+      double alpha = .0, delta = pi / ndirs;
       for (int i = 0; i < ndirs; ++i, alpha += delta) {
         dirs(i) = Point(e1) * cos(alpha) + Point(e2) * sin(alpha);
       }
       break;
   }
   if (nbetas > 1) {
-    beta = M_PI * beta / 180.0;
+    beta *= rad_per_deg;
     Point sin_beta_n(n);
     sin_beta_n *= sin(beta);
     const double cos_beta = cos(beta);

--- a/Modules/PointSet/src/mirtkPolyDataCurvature.cc
+++ b/Modules/PointSet/src/mirtkPolyDataCurvature.cc
@@ -574,7 +574,7 @@ void PolyDataCurvature::Initialize()
   // Compute volume and approximate radius of convex hull
   if (_Normalize && (_CurvatureType & (Mean | Gauss))) {
     _Volume = GetVolume(ConvexHull(_Input));
-    _Radius = pow( 3 * _Volume / (4.0 * M_PI), 1.0/3.0);
+    _Radius = pow( 3 * _Volume / (4.0 * pi), 1.0/3.0);
   }
 
   // Remove requested outputs from input to force recomputation

--- a/Modules/PointSet/src/mirtkPolyDataRemeshing.cc
+++ b/Modules/PointSet/src/mirtkPolyDataRemeshing.cc
@@ -834,8 +834,8 @@ void PolyDataRemeshing::Initialize()
   // Compute point normals if needed
   _MinFeatureAngle    = max(.0, min(_MinFeatureAngle, 180.0));
   _MaxFeatureAngle    = max(.0, min(_MaxFeatureAngle, 180.0));
-  _MinFeatureAngleCos = 1.0 - cos(_MinFeatureAngle * M_PI / 180.0);
-  _MaxFeatureAngleCos = 1.0 - cos(_MaxFeatureAngle * M_PI / 180.0);
+  _MinFeatureAngleCos = 1.0 - cos(_MinFeatureAngle * rad_per_deg);
+  _MaxFeatureAngleCos = 1.0 - cos(_MaxFeatureAngle * rad_per_deg);
 
   if (_MinFeatureAngle < 180.0 || _MaxFeatureAngle < 180.0) {
     vtkNew<vtkPolyDataNormals> calc_normals;

--- a/Modules/PointSet/src/mirtkSurfaceCollisions.cc
+++ b/Modules/PointSet/src/mirtkSurfaceCollisions.cc
@@ -379,7 +379,7 @@ public:
     body._Intersections        = intersections;
     body._Collisions           = collisions;
     body._MaxRadius            = radius->GetRange(0)[1];
-    body._MinAngleCos          = cos(filter->MaxAngle() * M_PI / 180.0);
+    body._MinAngleCos          = cos(filter->MaxAngle() * rad_per_deg);
     body._MinFrontfaceDistance = filter->MinFrontfaceDistance();
     body._MinBackfaceDistance  = filter->MinBackfaceDistance();
     if (!filter->BackfaceCollisionTest())  body._MinFrontfaceDistance = .0;

--- a/Modules/Registration/src/mirtkCurrentsDistance.cc
+++ b/Modules/Registration/src/mirtkCurrentsDistance.cc
@@ -19,6 +19,7 @@
 
 #include <mirtkCurrentsDistance.h>
 
+#include <mirtkMath.h>
 #include <mirtkMemory.h>
 #include <mirtkVector3D.h>
 #include <mirtkParallel.h>
@@ -516,8 +517,8 @@ void CurrentsDistance::Init()
     _Source->InputPointSet()->GetBounds(bb);
     double va = (ba[1] - ba[0]) * (ba[3] - ba[2]) * (ba[5] - ba[4]);
     double vb = (bb[1] - bb[0]) * (bb[3] - bb[2]) * (bb[5] - bb[4]);
-    double ra = pow(va * 3.0 / 4.0 / M_PI, (1.0/3.0));
-    double rb = pow(vb * 3.0 / 4.0 / M_PI, (1.0/3.0));
+    double ra = pow(va * 3.0 / 4.0 / pi, (1.0/3.0));
+    double rb = pow(vb * 3.0 / 4.0 / pi, (1.0/3.0));
     _Sigma = 0.5 * (ra + rb) * abs(_Sigma);
   }
 

--- a/Modules/Transformation/src/mirtkAffineTransformation.cc
+++ b/Modules/Transformation/src/mirtkAffineTransformation.cc
@@ -33,10 +33,9 @@ namespace mirtk {
 // -----------------------------------------------------------------------------
 void AffineTransformation::UpdateShearingTangent()
 {
-  const double deg2rad = M_PI / 180.0;
-  _tansxy = tan(_Param[SXY] * deg2rad);
-  _tansxz = tan(_Param[SXZ] * deg2rad);
-  _tansyz = tan(_Param[SYZ] * deg2rad);
+  _tansxy = tan(_Param[SXY] * rad_per_deg);
+  _tansxz = tan(_Param[SXZ] * rad_per_deg);
+  _tansyz = tan(_Param[SYZ] * rad_per_deg);
 }
 
 // -----------------------------------------------------------------------------
@@ -299,17 +298,16 @@ ParameterList AffineTransformation::Parameter() const
 Matrix AffineTransformation::DOFs2Matrix(const double *param)
 {
   Matrix matrix(4, 4);
-  const double deg2rad = M_PI / 180.0;
   AffineParametersToMatrix(param[TX], param[TY], param[TZ],
-                           param[RX]  * deg2rad,
-                           param[RY]  * deg2rad,
-                           param[RZ]  * deg2rad,
+                           param[RX]  * rad_per_deg,
+                           param[RY]  * rad_per_deg,
+                           param[RZ]  * rad_per_deg,
                            param[SX]  / 100.0,
                            param[SY]  / 100.0,
                            param[SZ]  / 100.0,
-                           param[SXY] * deg2rad,
-                           param[SXZ] * deg2rad,
-                           param[SYZ] * deg2rad,
+                           param[SXY] * rad_per_deg,
+                           param[SXZ] * rad_per_deg,
+                           param[SYZ] * rad_per_deg,
                            matrix);
   return matrix;
 }
@@ -324,13 +322,12 @@ void AffineTransformation::Matrix2DOFs(const Matrix &matrix, double *param)
                                    param[SXY], param[SXZ], param[SYZ]);
   
   // Convert angles to degrees
-  const double rad2deg = 180.0 / M_PI;
-  param[RX]  *= rad2deg;
-  param[RY]  *= rad2deg;
-  param[RZ]  *= rad2deg;
-  param[SXY] *= rad2deg;
-  param[SXZ] *= rad2deg;
-  param[SYZ] *= rad2deg;
+  param[RX]  *= deg_per_rad;
+  param[RY]  *= deg_per_rad;
+  param[RZ]  *= deg_per_rad;
+  param[SXY] *= deg_per_rad;
+  param[SXZ] *= deg_per_rad;
+  param[SYZ] *= deg_per_rad;
 
   // Convert scales to percentages
   param[SX] *= 100;
@@ -342,13 +339,12 @@ void AffineTransformation::Matrix2DOFs(const Matrix &matrix, double *param)
 void AffineTransformation::UpdateMatrix()
 {
   // Convert angles to radians
-  const double deg2rad = M_PI / 180.0;
-  const double rx  = _Param[RX]  * deg2rad;
-  const double ry  = _Param[RY]  * deg2rad;
-  const double rz  = _Param[RZ]  * deg2rad;
-  const double sxy = _Param[SXY] * deg2rad;
-  const double sxz = _Param[SXZ] * deg2rad;
-  const double syz = _Param[SYZ] * deg2rad;
+  const double rx  = _Param[RX]  * rad_per_deg;
+  const double ry  = _Param[RY]  * rad_per_deg;
+  const double rz  = _Param[RZ]  * rad_per_deg;
+  const double sxy = _Param[SXY] * rad_per_deg;
+  const double sxz = _Param[SXZ] * rad_per_deg;
+  const double syz = _Param[SYZ] * rad_per_deg;
 
   // Update sines, cosines, and tans
   _cosrx  = cos(rx);
@@ -403,13 +399,12 @@ void AffineTransformation::UpdateDOFs()
   _tansyz = tan(_Param[SYZ]);
 
   // Convert angles to degrees
-  const double rad2deg = 180.0 / M_PI;
-  _Param[RX]  *= rad2deg;
-  _Param[RY]  *= rad2deg;
-  _Param[RZ]  *= rad2deg;
-  _Param[SXY] *= rad2deg;
-  _Param[SXZ] *= rad2deg;
-  _Param[SYZ] *= rad2deg;
+  _Param[RX]  *= deg_per_rad;
+  _Param[RY]  *= deg_per_rad;
+  _Param[RZ]  *= deg_per_rad;
+  _Param[SXY] *= deg_per_rad;
+  _Param[SXZ] *= deg_per_rad;
+  _Param[SYZ] *= deg_per_rad;
 
   // Convert scales to percentages
   _Param[SX] *= 100.0;
@@ -507,22 +502,19 @@ void AffineTransformation::JacobianDOFs(double jac[3], int dof, double x, double
       jac[2] = (r[2][0] * _tansxz + r[2][1] * _tansyz + r[2][2]) * z / 100.0;
     } break;
     case SXY: {
-      const double deg2rad = M_PI / 180.0;
-      const double dsxy    = (deg2rad / pow(cos(_Param[SXY] * deg2rad), 2.0)) * y * _Param[SY] / 100.0;
+      const double dsxy = (rad_per_deg / pow(cos(_Param[SXY] * rad_per_deg), 2.0)) * y * _Param[SY] / 100.0;
       jac[0] = r[0][0] * dsxy;
       jac[1] = r[1][0] * dsxy;
       jac[2] = r[2][0] * dsxy;
     } break;
     case SYZ: {
-      const double deg2rad = M_PI / 180.0;
-      const double dsyz    = (deg2rad / pow(cos(_Param[SYZ] * deg2rad), 2.0)) * z * _Param[SZ] / 100.0;
+      const double dsyz = (rad_per_deg / pow(cos(_Param[SYZ] * rad_per_deg), 2.0)) * z * _Param[SZ] / 100.0;
       jac[0] = r[0][1] * dsyz;
       jac[1] = r[1][1] * dsyz;
       jac[2] = r[2][1] * dsyz;
     } break;
     case SXZ: {
-      const double deg2rad = M_PI / 180.0;
-      const double dsxz    = (deg2rad / pow(cos(_Param[SXZ] * deg2rad), 2.0)) * z * _Param[SZ] / 100.0;
+      const double dsxz = (rad_per_deg / pow(cos(_Param[SXZ] * rad_per_deg), 2.0)) * z * _Param[SZ] / 100.0;
       jac[0] = r[0][0] * dsxz;
       jac[1] = r[1][0] * dsxz;
       jac[2] = r[2][0] * dsxz;
@@ -588,22 +580,19 @@ void AffineTransformation::DeriveJacobianWrtDOF(Matrix &dJdp, int dof, double x,
       dJdp(2, 2) = (r[2][0] * _tansxz + r[2][1] * _tansyz + r[2][2]) / 100.0;
     } break;
     case SXY: {
-      const double deg2rad = M_PI / 180.0;
-      const double dsxy    = (deg2rad / pow(cos(_Param[SXY] * deg2rad), 2.0)) * _Param[SY] / 100.0;
+      const double dsxy = (rad_per_deg / pow(cos(_Param[SXY] * rad_per_deg), 2.0)) * _Param[SY] / 100.0;
       dJdp(0, 1) = r[0][0] * dsxy;
       dJdp(1, 1) = r[1][0] * dsxy;
       dJdp(2, 1) = r[2][0] * dsxy;
     } break;
     case SYZ: {
-      const double deg2rad = M_PI / 180.0;
-      const double dsyz    = (deg2rad / pow(cos(_Param[SYZ] * deg2rad), 2.0)) * _Param[SZ] / 100.0;
+      const double dsyz = (rad_per_deg / pow(cos(_Param[SYZ] * rad_per_deg), 2.0)) * _Param[SZ] / 100.0;
       dJdp(0, 2) = r[0][1] * dsyz;
       dJdp(1, 2) = r[1][1] * dsyz;
       dJdp(2, 2) = r[2][1] * dsyz;
     } break;
     case SXZ: {
-      const double deg2rad = M_PI / 180.0;
-      const double dsxz    = (deg2rad / pow(cos(_Param[SXZ] * deg2rad), 2.0)) * _Param[SZ] / 100.0;
+      const double dsxz = (rad_per_deg / pow(cos(_Param[SXZ] * rad_per_deg), 2.0)) * _Param[SZ] / 100.0;
       dJdp(0, 2) = r[0][0] * dsxz;
       dJdp(1, 2) = r[1][0] * dsxz;
       dJdp(2, 2) = r[2][0] * dsxz;

--- a/Modules/Transformation/src/mirtkInverseAffineTransformation.cc
+++ b/Modules/Transformation/src/mirtkInverseAffineTransformation.cc
@@ -134,7 +134,6 @@ void InverseAffineTransformation::JacobianDOFs(double jac[3], int dof, double x,
   const double &tansxy = _Transformation->_tansxy;
   const double &tansxz = _Transformation->_tansxz;
   const double &tansyz = _Transformation->_tansyz;
-  const double deg2rad = M_PI / 180.0;
 
   // inverse translation
   if (dof == TX) {
@@ -166,7 +165,7 @@ void InverseAffineTransformation::JacobianDOFs(double jac[3], int dof, double x,
     m[2][0] = .0;
     m[2][1] = cosrx * cosry;
     m[2][2] = - cosry * sinrx;
-    jac[0] *= deg2rad, jac[1] *= deg2rad, jac[2] *= deg2rad;
+    jac[0] *= rad_per_deg, jac[1] *= rad_per_deg, jac[2] *= rad_per_deg;
   } else if (dof == RY) {
     m[0][0] = - cosrz * sinry;
     m[0][1] = cosry * cosrz * sinrx;
@@ -177,7 +176,7 @@ void InverseAffineTransformation::JacobianDOFs(double jac[3], int dof, double x,
     m[2][0] = - cosry;
     m[2][1] = - sinrx * sinry;
     m[2][2] = - cosrx * sinry;
-    jac[0] *= deg2rad, jac[1] *= deg2rad, jac[2] *= deg2rad;
+    jac[0] *= rad_per_deg, jac[1] *= rad_per_deg, jac[2] *= rad_per_deg;
   } else if (dof == RZ) {
     m[0][0] = - cosry * sinrz;
     m[0][1] = - cosrx * cosrz - sinrx * sinry * sinrz;
@@ -188,7 +187,7 @@ void InverseAffineTransformation::JacobianDOFs(double jac[3], int dof, double x,
     m[2][0] = .0;
     m[2][1] = .0;
     m[2][2] = .0;
-    jac[0] *= deg2rad, jac[1] *= deg2rad, jac[2] *= deg2rad;
+    jac[0] *= rad_per_deg, jac[1] *= rad_per_deg, jac[2] *= rad_per_deg;
   } else {
     m[0][0] = cosry * cosrz;
     m[0][1] = cosrz * sinrx * sinry - cosrx * sinrz;
@@ -206,14 +205,14 @@ void InverseAffineTransformation::JacobianDOFs(double jac[3], int dof, double x,
   // inverse shearing
   memset(m, 0, sizeof(m));
   if (dof == SXY) {
-    const double derivative = deg2rad / pow(cos(param[SXY] * deg2rad), 2);
+    const double derivative = rad_per_deg / pow(cos(param[SXY] * rad_per_deg), 2);
     m[0][1] = - derivative;
     m[0][2] = tansyz * derivative;
   } else if (dof == SXZ) {
-    const double derivative = deg2rad / pow(cos(param[SXZ] * deg2rad), 2);
+    const double derivative = rad_per_deg / pow(cos(param[SXZ] * rad_per_deg), 2);
     m[0][2] = - derivative;
   } else if (dof == SYZ) {
-    const double derivative = deg2rad / pow(cos(param[SYZ] * deg2rad), 2);
+    const double derivative = rad_per_deg / pow(cos(param[SYZ] * rad_per_deg), 2);
     m[0][2] = tansxy * derivative;
     m[1][2] = - derivative;
   } else {

--- a/Modules/Transformation/src/mirtkRigidTransformation.cc
+++ b/Modules/Transformation/src/mirtkRigidTransformation.cc
@@ -35,13 +35,12 @@ namespace mirtk {
 // -----------------------------------------------------------------------------
 void RigidTransformation::UpdateRotationSineCosine()
 {
-  const double radians = M_PI / 180.0;
-  _sinrx = sin(_Param[RX] * radians);
-  _sinry = sin(_Param[RY] * radians);
-  _sinrz = sin(_Param[RZ] * radians);
-  _cosrx = cos(_Param[RX] * radians);
-  _cosry = cos(_Param[RY] * radians);
-  _cosrz = cos(_Param[RZ] * radians);
+  _sinrx = sin(_Param[RX] * rad_per_deg);
+  _sinry = sin(_Param[RY] * rad_per_deg);
+  _sinrz = sin(_Param[RZ] * rad_per_deg);
+  _cosrx = cos(_Param[RX] * rad_per_deg);
+  _cosry = cos(_Param[RY] * rad_per_deg);
+  _cosrz = cos(_Param[RZ] * rad_per_deg);
 }
 
 // -----------------------------------------------------------------------------
@@ -205,11 +204,10 @@ void RigidTransformation
 Matrix RigidTransformation::DOFs2Matrix(const double *param)
 {
   Matrix matrix(4, 4);
-  const double radians = M_PI / 180.0;
   RigidParametersToMatrix(param[TX], param[TY], param[TZ],
-                          param[RX] * radians,
-                          param[RY] * radians,
-                          param[RZ] * radians,
+                          param[RX] * rad_per_deg,
+                          param[RY] * rad_per_deg,
+                          param[RZ] * rad_per_deg,
                           matrix);
   return matrix;
 }
@@ -222,10 +220,9 @@ void RigidTransformation::Matrix2DOFs(const Matrix &matrix, double *param)
                                   param[RX], param[RY], param[RZ]);
 
   // Convert angles to degrees
-  const double degrees = 180.0 / M_PI;
-  param[RX] *= degrees;
-  param[RY] *= degrees;
-  param[RZ] *= degrees;
+  param[RX] *= deg_per_rad;
+  param[RY] *= deg_per_rad;
+  param[RZ] *= deg_per_rad;
 }
 
 // -----------------------------------------------------------------------------
@@ -257,10 +254,9 @@ void RigidTransformation::UpdateDOFs()
   _sinrz = sin(_Param[RZ]);
 
   // Convert angles to degrees
-  const double degrees = 180.0 / M_PI;
-  _Param[RX] *= degrees;
-  _Param[RY] *= degrees;
-  _Param[RZ] *= degrees;
+  _Param[RX] *= deg_per_rad;
+  _Param[RY] *= deg_per_rad;
+  _Param[RZ] *= deg_per_rad;
 }
 
 // =============================================================================
@@ -287,36 +283,32 @@ void RigidTransformation::JacobianDOFs(double jac[3], int dof, double x, double 
       jac[2] = 1.0;
     } break;
     case RX: {
-      const double deg2rad = M_PI / 180.0;
-
       jac[0] = .0;
       jac[1] = (+ (_cosrx * _sinry * _cosrz + _sinrx * _sinrz) * x
                 + (_cosrx * _sinry * _sinrz - _sinrx * _cosrz) * y
-                + (_cosrx * _cosry                           ) * z) * deg2rad;
+                + (_cosrx * _cosry                           ) * z) * rad_per_deg;
       jac[2] = (+ (_cosrx * _sinrz - _sinrx * _sinry * _cosrz) * x
                 - (_cosrx * _cosrz + _sinrx * _sinry * _sinrz) * y
-                - (_sinrx * _cosry                           ) * z) * deg2rad;
+                - (_sinrx * _cosry                           ) * z) * rad_per_deg;
     } break;
     case RY: {
-      const double deg2rad = M_PI / 180.0;
       jac[0] = (- (_sinry * _cosrz         ) * x
                 - (_sinry * _sinrz         ) * y
-                - (_cosry                  ) * z) * deg2rad;
+                - (_cosry                  ) * z) * rad_per_deg;
       jac[1] = (+ (_sinrx * _cosry * _cosrz) * x
                 + (_sinrx * _cosry * _sinrz) * y
-                - (_sinry * _sinrx         ) * z) * deg2rad;
+                - (_sinry * _sinrx         ) * z) * rad_per_deg;
       jac[2] = (+ (_cosrx * _cosry * _cosrz) * x
                 + (_cosrx * _cosry * _sinrz) * y
-                - (_cosrx * _sinry         ) * z) * deg2rad;
+                - (_cosrx * _sinry         ) * z) * rad_per_deg;
     } break;
     case RZ: {
-      const double deg2rad = M_PI / 180.0;
       jac[0] = (- (_sinrz * _cosry                             ) * x
-                + (_cosry * _cosrz                             ) * y) * deg2rad;
+                + (_cosry * _cosrz                             ) * y) * rad_per_deg;
       jac[1] = (+ (- _sinrx * _sinry * _sinrz - _cosrx * _cosrz) * x
-                + (  _sinrx * _sinry * _cosrz - _cosrx * _sinrz) * y) * deg2rad;
+                + (  _sinrx * _sinry * _cosrz - _cosrx * _sinrz) * y) * rad_per_deg;
       jac[2] = (+ (- _cosrx * _sinry * _sinrz + _sinrx * _cosrz) * x
-                + (  _cosrx * _sinry * _cosrz + _sinrx * _sinrz) * y) * deg2rad;
+                + (  _cosrx * _sinry * _cosrz + _sinrx * _sinrz) * y) * rad_per_deg;
     } break;
     default:
       cerr << this->NameOfClass() << "::JacobianDOFs(): No such parameter: " << dof << endl;
@@ -335,8 +327,6 @@ void RigidTransformation::DeriveJacobianWrtDOF(Matrix &dJdp, int dof, double, do
       return;
     } break;
     case RX: {
-      const double deg2rad = M_PI / 180.0;
-
       dJdp(0, 0) = .0;
       dJdp(1, 0) = + (_cosrx * _sinry * _cosrz + _sinrx * _sinrz);
       dJdp(2, 0) = + (_cosrx * _sinrz - _sinrx * _sinry * _cosrz);
@@ -346,12 +336,9 @@ void RigidTransformation::DeriveJacobianWrtDOF(Matrix &dJdp, int dof, double, do
       dJdp(0, 2) = .0;
       dJdp(1, 2) = + (_cosrx * _cosry);
       dJdp(2, 2) = - (_sinrx * _cosry);
-
-      dJdp *= deg2rad;
+      dJdp *= rad_per_deg;
     } break;
     case RY: {
-      const double deg2rad = M_PI / 180.0;
-
       dJdp(0, 0) = - (_sinry * _cosrz);
       dJdp(1, 0) = + (_sinrx * _cosry * _cosrz);
       dJdp(2, 0) = + (_cosrx * _cosry * _cosrz);
@@ -361,12 +348,9 @@ void RigidTransformation::DeriveJacobianWrtDOF(Matrix &dJdp, int dof, double, do
       dJdp(0, 2) = - (_cosry);
       dJdp(1, 2) = - (_sinry * _sinrx);
       dJdp(2, 2) = - (_cosrx * _sinry);
-
-      dJdp *= deg2rad;
+      dJdp *= rad_per_deg;
     } break;
     case RZ: {
-      const double deg2rad = M_PI / 180.0;
-
       dJdp(0, 0) = - (_sinrz * _cosry);
       dJdp(1, 0) = + (-_sinrx * _sinry * _sinrz - _cosrx * _cosrz);
       dJdp(2, 0) = + (-_cosrx * _sinry * _sinrz + _sinrx * _cosrz);
@@ -376,8 +360,7 @@ void RigidTransformation::DeriveJacobianWrtDOF(Matrix &dJdp, int dof, double, do
       dJdp(0, 2) = .0;
       dJdp(1, 2) = .0;
       dJdp(2, 2) = .0;
-
-      dJdp *= deg2rad;
+      dJdp *= rad_per_deg;
     } break;
     default:
       cerr << this->NameOfClass() << "::DeriveJacobianWrtDOF(): No such parameter: " << dof << endl;


### PR DESCRIPTION
Related to issue #52. Solves issue with ```cmath``` header file include only after ```_USE_MATH_DEFINES``` (see [this SO thread](http://stackoverflow.com/questions/6563810/m-pi-works-with-math-h-but-not-with-cmath-in-visual-studio) for details on the dilemma). The ```_USE_MATH_DEFINES``` was missing before and thus the build errors with MSVC.