### PR TITLE
Fix surface remeshing filter

### DIFF
--- a/Applications/remesh.cc
+++ b/Applications/remesh.cc
@@ -25,6 +25,7 @@
 #include <mirtkPolyDataRemeshing.h>
 
 #include <vtkSmartPointer.h>
+#include <vtkDataReader.h> // VTK_BINARY, VTK_ASCII defines
 #include <vtkPolyData.h>
 #include <vtkPointData.h>
 #include <vtkCellArray.h>
@@ -41,28 +42,64 @@ using namespace mirtk;
 // -----------------------------------------------------------------------------
 void PrintHelp(const char *name)
 {
+  PolyDataRemeshing remesher; // with default settings
   cout << endl;
   cout << "Usage: " << name << " <input> <output> [options]" << endl;
   cout << endl;
   cout << "Description:" << endl;
   cout << "  Remeshes a surface mesh such that the resulting mesh has an average" << endl;
-  cout << "  edge length within the specified limits." << endl;
+  cout << "  edge length within the specified limits. The input surface mesh is" << endl;
+  cout << "  triangulated when necessary before the local remeshing passes." << endl;
+  cout << endl;
+  cout << "Arguments:" << endl;
+  cout << "  input    Input surface mesh." << endl;
+  cout << "  output   Output surface mesh." << endl;
   cout << endl;
   cout << "Options:" << endl;
-  cout << "  -write-all                         Write also intermediate meshes when more than one" << endl;
-  cout << "                                     desired average edge length was specified. Output file" << endl;
-  cout << "                                     names contain the level number as suffix. (default: off)" << endl;
-  cout << "  -target <file>                     Find closest cell points on target surface" << endl;
-  cout << "                                     and use these as new point locations." << endl;
-  cout << "  -edgelength    <float>...          Average edge length." << endl;
-  cout << "  -minedgelength <float>...          Minimum edge length. (default: 0)" << endl;
-  cout << "  -maxedgelength <float>...          Maximum edge length. (default: inf)" << endl;
-  cout << "  -adaptiveedgelength <name>         Name of point data array to use for adapting the edge length range. (default: none)" << endl;
-  cout << "  -meltorder <index|area|shortest>   Order in which to process cells in melting pass. (default: area)" << endl;
-  cout << "  -[no]meltnodes                     Whether to allow removal of nodes with connectivity 3. (default: off)" << endl;
-  cout << "  -[no]melttriangles                 Whether to melt triangles when all three edges are too short. (default: off)" << endl;
-  cout << "  -ascii/-binary                     Write legacy VTK in ASCII or binary format. (default: binary)" << endl;
-  cout << "  -[no]compress                      Write XML VTK file with or without compression. (default: compress)" << endl;
+  cout << "  -target <file>" << endl;
+  cout << "      Find closest cell points on target surface and use these as new point locations." << endl;
+  cout << "      (default: use points of input mesh)" << endl;
+  cout << "  -edgelength <float>..." << endl;
+  cout << "      Average edge length. (default: [0, inf)" << endl;
+  cout << "  -min-edgelength <float>..." << endl;
+  cout << "      Minimum edge length. (default: 0)" << endl;
+  cout << "  -max-edgelength <float>..." << endl;
+  cout << "      Maximum edge length. (default: inf)" << endl;
+  cout << "  -adaptive-edgelength <name>" << endl;
+  cout << "      Name of point data array to use for adapting the edge length range. (default: none)" << endl;
+  cout << "  -melting-order <none|area|shortest>" << endl;
+  cout << "      Order in which to process cells in melting pass. (default: ";
+  switch (remesher.MeltingOrder()) {
+    case PolyDataRemeshing::INDEX:         cout << "none"; break;
+    case PolyDataRemeshing::AREA:          cout << "area"; break;
+    case PolyDataRemeshing::SHORTEST_EDGE: cout << "shortest"; break;
+  }
+  cout << ")" << endl;
+  cout << "  -[no]melt-nodes" << endl;
+  cout << "      Whether to allow removal of adjacent nodes with connectivity three" << endl;
+  cout << "      during melting pass. (default: " << ToLower(ToString(remesher.MeltNodes())) << ")" << endl;
+  cout << "  -[no]melt-triangles" << endl;
+  cout << "      Whether to melt triangles when all three edges are too short. (default: "
+       << ToLower(ToString(remesher.MeltTriangles())) << ")" << endl;
+  cout << "  -[no]invert-long-edges" << endl;
+  cout << "      Enable/disable inversion of triangles sharing one too long edge. (default: "
+       << ToLower(ToString(remesher.InvertTrianglesSharingOneLongEdge())) << ")" << endl;
+  cout << "  -[no]invert-min-height" << endl;
+  cout << "      Enable/disable inversion of triangles when it increases the minimum height. (default: "
+       << ToLower(ToString(remesher.InvertTrianglesToIncreaseMinHeight())) << ")" << endl;
+  cout << "  -noinversion" << endl;
+  cout << "      Disable :option:`-invert-long-edges` and :options:`-invert-min-height`." << endl;
+  cout << endl;
+  cout << "Output options:" << endl;
+  cout << "  -write-all" << endl;
+  cout << "      Write also intermediate meshes when more than one edge length range" << endl;
+  cout << "      was specified. Output file names contain the level number as suffix. (default: off)" << endl;
+  cout << "  -[no]ascii" << endl;
+  cout << "      Write legacy VTK in ASCII or binary format. (default: input type)" << endl;
+  cout << "  -[no]binary" << endl;
+  cout << "      Write legacy VTK in ASCII or binary format. (default: input type)" << endl;
+  cout << "  -[no]compress" << endl;
+  cout << "      Write XML VTK file with or without compression. (default: on)" << endl;
   PrintStandardOptions(cout);
   cout << endl;
 }
@@ -74,42 +111,46 @@ void PrintHelp(const char *name)
 // -----------------------------------------------------------------------------
 int main(int argc, char *argv[])
 {
+  PolyDataRemeshing remesher;
+
+  // Parse positional arguments
   EXPECTS_POSARGS(2);
 
   const char *input_name  = POSARG(1);
   const char *output_name = POSARG(2);
 
-  string dir  = Directory(output_name);
-  string name = FileName(output_name);
-  string ext  = Extension(output_name);
+  const string dir  = Directory(output_name);
+  const string name = FileName (output_name);
+  const string ext  = Extension(output_name);
 
+  // Read input mesh
+  int output_type = VTK_BINARY;
+  vtkSmartPointer<vtkPolyData> mesh = ReadPolyData(input_name, &output_type);
+  const vtkIdType npoints = mesh->GetNumberOfPoints();
+  const vtkIdType ncells  = mesh->GetNumberOfCells();
+
+  // Parse optional arguments
   Array<double> minlength;
   Array<double> maxlength;
   Array<double> minangle;
   Array<double> maxangle;
 
-  bool        melt_nodes     = false;
-  bool        melt_triangles = false;
-  const char *adaptive_name  = NULL;
-  const char *target_name    = NULL;
-  bool        ascii          = false;
-  bool        compress       = true;
-  bool        write_all      = false;
-
-  PolyDataRemeshing::Order melt_order = PolyDataRemeshing::AREA;
+  const char *target_name = NULL;
+  bool        compress    = true;
+  bool        write_all   = false;
 
   for (ALL_OPTIONS) {
-    if (OPTION("-minedgelength")) {
+    if (OPTION("-min-edge-length") || OPTION("-min-edgelength") || OPTION("-minedgelength")) {
       do {
         minlength.push_back(atof(ARGUMENT));
       } while (HAS_ARGUMENT);
     }
-    else if (OPTION("-maxedgelength")) {
+    else if (OPTION("-max-edge-length") || OPTION("-max-edgelength") || OPTION("-maxedgelength")) {
       do {
         maxlength.push_back(atof(ARGUMENT));
       } while (HAS_ARGUMENT);
     }
-    else if (OPTION("-edgelength")) {
+    else if (OPTION("-edge-length") || OPTION("-edgelength")) {
       if (minlength.size() < maxlength.size()) minlength.resize(maxlength.size(), minlength.back());
       if (minlength.size() > maxlength.size()) maxlength.resize(minlength.size(), maxlength.back());
       do {
@@ -118,44 +159,83 @@ int main(int argc, char *argv[])
         maxlength.push_back(l);
       } while (HAS_ARGUMENT);
     }
-    else if (OPTION("-adaptive") || OPTION("-adaptiveedgelength")) {
-      adaptive_name = ARGUMENT;
+    else if (OPTION("-adaptive") || OPTION("-adaptive-edge-length") ||
+             OPTION("-adaptive-edgelength") || OPTION("-adaptiveedgelength")) {
+      const char *adaptive_name = ARGUMENT;
+      vtkDataArray *array = mesh->GetPointData()->GetArray(adaptive_name);
+      if (!array) {
+        cerr << "Error: Input mesh has no point data array named: " << adaptive_name << endl;
+        exit(1);
+      }
+      remesher.AdaptiveEdgeLengthArray(array);
     }
-    else if (OPTION("-minangle")) {
+    else if (OPTION("-min-angle") || OPTION("-minangle")) {
       do {
         minangle.push_back(atof(ARGUMENT));
       } while (HAS_ARGUMENT);
     }
-    else if (OPTION("-maxangle")) {
+    else if (OPTION("-max-angle") || OPTION("-maxangle")) {
       do {
         maxangle.push_back(atof(ARGUMENT));
       } while (HAS_ARGUMENT);
     }
-    else if (OPTION("-meltorder")) {
+    else if (OPTION("-melting-order") || OPTION("-melt-order") || OPTION("-meltorder")) {
       string arg = ARGUMENT;
       transform(arg.begin(), arg.end(), arg.begin(), ::tolower);
-      if (arg == "area" || arg == "smallest area" || arg == "smallestarea")
-        melt_order = PolyDataRemeshing::AREA;
-      else if (arg == "edge" ||
+      if (arg == "area" || arg == "smallest area" || arg == "smallestarea") {
+        remesher.MeltingOrder(PolyDataRemeshing::AREA);
+      } else if (arg == "edge" ||
                arg == "shortest" ||
                arg == "shortest edge" ||
-               arg == "shortestedge")
-        melt_order = PolyDataRemeshing::SHORTEST_EDGE;
-      else if (arg == "index" || arg == "none")
-        melt_order = PolyDataRemeshing::INDEX;
-      else {
+               arg == "shortestedge") {
+        remesher.MeltingOrder(PolyDataRemeshing::SHORTEST_EDGE);
+      } else if (arg == "index" || arg == "none") {
+        remesher.MeltingOrder(PolyDataRemeshing::INDEX);
+      } else {
         cerr << "Invalid -meltorder: " << arg << endl;
         exit(1);
       }
     }
     else if (OPTION("-write-all")) write_all = true;
-    else if (OPTION("-meltnodes")) melt_nodes = true;
-    else if (OPTION("-nomeltnodes")) melt_nodes = false;
-    else if (OPTION("-melttriangles")) melt_triangles = true;
-    else if (OPTION("-nomelttriangles")) melt_triangles = false;
+    else if (OPTION("-melt-nodes") || OPTION("-meltnodes")) {
+      bool melt_nodes = true;
+      if (HAS_ARGUMENT) PARSE_ARGUMENT(melt_nodes);
+      remesher.MeltNodes(melt_nodes);
+    }
+    else if (OPTION("-nomelt-nodes") || OPTION("-nomeltnodes")) {
+      remesher.MeltNodesOff();
+    }
+    else if (OPTION("-melt-triangles") || OPTION("-melttriangles")) {
+      bool melt_triangles = true;;
+      if (HAS_ARGUMENT) PARSE_ARGUMENT(melt_triangles);
+      remesher.MeltTriangles(melt_triangles);
+    }
+    else if (OPTION("-nomelt-triangles") || OPTION("-nomelttriangles")) {
+      remesher.MeltTrianglesOff();
+    }
+    else if (OPTION("-invert-long-edges")) {
+      bool invert = true;
+      if (HAS_ARGUMENT) PARSE_ARGUMENT(invert);
+      remesher.InvertTrianglesSharingOneLongEdge(invert);
+    }
+    else if (OPTION("-noinvert-long-edges")) {
+      remesher.InvertTrianglesSharingOneLongEdgeOff();
+    }
+    else if (OPTION("-invert-min-height")) {
+      bool invert = true;
+      if (HAS_ARGUMENT) PARSE_ARGUMENT(invert);
+      remesher.InvertTrianglesToIncreaseMinHeight(invert);
+    }
+    else if (OPTION("-noinvert-min-height")) {
+      remesher.InvertTrianglesToIncreaseMinHeightOff();
+    }
+    else if (OPTION("-noinversion")) {
+      remesher.InvertTrianglesSharingOneLongEdgeOff();
+      remesher.InvertTrianglesToIncreaseMinHeightOff();
+    }
     else if (OPTION("-target")) target_name = ARGUMENT;
-    else if (OPTION("-ascii" ) || OPTION("-nobinary")) ascii = true;
-    else if (OPTION("-binary") || OPTION("-noascii" )) ascii = false;
+    else if (OPTION("-ascii" ) || OPTION("-nobinary")) output_type = VTK_ASCII;
+    else if (OPTION("-binary") || OPTION("-noascii" )) output_type = VTK_BINARY;
     else if (OPTION("-compress"))   compress = true;
     else if (OPTION("-nocompress")) compress = false;
     else HANDLE_COMMON_OR_UNKNOWN_OPTION();
@@ -169,17 +249,6 @@ int main(int argc, char *argv[])
   maxangle .resize(nlevels, maxangle .empty() ? 180.0 : maxangle .back());
   for (size_t i = 0; i < nlevels; ++i) {
     if (minangle[i] > maxangle[i]) minangle[i] = maxangle[i];
-  }
-
-  // Read input surface
-  vtkSmartPointer<vtkPolyData> mesh = ReadPolyData(input_name);
-
-  const vtkIdType npoints = mesh->GetNumberOfPoints();
-  const vtkIdType ncells  = mesh->GetNumberOfCells();
-
-  if (verbose) {
-    cout << "No. of input vertices    = " << npoints << endl;
-    cout << "No. of input triangles   = " << ncells  << endl;
   }
 
   // Use point locations of closest target surface as initial vertex positions
@@ -198,19 +267,18 @@ int main(int argc, char *argv[])
   }
 
   // Remesh to desired average edge length
-  PolyDataRemeshing remesher;
-  remesher.MeltingOrder(melt_order);
-  remesher.MeltNodes(melt_nodes);
-  remesher.MeltTriangles(melt_triangles);
-  if (adaptive_name) {
-    vtkDataArray *array = mesh->GetPointData()->GetArray(adaptive_name);
-    if (!array) {
-      cerr << "Error: Input mesh has no point data array named: " << adaptive_name << endl;
-      exit(1);
-    }
-    remesher.AdaptiveEdgeLengthArray(array);
+  EdgeTable edgeTable;
+  vtkIdType nedges;
+  if (verbose) {
+    edgeTable.Initialize(mesh);
+    nedges = edgeTable.NumberOfEdges();
+    vtkIdType euler = mesh->GetNumberOfPoints() - nedges + mesh->GetNumberOfCells();
+    cout << "No. of input vertices  = " << npoints << "\n";
+    cout << "No. of input triangles = " << ncells  << "\n";
+    cout << "No. of input edges     = " << nedges  << "\n";
+    cout << "Euler characteristic   = " << euler << "\n";
+    cout.flush();
   }
-
   for (size_t i = 0; i < nlevels; ++i) {
     if (verbose) {
       cout << "\nRemeshing surface with edge length range [" << minlength[i] << ", " << maxlength[i] << "]";
@@ -223,21 +291,30 @@ int main(int argc, char *argv[])
     remesher.MinFeatureAngle(minangle [i]);
     remesher.MaxFeatureAngle(maxangle [i]);
     remesher.Run();
-    if (verbose > 1) {
-      cout << "No. of node-meltings     = " << remesher.NumberOfMeltedNodes() << endl;
-      cout << "No. of edge-meltings     = " << remesher.NumberOfMeltedEdges() << endl;
-      cout << "No. of triangle-meltings = " << remesher.NumberOfMeltedCells() << endl;
-      cout << "No. of inversions        = " << remesher.NumberOfInversions() << endl;
-      cout << "No. of bisections        = " << remesher.NumberOfBisections() << endl;
-      cout << "No. of trisections       = " << remesher.NumberOfTrisections() << endl;
-      cout << "No. of quadsections      = " << remesher.NumberOfQuadsections() << endl;
-    }
     mesh = remesher.Output();
+    if (verbose > 1) {
+      if (debug_time) cout << endl;
+      cout << "\n";
+      cout << "  No. of node-meltings     = " << remesher.NumberOfMeltedNodes()  << "\n";
+      cout << "  No. of edge-meltings     = " << remesher.NumberOfMeltedEdges()  << "\n";
+      cout << "  No. of triangle-meltings = " << remesher.NumberOfMeltedCells()  << "\n";
+      cout << "  No. of inversions        = " << remesher.NumberOfInversions()   << "\n";
+      cout << "  No. of bisections        = " << remesher.NumberOfBisections()   << "\n";
+      cout << "  No. of trisections       = " << remesher.NumberOfTrisections()  << "\n";
+      cout << "  No. of quadsections      = " << remesher.NumberOfQuadsections() << "\n";
+    }
     if (verbose) {
-      cout << "No. of output vertices   = " << mesh->GetNumberOfPoints()
-           << " (" << (100.0 * mesh->GetNumberOfPoints() / npoints) << "%)" << endl;
-      cout << "No. of output triangles  = " << mesh->GetNumberOfCells()
-           << " (" << (100.0 * mesh->GetNumberOfCells() / ncells) << "%)" << endl;
+      edgeTable.Initialize(mesh);
+      vtkIdType euler = mesh->GetNumberOfPoints() - edgeTable.NumberOfEdges() + mesh->GetNumberOfCells();
+      cout << "\n";
+      cout << "  No. of output vertices   = " << mesh->GetNumberOfPoints()
+           << " (" << (100.0 * mesh->GetNumberOfPoints() / npoints) << "%)" << "\n";
+      cout << "  No. of output triangles  = " << mesh->GetNumberOfCells()
+           << " (" << (100.0 * mesh->GetNumberOfCells() / ncells) << "%)" << "\n";
+      cout << "  No. of output edges      = " << edgeTable.NumberOfEdges()
+           << " (" << (100.0 * edgeTable.NumberOfEdges() / nedges) << "%)" << "\n";
+      cout << "  Euler characteristic     = " << euler << "\n";
+      cout.flush();
     }
     if (write_all && i < minlength.size() - 1) {
       ostringstream os;
@@ -253,8 +330,6 @@ int main(int argc, char *argv[])
     vtkIdType ptId1, ptId2;
     double p1[3], p2[3], l, sum = .0, max = .0;
     double min = numeric_limits<double>::infinity();
-
-    EdgeTable edgeTable(mesh);
     EdgeIterator it(edgeTable);
     for (it.InitTraversal(); it.GetNextEdge(ptId1, ptId2) != -1;) {
       mesh->GetPoint(ptId1, p1);
@@ -264,13 +339,13 @@ int main(int argc, char *argv[])
       if (l > max) max = l;
       sum += l;
     }
-
-    cout << endl;
-    cout << "Minimum edge length      = " << min << endl;
-    cout << "Maximum edge length      = " << max << endl;
-    cout << "Average edge length      = " << sum / edgeTable.NumberOfEdges() << endl;
+    cout << "\n";
+    cout << "Minimum edge length = " << min << "\n";
+    cout << "Maximum edge length = " << max << "\n";
+    cout << "Average edge length = " << sum / edgeTable.NumberOfEdges() << "\n";
+    cout.flush();
   }
 
   // Write surface mesh
-  return WritePolyData(output_name, mesh, compress, ascii) ? 0 : 1;
+  return WritePolyData(output_name, mesh, compress, output_type == VTK_ASCII) ? 0 : 1;
 }

--- a/Modules/PointSet/src/mirtkPolyDataRemeshing.cc
+++ b/Modules/PointSet/src/mirtkPolyDataRemeshing.cc
@@ -23,7 +23,6 @@
 #include <mirtkAssert.h>
 #include <mirtkMath.h>
 #include <mirtkProfiling.h>
-#include <mirtkEdgeTable.h>
 #include <mirtkPolyDataSmoothing.h>
 #include <mirtkPointSetUtils.h>
 #include <mirtkDataStatistics.h>
@@ -75,33 +74,38 @@ void PolyDataRemeshing::CopyAttributes(const PolyDataRemeshing &other)
   _NumberOfTrisections     = other._NumberOfTrisections;
   _NumberOfQuadsections    = other._NumberOfQuadsections;
 
+  _InvertTrianglesSharingOneLongEdge  = other._InvertTrianglesSharingOneLongEdge;
+  _InvertTrianglesToIncreaseMinHeight = other._InvertTrianglesToIncreaseMinHeight;
+
   // Get output point labels from _Output (copied by PolyDataFilter::Copy)
   if (_Output) {
     _OutputPointLabels  = GetArrayByCaseInsensitiveName(_Output->GetPointData(), "labels");
     _MinEdgeLengthArray = _Output->GetPointData()->GetArray("MinEdgeLength");
     _MaxEdgeLengthArray = _Output->GetPointData()->GetArray("MaxEdgeLength");
   } else {
-    _OutputPointLabels  = NULL;
-    _MinEdgeLengthArray = NULL;
-    _MaxEdgeLengthArray = NULL;
+    _OutputPointLabels  = nullptr;
+    _MinEdgeLengthArray = nullptr;
+    _MaxEdgeLengthArray = nullptr;
   }
 }
 
 // -----------------------------------------------------------------------------
 PolyDataRemeshing::PolyDataRemeshing()
 :
-  _Transformation(NULL),
+  _Transformation(nullptr),
   _MinFeatureAngle(180.0),
-  _MinFeatureAngleCos(2.0),
+  _MinFeatureAngleCos(cos(_MinFeatureAngle * rad_per_deg)),
   _MaxFeatureAngle(180.0),
-  _MaxFeatureAngleCos(2.0),
+  _MaxFeatureAngleCos(cos(_MaxFeatureAngle * rad_per_deg)),
   _MinEdgeLength(.0),
   _MinEdgeLengthSquared(.0),
   _MaxEdgeLength(numeric_limits<double>::infinity()),
   _MaxEdgeLengthSquared(numeric_limits<double>::infinity()),
   _MeltingOrder(AREA),
-  _MeltNodes(false),
+  _MeltNodes(true),
   _MeltTriangles(false),
+  _InvertTrianglesSharingOneLongEdge(false),
+  _InvertTrianglesToIncreaseMinHeight(true),
   _NumberOfMeltedNodes(0),
   _NumberOfMeltedEdges(0),
   _NumberOfMeltedCells(0),
@@ -149,7 +153,7 @@ inline void PolyDataRemeshing::GetPoint(vtkIdType ptId, double p[3]) const
 // -----------------------------------------------------------------------------
 inline void PolyDataRemeshing::GetNormal(vtkIdType ptId, double n[3]) const
 {
-  // TODO: Need to compute normal of transformed surface if _Transformation != NULL.
+  // TODO: Need to compute normal of transformed surface if _Transformation != nullptr.
   //       Can be computed from normals of adjacent triangles which in turn
   //       must be computed from the transformed triangle corners (cf. GetPoint)
   _Output->GetPointData()->GetNormals()->GetTuple(ptId, n);
@@ -160,6 +164,7 @@ inline double PolyDataRemeshing::ComputeArea(vtkIdType cellId) const
 {
   vtkIdType npts, *pts;
   _Output->GetCellPoints(cellId, npts, pts);
+  if (npts != 3) return numeric_limits<double>::infinity();
   double p1[3], p2[3], p3[3];
   GetPoint(pts[0], p1);
   GetPoint(pts[1], p2);
@@ -210,16 +215,10 @@ inline void PolyDataRemeshing::DeleteCells(vtkIdList *cellIds)
 // -----------------------------------------------------------------------------
 inline void PolyDataRemeshing::ReplaceCellPoint(vtkIdType cellId, vtkIdType oldPtId, vtkIdType newPtId)
 {
-  vtkIdType npts, *pts;
-  _Output->GetCellPoints(cellId, npts, pts);
-  for (vtkIdType j = 0; j < npts; ++j) {
-    if (pts[j] == oldPtId) pts[j] = newPtId;
-  }
   _Output->RemoveReferenceToCell(oldPtId, cellId); // NOT THREAD SAFE!
+  _Output->ReplaceCellPoint(cellId, oldPtId, newPtId);
   _Output->ResizeCellList(newPtId, 1);
   _Output->AddReferenceToCell(newPtId, cellId);
-  // Note: Not necessary as we manipulated the pts array directly!
-  //_Output->ReplaceCell(cellId, npts, pts);
 }
 
 // -----------------------------------------------------------------------------
@@ -260,7 +259,10 @@ inline vtkIdType PolyDataRemeshing
 ::GetCellEdgeNeighborPoint(vtkIdType cellId, vtkIdType ptId1, vtkIdType ptId2, bool mergeTriples)
 {
   unsigned short ncells;
-  vtkIdType npts, *pts, *cells;
+  vtkIdType ptId3, npts, *pts, *cells;
+
+  // Get other cell adjacent to this edge
+  const vtkIdType neighborCellId = GetCellEdgeNeighbor(cellId, ptId1, ptId2);
 
   // Get points which are adjacent to both edge points
   vtkSmartPointer<vtkIdList> ptIds1 = vtkSmartPointer<vtkIdList>::New();
@@ -271,124 +273,113 @@ inline vtkIdType PolyDataRemeshing
 
   ptIds1->IntersectWith(ptIds2);
 
-  // Intersection should only contain the other point of this cell
+  // Intersection contains all points connected to both edge points.
+  // This is the third point of cell with ID cellId, and all points on
+  // the opposite side of the edge, i.e., the third point defining the
+  // neighboring cell. Other points included belong to nodes that are
+  // connected to triangles that are fully contained within the triangle
+  // defined by the edge points and one of the adjacent points (furthest
+  // away from the edge when surface has no self-intersections). These can
+  // be removed starting at the third point defining the neighboring cell
+  // which in this case has node connectivity three. The next third point
+  // defining the new (merged) neighboring cell then has node connectivity
+  // three and it's adjacent triangles can be merged as well. This is
+  // continued until no more point with node connectivity three remains and
+  // the ptIds1 list has only two points left.
+  if (ptIds1->GetNumberOfIds() < 2) {
+    return -1; // Boundary point, cannot happen in case of closed surface mesh
+  }
+
+  if (mergeTriples) {
+    while (ptIds1->GetNumberOfIds() > 2) {
+      int idx = -1; // index of cell that becomes union of node adjacent cells
+      for (vtkIdType i = 0; i < ptIds1->GetNumberOfIds(); ++i) {
+        ptId3 = ptIds1->GetId(i);
+        _Output->GetPointCells(ptId3, ncells, cells);
+        if (ncells != 3) continue; // node connectivity must be three
+        for (unsigned short j = 0; j < ncells; ++j) {
+          _Output->GetCellPoints(cells[j], npts, pts);
+          for (vtkIdType k = 0; k < npts; ++k) {
+            if (pts[k] != ptId1 && pts[k] != ptId2 && pts[k] != ptId3) {
+              for (unsigned short l = 0; l < ncells; ++l) {
+                if (cells[l] == cellId || cells[l] == neighborCellId) {
+                  ReplaceCellPoint(cells[l], ptId3, pts[k]);
+                  idx = l;
+                  break;
+                }
+              }
+              if (idx != -1) {
+                for (unsigned short l = 0; l < ncells; ++l) {
+                  if (l != idx) DeleteCell(cells[l]);
+                }
+                ptIds1->DeleteId(ptId3);
+                ptIds1->InsertUniqueId(pts[k]); // should be in list already
+                if (_MeltingQueue) {
+                  for (unsigned short l = 0; l < ncells; ++l) {
+                    _MeltingQueue->DeleteId(cells[l]);
+                    if (l == idx && cells[l] != cellId) {
+                      double priority = MeltingPriority(cells[idx]);
+                      if (!IsInf(priority)) {
+                        _MeltingQueue->Insert(priority, cells[idx]);
+                      }
+                    }
+                  }
+                }
+                ++_NumberOfMeltedNodes;
+              }
+              break;
+            }
+          }
+          break;
+        }
+        break;
+      }
+      if (idx == -1) break;
+    };
+  }
+
+  // Intersection should now contain the other point of this cell
   // and the third point belonging to the cell edge neighbor
   if (ptIds1->GetNumberOfIds() != 2) return -1;
 
-  // Get third point defining this cell
-  _Output->GetCellPoints(cellId, npts, pts);
-  vtkIdType ptId3 = -1;
-  for (vtkIdType i = 0; i < npts; ++i) {
-    if (pts[i] != ptId1 && pts[i] != ptId2) {
-      ptId3 = pts[i];
-      break;
+  // Get other cell edge neighbor point
+  _Output->GetCellPoints(neighborCellId, npts, pts);
+  if (npts == 3) {
+    for (vtkIdType i = 0; i < npts; ++i) {
+      if (pts[i] != ptId1 && pts[i] != ptId2) {
+        return pts[i];
+      }
     }
   }
+  return -1;
+}
 
-  // Get other cell edge neighbor point
-  vtkIdType adjPtId = ptIds1->GetId(vtkIdType(ptIds1->GetId(0) == ptId3));
-
-  // Check/adjust connectivity of adjacent point
-  switch (NodeConnectivity(adjPtId)) {
-    case 1: case 2:
-      return -1; // should never happen
-    case 3: {
-      if (!mergeTriples) return -1;
-      // Merge three adjacent triangles into one
-      //
-      // TODO: Only when the lengths of the edges of the resulting triangle
-      //       are within the valid range [_MinEdgeLength, _MaxEdgeLength]
-      //       and if the normals of the three triangles make up an angle
-      //       less than the _MinFeatureAngle.
-      vtkIdType newPtId = -1;
-      _Output->GetPointCells(adjPtId, ncells, cells);
-      for (unsigned short i = 0; i < ncells; ++i) {
-        _Output->GetCellPoints(cells[i], npts, pts);
-        for (vtkIdType j = 0; j < npts; ++j) {
-          if (pts[j] != ptId1 && pts[j] != ptId2) {
-            newPtId = pts[j];
-            break;
-          }
-        }
+// -----------------------------------------------------------------------------
+inline double PolyDataRemeshing::MeltingPriority(vtkIdType cellId) const
+{
+  double priority = numeric_limits<double>::infinity();
+  switch (_MeltingOrder) {
+    case INDEX: {
+      priority = double(cellId);
+    } break;
+    case AREA: {
+      priority = ComputeArea(cellId);
+    } break;
+    case SHORTEST_EDGE: {
+      vtkIdType npts, *pts;
+      _Output->GetCellPoints(cellId, npts, pts);
+      if (npts == 3) {
+        double p1[3], p2[3], p3[3];
+        GetPoint(pts[0], p1);
+        GetPoint(pts[1], p2);
+        GetPoint(pts[2], p3);
+        priority = min(min(vtkMath::Distance2BetweenPoints(p1, p2),
+                           vtkMath::Distance2BetweenPoints(p1, p3)),
+                           vtkMath::Distance2BetweenPoints(p2, p3));
       }
-      if (newPtId != -1) {
-        ReplaceCellPoint(cells[0], adjPtId, newPtId);
-        DeleteCell(cells[1]);
-        DeleteCell(cells[2]);
-        ++_NumberOfMeltedNodes;
-      }
-      adjPtId = newPtId;
     } break;
   }
-
-  return adjPtId;
-}
-
-// -----------------------------------------------------------------------------
-PolyDataRemeshing::CellQueue PolyDataRemeshing::QueueCellsByArea() const
-{
-  CellQueue queue;
-  queue.reserve(_Output->GetNumberOfCells());
-
-  CellInfo cur;
-  for (cur.cellId = 0; cur.cellId < _Output->GetNumberOfCells(); ++cur.cellId) {
-    if (_Output->GetCellType(cur.cellId) == VTK_TRIANGLE) {
-      cur.priority = ComputeArea(cur.cellId);
-      queue.push_back(cur);
-    }
-  }
-
-  sort(queue.begin(), queue.end());
-  return queue;
-}
-
-// -----------------------------------------------------------------------------
-PolyDataRemeshing::CellQueue PolyDataRemeshing::QueueCellsByShortestEdge() const
-{
-  CellInfo  cur;
-  vtkIdType npts, *pts;
-  double    p1[3], p2[3], p3[3];
-
-  CellQueue queue;
-  queue.reserve(_Output->GetNumberOfCells());
-
-  for (cur.cellId = 0; cur.cellId < _Output->GetNumberOfCells(); ++cur.cellId) {
-    _Output->GetCellPoints(cur.cellId, npts, pts);
-    if (npts == 0) continue;
-    GetPoint(pts[0], p1);
-    GetPoint(pts[1], p2);
-    GetPoint(pts[2], p3);
-    cur.priority = min(min(vtkMath::Distance2BetweenPoints(p1, p2),
-                           vtkMath::Distance2BetweenPoints(p2, p3)),
-                           vtkMath::Distance2BetweenPoints(p1, p3));
-    queue.push_back(cur);
-  }
-
-  sort(queue.begin(), queue.end());
-  return queue;
-}
-
-// -----------------------------------------------------------------------------
-PolyDataRemeshing::EdgeQueue PolyDataRemeshing::QueueEdgesByLength() const
-{
-  EdgeInfo cur;
-  double   p1[3], p2[3];
-
-  const class EdgeTable edgeTable(_Output);
-
-  EdgeQueue queue;
-  queue.reserve(edgeTable.NumberOfEdges());
-
-  mirtk::EdgeIterator it(edgeTable);
-  for (it.InitTraversal(); it.GetNextEdge(cur.ptId1, cur.ptId2) != -1;) {
-    GetPoint(cur.ptId1, p1);
-    GetPoint(cur.ptId2, p2);
-    cur.priority = vtkMath::Distance2BetweenPoints(p1, p2);
-    queue.push_back(cur);
-  }
-
-  sort(queue.begin(), queue.end());
-  return queue;
+  return priority;
 }
 
 // -----------------------------------------------------------------------------
@@ -396,7 +387,7 @@ inline void PolyDataRemeshing
 ::InterpolatePointData(vtkIdType newId, vtkIdType ptId1, vtkIdType ptId2)
 {
   vtkPointData *pd = _Output->GetPointData();
-  if (pd == NULL) return;
+  if (pd == nullptr) return;
   if (_OutputPointLabels) {
     double label = _OutputPointLabels->GetComponent(ptId1, 0);
     pd->InterpolateEdge(pd, newId, ptId1, ptId2, .5);
@@ -411,7 +402,7 @@ inline void PolyDataRemeshing
 ::InterpolatePointData(vtkIdType newId, vtkIdList *ptIds, double *weights)
 {
   vtkPointData *pd = _Output->GetPointData();
-  if (pd == NULL) return;
+  if (pd == nullptr) return;
   if (_OutputPointLabels) {
     double label = _OutputPointLabels->GetComponent(ptIds->GetId(0), 0);
     pd->InterpolatePoint(pd, newId, ptIds, weights);
@@ -450,75 +441,16 @@ inline double PolyDataRemeshing
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-void PolyDataRemeshing::MeltTriplets()
-{
-  MIRTK_START_TIMING();
-
-  bool replace;
-  vtkIdType npts, *pts;
-  double    p1[3], p2[3], p3[3];
-  vtkSmartPointer<vtkIdList> cellIds = vtkSmartPointer<vtkIdList>::New();
-  vtkSmartPointer<vtkIdList> ptIds   = vtkSmartPointer<vtkIdList>::New();
-
-  for (vtkIdType ptId = 0; ptId < _Output->GetNumberOfPoints(); ++ptId) {
-    _Output->GetPointCells(ptId, cellIds);
-    if (cellIds->GetNumberOfIds() == 3) {
-      replace = false;
-      ptIds->Reset();
-      for (vtkIdType i = 0; i < cellIds->GetNumberOfIds(); ++i) {
-        _Output->GetCellPoints(cellIds->GetId(i), npts, pts);
-        GetPoint(pts[0], p1);
-        GetPoint(pts[1], p2);
-        GetPoint(pts[2], p3);
-        if (vtkMath::Distance2BetweenPoints(p1, p2) < SquaredMinEdgeLength(pts[0], pts[1]) ||
-            vtkMath::Distance2BetweenPoints(p2, p3) < SquaredMinEdgeLength(pts[1], pts[2]) ||
-            vtkMath::Distance2BetweenPoints(p3, p1) < SquaredMinEdgeLength(pts[2], pts[0])) {
-          replace = true;
-        }
-        for (vtkIdType j = 0; j < npts; ++j) {
-          if (pts[j] != ptId) ptIds->InsertUniqueId(pts[j]);
-        }
-      }
-      replace = (replace && ptIds->GetNumberOfIds() == 3);
-      if (replace) {
-        replace = NodeConnectivity(ptIds->GetId(0)) > 3 &&
-                  NodeConnectivity(ptIds->GetId(1)) > 3 &&
-                  NodeConnectivity(ptIds->GetId(2)) > 3;
-      }
-      if (replace) {
-        _Output->GetCellPoints(cellIds->GetId(0), npts, pts);
-        vtkIdType newPtId = -1;
-        for (vtkIdType i = 0; newPtId == -1 && i < ptIds->GetNumberOfIds(); ++i) {
-          newPtId = ptIds->GetId(i);
-          for (vtkIdType j = 0; j < npts; ++j) {
-            if (newPtId == pts[j]) {
-              newPtId = -1;
-              break;
-            }
-          }
-        }
-        ReplaceCellPoint(cellIds->GetId(0), ptId, newPtId);
-        DeleteCell(cellIds->GetId(1));
-        DeleteCell(cellIds->GetId(2));
-        ++_NumberOfMeltedNodes;
-      }
-    }
-  }
-
-  MIRTK_DEBUG_TIMING(2, "melting nodes with connectivity 3");
-}
-
-// -----------------------------------------------------------------------------
-void PolyDataRemeshing
+bool PolyDataRemeshing
 ::MeltEdge(vtkIdType cellId, vtkIdType ptId1, vtkIdType ptId2, vtkIdList *cellIds)
 {
   // Check/resolve node connectivity of adjacent points
-  vtkIdType neighborPtId = GetCellEdgeNeighborPoint(cellId, ptId1, ptId2, true);
-  if (neighborPtId == -1) return;
+  vtkIdType neighborPtId = GetCellEdgeNeighborPoint(cellId, ptId1, ptId2, _MeltNodes);
+  if (neighborPtId == -1) return false;
 
   // Get edge neighbor cell
   vtkIdType neighborCellId = GetCellEdgeNeighbor(cellId, ptId1, ptId2);
-  if (neighborCellId == -1) return;
+  if (neighborCellId == -1) return false;
 
   // Interpolate point data
   InterpolatePointData(ptId1, ptId1, ptId2);
@@ -526,6 +458,7 @@ void PolyDataRemeshing
   // Move first point to edge middlepoint
   Point m = MiddlePoint(ptId1, ptId2);
   _Output->GetPoints()->SetPoint(ptId1, m._x, m._y, m._z);
+  _Output->GetPoints()->Modified();
 
   // Replace second point in (remaining) adjacent cells by first point
   _Output->GetPointCells(ptId2, cellIds);
@@ -537,31 +470,41 @@ void PolyDataRemeshing
   DeleteCell(cellId);
   DeleteCell(neighborCellId);
 
+  // Update priority queue
+  _Output->GetPointCells(ptId1, cellIds);
+  for (vtkIdType i = 0; i < cellIds->GetNumberOfIds(); ++i) {
+    _MeltingQueue->DeleteId(cellIds->GetId(i));
+    double priority = MeltingPriority(cellIds->GetId(i));
+    if (!IsInf(priority)) _MeltingQueue->Insert(priority, cellIds->GetId(i));
+  }
+  _MeltingQueue->DeleteId(neighborCellId);
+
   ++_NumberOfMeltedEdges;
+  return true;
 }
 
 // -----------------------------------------------------------------------------
-void PolyDataRemeshing::MeltTriangle(vtkIdType cellId, vtkIdList *cellIds)
+bool PolyDataRemeshing::MeltTriangle(vtkIdType cellId, vtkIdList *cellIds)
 {
   // Get triangle corners
   vtkSmartPointer<vtkIdList> ptIds = vtkSmartPointer<vtkIdList>::New();
   _Output->GetCellPoints(cellId, ptIds);
 
   // Get points opposite to cell edges and resolve connectivity of 3 if possible
-  vtkIdType ptId1 = GetCellEdgeNeighborPoint(cellId, ptIds->GetId(0), ptIds->GetId(1), true);
-  if (ptId1 == -1) return;
-  vtkIdType ptId2 = GetCellEdgeNeighborPoint(cellId, ptIds->GetId(1), ptIds->GetId(2), true);
-  if (ptId2 == -1) return;
-  vtkIdType ptId3 = GetCellEdgeNeighborPoint(cellId, ptIds->GetId(2), ptIds->GetId(0), true);
-  if (ptId3 == -1) return;
+  vtkIdType ptId1 = GetCellEdgeNeighborPoint(cellId, ptIds->GetId(0), ptIds->GetId(1), _MeltNodes);
+  if (ptId1 == -1) return false;
+  vtkIdType ptId2 = GetCellEdgeNeighborPoint(cellId, ptIds->GetId(1), ptIds->GetId(2), _MeltNodes);
+  if (ptId2 == -1) return false;
+  vtkIdType ptId3 = GetCellEdgeNeighborPoint(cellId, ptIds->GetId(2), ptIds->GetId(0), _MeltNodes);
+  if (ptId3 == -1) return false;
 
   // Get adjacent triangles
   vtkIdType neighborCellId1 = GetCellEdgeNeighbor(cellId, ptIds->GetId(0), ptIds->GetId(1));
-  if (neighborCellId1 == -1) return;
+  if (neighborCellId1 == -1) return false;
   vtkIdType neighborCellId2 = GetCellEdgeNeighbor(cellId, ptIds->GetId(1), ptIds->GetId(2));
-  if (neighborCellId2 == -1) return;
+  if (neighborCellId2 == -1) return false;
   vtkIdType neighborCellId3 = GetCellEdgeNeighbor(cellId, ptIds->GetId(2), ptIds->GetId(0));
-  if (neighborCellId3 == -1) return;
+  if (neighborCellId3 == -1) return false;
 
   // Get triangle center point and interpolation weights
   double pcoords[3], c[3], weights[3];
@@ -593,112 +536,183 @@ void PolyDataRemeshing::MeltTriangle(vtkIdType cellId, vtkIdList *cellIds)
   DeleteCell(neighborCellId2);
   DeleteCell(neighborCellId3);
 
+  // Update priority queue
+  _Output->GetPointCells(ptIds->GetId(0), cellIds);
+  for (vtkIdType i = 0, cellId; i < cellIds->GetNumberOfIds(); ++i) {
+    cellId = cellIds->GetId(i);
+    _MeltingQueue->DeleteId(cellId);
+    double priority = MeltingPriority(cellId);
+    if (!IsInf(priority)) _MeltingQueue->Insert(priority, cellId);
+  }
+  _MeltingQueue->DeleteId(neighborCellId1);
+  _MeltingQueue->DeleteId(neighborCellId2);
+  _MeltingQueue->DeleteId(neighborCellId3);
+
   ++_NumberOfMeltedCells;
+  return true;
 }
 
 // -----------------------------------------------------------------------------
-void PolyDataRemeshing::Melting(vtkIdType cellId, vtkIdList *cellIds)
+void PolyDataRemeshing::MeltingOfCells()
 {
+  MIRTK_START_TIMING();
+
   int       melt[3], i, j;
   double    p1[3], p2[3], p3[3], length2[3], n1[3], n2[3], n3[3];
-  vtkIdType npts, *pts;
+  vtkIdType cellId, npts, *pts;
 
-  _Output->GetCellPoints(cellId, npts, pts);
-  if (npts == 0) return; // cell marked as deleted (i.e., VTK_EMPTY_CELL)
-  mirtkAssert(npts == 3, "surface is triangulated");
+  // Cell ID list shared by melting operation functions to save reallocation
+  vtkSmartPointer<vtkIdList> cellIds = vtkSmartPointer<vtkIdList>::New();
+  cellIds->Allocate(20);
 
-  // Get (transformed) point coordinates
-  GetPoint(pts[0], p1);
-  GetPoint(pts[1], p2);
-  GetPoint(pts[2], p3);
+  // Initialize priority queue of cells to process
+  _MeltingQueue = vtkSmartPointer<vtkPriorityQueue>::New();
+  for (cellId = 0; cellId < _Output->GetNumberOfCells(); ++cellId) {
+    double priority = MeltingPriority(cellId);
+    if (!IsInf(priority)) _MeltingQueue->Insert(priority, cellId);
+  }
 
-  length2[0] = vtkMath::Distance2BetweenPoints(p1, p2);
-  length2[1] = vtkMath::Distance2BetweenPoints(p2, p3);
-  length2[2] = vtkMath::Distance2BetweenPoints(p3, p1);
+  int num_triangle_melting_attempts = 0;
 
-  // If triangle-melting is allowed
-  if (_MeltTriangles) {
+  // Process cells in order determined by priority (e.g., smallest triangle first)
+  while (_MeltingQueue->GetNumberOfItems() > 0) {
+    cellId = _MeltingQueue->Pop();
 
-    // Determine which edges are too short
-    melt[0] = int(length2[0] < SquaredMinEdgeLength(pts[0], pts[1]));
-    melt[1] = int(length2[1] < SquaredMinEdgeLength(pts[1], pts[2]));
-    melt[2] = int(length2[2] < SquaredMinEdgeLength(pts[2], pts[0]));
+    _Output->GetCellPoints(cellId, npts, pts);
+    if (npts == 0) continue; // cell marked as deleted (i.e., VTK_EMPTY_CELL)
+    mirtkAssert(npts == 3, "surface is triangulated");
 
-    // Do not melt feature edges (otherwise remeshing may smooth surface too much)
-    if ((melt[0] || melt[1] || melt[2]) && _MinFeatureAngle < 180.0) {
-      GetNormal(pts[0], n1);
-      GetNormal(pts[1], n2);
-      GetNormal(pts[2], n3);
-      if (melt[0]) melt[0] = int(1.0 - vtkMath::Dot(n1, n2) < _MinFeatureAngleCos);
-      if (melt[1]) melt[1] = int(1.0 - vtkMath::Dot(n2, n3) < _MinFeatureAngleCos);
-      if (melt[2]) melt[2] = int(1.0 - vtkMath::Dot(n3, n1) < _MinFeatureAngleCos);
-    }
+    // Get (transformed) point coordinates
+    GetPoint(pts[0], p1);
+    GetPoint(pts[1], p2);
+    GetPoint(pts[2], p3);
 
-    // Perform either edge-melting, triangle-melting, or no operation
-    switch (melt[0] + melt[1] + melt[2]) {
-      case 1: {
-        if      (melt[0]) MeltEdge(cellId, pts[0], pts[1], cellIds);
-        else if (melt[1]) MeltEdge(cellId, pts[1], pts[2], cellIds);
-        else              MeltEdge(cellId, pts[2], pts[0], cellIds);
-      } break;
-      case 3: {
-        MeltTriangle(cellId, cellIds);
-      } break;
-    }
+    length2[0] = vtkMath::Distance2BetweenPoints(p1, p2);
+    length2[1] = vtkMath::Distance2BetweenPoints(p2, p3);
+    length2[2] = vtkMath::Distance2BetweenPoints(p3, p1);
 
-  // If only individual edges are allowed to be melted
-  } else {
+    // If triangle-melting is allowed
+    if (_MeltTriangles) {
 
-    // Determine shortest edge
-    for (i = 0, j = 1; j < 3; ++j) {
-      if (length2[j] < length2[i]) i = j;
-    }
-    j = (i + 1) % 3;
+      // Determine which edges are too short
+      melt[0] = int(length2[0] < SquaredMinEdgeLength(pts[0], pts[1]));
+      melt[1] = int(length2[1] < SquaredMinEdgeLength(pts[1], pts[2]));
+      melt[2] = int(length2[2] < SquaredMinEdgeLength(pts[2], pts[0]));
 
-    // Melt edge if it is too short and not a feature edge
-    if (length2[i] < SquaredMinEdgeLength(pts[i], pts[j])) {
-      if (_MinFeatureAngle < 180.0) {
-        GetNormal(pts[i], n1);
-        GetNormal(pts[j], n2);
-        if (1.0 - vtkMath::Dot(n1, n2) < _MinFeatureAngleCos) {
+      // Do not melt feature edges (otherwise remeshing may smooth surface too much)
+      if ((melt[0] || melt[1] || melt[2]) && _MinFeatureAngle < 180.0) {
+        GetNormal(pts[0], n1);
+        GetNormal(pts[1], n2);
+        GetNormal(pts[2], n3);
+        if (melt[0]) melt[0] = int(1.0 - vtkMath::Dot(n1, n2) < _MinFeatureAngleCos);
+        if (melt[1]) melt[1] = int(1.0 - vtkMath::Dot(n2, n3) < _MinFeatureAngleCos);
+        if (melt[2]) melt[2] = int(1.0 - vtkMath::Dot(n3, n1) < _MinFeatureAngleCos);
+      }
+
+      // Perform either edge-melting, triangle-melting, or no operation
+      switch (melt[0] + melt[1] + melt[2]) {
+        case 1: {
+          if      (melt[0]) MeltEdge(cellId, pts[0], pts[1], cellIds);
+          else if (melt[1]) MeltEdge(cellId, pts[1], pts[2], cellIds);
+          else              MeltEdge(cellId, pts[2], pts[0], cellIds);
+        } break;
+        case 3: {
+          ++num_triangle_melting_attempts;
+          if (!MeltTriangle(cellId, cellIds)) {
+            i = 0;
+            if (length2[1] < length2[0]) i = 1;
+            if (length2[2] < length2[i]) i = 2;
+            j = (i + 1) % 3;
+            MeltEdge(cellId, pts[i], pts[j], cellIds);
+          }
+        } break;
+      }
+
+    // If only individual edges are allowed to be melted
+    } else {
+
+      // Determine shortest edge
+      i = 0;
+      if (length2[1] < length2[0]) i = 1;
+      if (length2[2] < length2[i]) i = 2;
+      j = (i + 1) % 3;
+
+      // Melt edge if it is too short and not a feature edge
+      if (length2[i] < SquaredMinEdgeLength(pts[i], pts[j])) {
+        if (_MinFeatureAngle < 180.0) {
+          GetNormal(pts[i], n1);
+          GetNormal(pts[j], n2);
+          if (1.0 - vtkMath::Dot(n1, n2) < _MinFeatureAngleCos) {
+            MeltEdge(cellId, pts[i], pts[j], cellIds);
+          }
+        } else {
           MeltEdge(cellId, pts[i], pts[j], cellIds);
         }
-      } else {
-        MeltEdge(cellId, pts[i], pts[j], cellIds);
       }
-    }
 
+    }
   }
+
+  _MeltingQueue = nullptr;
+  MIRTK_DEBUG_TIMING(3, "melting edges and triangles");
 }
 
 // -----------------------------------------------------------------------------
-void PolyDataRemeshing
-::Melting(vtkIdType ptId1, vtkIdList *cellIds1, vtkIdType ptId2, vtkIdList *cellIds2)
+void PolyDataRemeshing::MeltingOfNodes()
 {
-  _Output->GetPointCells(ptId1, cellIds1);
-  _Output->GetPointCells(ptId2, cellIds2);
-  cellIds1->IntersectWith(cellIds2);
+  MIRTK_START_TIMING();
 
-  if (cellIds1->GetNumberOfIds() != 2) {
-    // Either unexpected topology or either one of the points is marked as deleted
-    return;
-  }
+  unsigned short             ncells;
+  vtkIdType                  ptIdx, npts, *pts, *cells;
+  vtkSmartPointer<vtkIdList> ptIds1, ptIds2;
+  ptIds1 = vtkSmartPointer<vtkIdList>::New();
+  ptIds2 = vtkSmartPointer<vtkIdList>::New();
 
-  double p1[3], p2[3], n1[3], n2[3];
-  GetPoint(ptId1, p1);
-  GetPoint(ptId2, p2);
-
-  if (vtkMath::Distance2BetweenPoints(p1, p2) < SquaredMinEdgeLength(ptId1, ptId2)) {
-    if (_MinFeatureAngle < 180.0) {
-      GetNormal(ptId1, n1);
-      GetNormal(ptId2, n2);
-      if (1.0 - vtkMath::Dot(n1, n2) < _MinFeatureAngleCos) {
-        MeltEdge(cellIds1->GetId(0), ptId1, ptId2, cellIds2);
+  bool changed = true;
+  for (int iter = 0; iter < 10 && changed; ++iter) {
+    changed = false;
+    for (vtkIdType ptId = 0; ptId < _Output->GetNumberOfPoints(); ++ptId) {
+      _Output->GetPointCells(ptId, ncells, cells);
+      switch (ncells) {
+        case 1: case 2: {
+          for (unsigned short i = 0; i < ncells; ++i) {
+            DeleteCell(cells[i]);
+          }
+          ++_NumberOfMeltedNodes;
+          changed = true;
+        } break;
+        case 3: {
+          ptIds1->Reset();
+          ptIds2->Reset();
+          for (unsigned short i = 0; i < ncells; ++i) {
+            _Output->GetCellPoints(cells[i], npts, pts);
+            if (i == 0) {
+              ptIds1->Allocate(npts);
+              for (vtkIdType j = 0; j < npts; ++j) {
+                ptIds1->InsertNextId(pts[j]);
+              }
+            }
+            for (vtkIdType j = 0; j < npts; ++j) {
+              ptIds2->InsertUniqueId(pts[j]);
+            }
+          }
+          ptIds2->DeleteId(ptId);
+          if (ptIds2->GetNumberOfIds() != 3) continue;
+          for (ptIdx = 0; ptIdx < ptIds2->GetNumberOfIds(); ++ptIdx) {
+            if (ptIds1->IsId(ptIds2->GetId(ptIdx)) == -1) break;
+          }
+          if (ptIdx == ptIds2->GetNumberOfIds()) continue;
+          ReplaceCellPoint(cells[0], ptId, ptIds2->GetId(ptIdx));
+          DeleteCell(cells[1]);
+          DeleteCell(cells[2]);
+          ++_NumberOfMeltedNodes;
+          changed = true;
+        } break;
       }
-    } else {
-      MeltEdge(cellIds1->GetId(0), ptId1, ptId2, cellIds2);
     }
   }
+
+  MIRTK_DEBUG_TIMING(3, "melting nodes with connectivity less equal 3");
 }
 
 // -----------------------------------------------------------------------------
@@ -875,6 +889,7 @@ void PolyDataRemeshing::Initialize()
   _Output->BuildLinks();
 
   // Reset counters
+  _NumberOfMeltedNodes  = 0;
   _NumberOfMeltedEdges  = 0;
   _NumberOfMeltedCells  = 0;
   _NumberOfInversions   = 0;
@@ -990,61 +1005,35 @@ void PolyDataRemeshing::Melting()
 {
   MIRTK_START_TIMING();
 
-  // Cell ID list shared by melting operation functions to save reallocation
-  vtkSmartPointer<vtkIdList> cellIds = vtkSmartPointer<vtkIdList>::New();
+  // Melt triplets of triangles adjacent to nodes with connectivity 3
+  // and remove any triangles connected to possibly resulting nodes with
+  // connectivity less than 3
+  if (_MeltNodes) MeltingOfNodes();
 
-  // Pre-melt triplet of small triangles adjacent sharing one point
-  if (_MeltNodes) MeltTriplets();
+  // Process triangles in chosen melting order
+  MeltingOfCells();
 
-  // Either iterate edges and only melt individual edges...
-  if (!_MeltTriangles && _MeltingOrder == SHORTEST_EDGE) {
+  // Melt triplets of triangles adjacent to nodes with connectivity 3
+  // and remove any triangles connected to possibly resulting nodes with
+  // connectivity less than 3
+  if (_MeltNodes) MeltingOfNodes();
 
-    // Determine order in which to process edges
-    EdgeQueue queue = QueueEdgesByLength();
-
-    // Process edges in determined order
-    vtkSmartPointer<vtkIdList> cellIds2 = vtkSmartPointer<vtkIdList>::New();
-    for (EdgeIterator cur = queue.begin(); cur != queue.end(); ++cur) {
-      Melting(cur->ptId1, cellIds, cur->ptId2, cellIds2);
-    }
-
-  // ...or iterate faces and possibly allow also triangles to be melted
-  } else {
-
-    // Determine order in which to process cells
-    CellQueue queue;
-    switch (_MeltingOrder) {
-      case INDEX: break;
-      case AREA:          queue = QueueCellsByArea();         break;
-      case SHORTEST_EDGE: queue = QueueCellsByShortestEdge(); break;
-    }
-
-    // Process triangles in determined order
-    if (queue.empty()) {
-      const vtkIdType ncells = _Output->GetNumberOfCells();
-      for (vtkIdType cellId = 0; cellId < ncells; ++cellId) {
-        Melting(cellId, cellIds);
-      }
-    } else {
-      for (CellIterator cur = queue.begin(); cur != queue.end(); ++cur) {
-        Melting(cur->cellId, cellIds);
-      }
-    }
+  // Remove cells which are marked as deleted
+  if (NumberOfMeltings() > 0) {
+    _Output->RemoveDeletedCells();
+    _Output->BuildLinks();
   }
-
-  // Post-melt triplet of small triangles adjacent sharing one point
-  if (_MeltNodes) MeltTriplets();
 
   MIRTK_DEBUG_TIMING(2, "melting pass");
 }
 
 // -----------------------------------------------------------------------------
-void PolyDataRemeshing::Inversion()
+void PolyDataRemeshing::InversionOfTrianglesSharingOneLongEdge()
 {
   MIRTK_START_TIMING();
 
   int       i, j, k;
-  double    p1[3], p2[3], p3[3], length2[3], min2[3], max2[3];
+  double    p[4][3], length2[3], min2[3], max2[3];
   vtkIdType adjCellId, adjPtId, npts, *pts;
 
   for (vtkIdType cellId = 0; cellId < _Output->GetNumberOfCells(); ++cellId) {
@@ -1054,14 +1043,14 @@ void PolyDataRemeshing::Inversion()
     mirtkAssert(npts == 3, "surface is triangulated");
 
     // Get (transformed) point coordinates
-    GetPoint(pts[0], p1);
-    GetPoint(pts[1], p2);
-    GetPoint(pts[2], p3);
+    GetPoint(pts[0], p[0]);
+    GetPoint(pts[1], p[1]);
+    GetPoint(pts[2], p[2]);
 
     // Calculate lengths of triangle edges
-    length2[0] = vtkMath::Distance2BetweenPoints(p1, p2);
-    length2[1] = vtkMath::Distance2BetweenPoints(p2, p3);
-    length2[2] = vtkMath::Distance2BetweenPoints(p3, p1);
+    length2[0] = vtkMath::Distance2BetweenPoints(p[0], p[1]);
+    length2[1] = vtkMath::Distance2BetweenPoints(p[1], p[2]);
+    length2[2] = vtkMath::Distance2BetweenPoints(p[2], p[0]);
 
     min2[0] = SquaredMinEdgeLength(pts[0], pts[1]);
     min2[1] = SquaredMinEdgeLength(pts[1], pts[2]);
@@ -1088,15 +1077,13 @@ void PolyDataRemeshing::Inversion()
       if (NodeConnectivity(pts[i]) > 3 && NodeConnectivity(pts[j]) > 3) {
         // Get other vertex of triangle sharing long edge
         adjPtId = GetCellEdgeNeighborPoint(cellId, pts[i], pts[j]);
-        if (adjPtId == -1) continue;
+        if (adjPtId == -1 || _Output->IsEdge(pts[k], adjPtId)) continue;
         // Check if length of other edges are in range
-        GetPoint(pts[i],  p1);
-        GetPoint(adjPtId, p3);
-        length2[0] = vtkMath::Distance2BetweenPoints(p1, p3);
+        GetPoint(adjPtId, p[3]);
+        length2[0] = vtkMath::Distance2BetweenPoints(p[i], p[3]);
         if (length2[0] < SquaredMinEdgeLength(pts[i], adjPtId) ||
             length2[0] > SquaredMaxEdgeLength(pts[i], adjPtId)) continue;
-        GetPoint(pts[j], p2);
-        length2[1] = vtkMath::Distance2BetweenPoints(p2, p3);
+        length2[1] = vtkMath::Distance2BetweenPoints(p[j], p[3]);
         if (length2[1] < SquaredMinEdgeLength(pts[j], adjPtId) ||
             length2[1] > SquaredMaxEdgeLength(pts[j], adjPtId)) continue;
         // Perform inversion operation
@@ -1109,7 +1096,97 @@ void PolyDataRemeshing::Inversion()
     }
   }
 
-  MIRTK_DEBUG_TIMING(2, "inversion pass");
+  MIRTK_DEBUG_TIMING(3, "inversion of triangles shared one long edge");
+}
+
+// -----------------------------------------------------------------------------
+void PolyDataRemeshing::InversionOfTrianglesToIncreaseMinHeight()
+{
+  MIRTK_START_TIMING();
+
+  int       i, j, k;
+  double    p[4][3], length2[3], l1, l2, a1, a2, a3, a4;
+  vtkIdType adjCellId, adjPtId, npts, *pts;
+
+  for (vtkIdType cellId = 0; cellId < _Output->GetNumberOfCells(); ++cellId) {
+
+    _Output->GetCellPoints(cellId, npts, pts);
+    if (npts == 0) continue; // cell marked as deleted (i.e., VTK_EMPTY_CELL)
+    mirtkAssert(npts == 3, "surface is triangulated");
+
+    // Get (transformed) point coordinates
+    GetPoint(pts[0], p[0]);
+    GetPoint(pts[1], p[1]);
+    GetPoint(pts[2], p[2]);
+
+    // Calculate lengths of triangle edges
+    length2[0] = vtkMath::Distance2BetweenPoints(p[0], p[1]);
+    length2[1] = vtkMath::Distance2BetweenPoints(p[1], p[2]);
+    length2[2] = vtkMath::Distance2BetweenPoints(p[2], p[0]);
+
+    // Get longest edge in triangle
+    i = 0;
+    if (length2[1] > length2[0]) i = 1;
+    if (length2[2] > length2[i]) i = 2; // 1st long edge point index
+    j = (i == 2 ? 0 : i + 1);           // 2nd long edge point index
+    k = (j == 2 ? 0 : j + 1);           // 3rd point of this triangle
+
+    a1 = vtkTriangle::TriangleArea(p[0], p[1], p[2]);
+    if (a1 > .25 * length2[i]) continue; // ratio of height over l1
+
+    // Check connectivity of long edge end points
+    if (NodeConnectivity(pts[i]) > 3 && NodeConnectivity(pts[j]) > 3) {
+
+      // Get other vertex of triangle sharing long edge
+      adjCellId = GetCellEdgeNeighbor(cellId, pts[i], pts[j]);
+      if (adjCellId == -1) continue;
+
+      adjPtId = GetCellEdgeNeighborPoint(cellId, pts[i], pts[j]);
+      if (adjPtId == -1 || _Output->IsEdge(pts[k], adjPtId)) continue;
+      GetPoint(adjPtId, p[3]);
+
+      // Do not invert when other edge of neighboring triangle is longer
+      if (vtkMath::Distance2BetweenPoints(p[i], p[3]) > length2[i] ||
+          vtkMath::Distance2BetweenPoints(p[j], p[3]) > length2[i]) continue;
+
+      // Length of edge before and after inversion
+      l1 = sqrt(length2[i]);
+      l2 = sqrt(vtkMath::Distance2BetweenPoints(p[k], p[3]));
+
+      // Areas of adjacent triangles after inversion
+      a2 = vtkTriangle::TriangleArea(p[i], p[j], p[3]);
+      a3 = vtkTriangle::TriangleArea(p[i], p[k], p[3]);
+      a4 = vtkTriangle::TriangleArea(p[j], p[k], p[3]);
+
+      // Perform inversion operation when minimum height over edge before
+      // and after inversion is greater after the operation
+      if ((a1 + a2) * l2 < (a3 + a4) * l1) {
+        const vtkIdType ptId[4] = {pts[i], pts[j], pts[k], adjPtId};
+        ReplaceCellPoint(adjCellId, ptId[0], ptId[2]);
+        ReplaceCellPoint(cellId,    ptId[1], ptId[3]);
+        ++_NumberOfInversions;
+      }
+    }
+  }
+
+  MIRTK_DEBUG_TIMING(3, "inversion of triangles to increase height");
+}
+
+// -----------------------------------------------------------------------------
+void PolyDataRemeshing::Inversion()
+{
+  MIRTK_START_TIMING();
+
+  if (_InvertTrianglesSharingOneLongEdge) {
+    InversionOfTrianglesSharingOneLongEdge();
+  }
+  if (_InvertTrianglesToIncreaseMinHeight) {
+    InversionOfTrianglesToIncreaseMinHeight();
+  }
+
+  if (_InvertTrianglesSharingOneLongEdge || _InvertTrianglesToIncreaseMinHeight) {
+    MIRTK_DEBUG_TIMING(2, "inversion pass");
+  }
 }
 
 // -----------------------------------------------------------------------------
@@ -1195,6 +1272,7 @@ void PolyDataRemeshing::Subdivision()
   newPolys->Squeeze();
   _Output->DeleteCells();
   _Output->SetPolys(newPolys);
+  _Output->BuildLinks();
 
   MIRTK_DEBUG_TIMING(2, "subdivison pass");
 }
@@ -1207,9 +1285,7 @@ void PolyDataRemeshing::Finalize()
 
   // If input surface mesh unchanged, set output equal to input
   // Users can check if this->Output() == this->Input() to see if something changed
-  if (_NumberOfMeltedNodes + _NumberOfMeltedEdges + _NumberOfMeltedCells +
-      _NumberOfInversions  +
-      _NumberOfBisections  + _NumberOfTrisections +_NumberOfQuadsections == 0) {
+  if (NumberOfChanges() == 0) {
     _Output = _Input;
     return;
   }
@@ -1223,7 +1299,7 @@ void PolyDataRemeshing::Finalize()
   //        This is avoided when running the vtkPolyDataNormals filter before.
   //        An inconsistent cell vertex ordering may in particular be caused
   //        by the Quadsect function (maybe also other Subdivision routines).
-  vtkSmartPointer<vtkPolyDataNormals> prenormals = vtkSmartPointer<vtkPolyDataNormals>::New();
+  vtkNew<vtkPolyDataNormals> prenormals;
   SetVTKInput(prenormals, _Output);
   prenormals->SplittingOff();
   prenormals->AutoOrientNormalsOn();
@@ -1234,7 +1310,7 @@ void PolyDataRemeshing::Finalize()
   prenormals->Update();
   _Output = prenormals->GetOutput();
 
-  vtkSmartPointer<vtkCleanPolyData> cleaner = vtkSmartPointer<vtkCleanPolyData>::New();
+  vtkNew<vtkCleanPolyData> cleaner;
   SetVTKInput(cleaner, _Output);
   cleaner->PointMergingOn();
   cleaner->SetAbsoluteTolerance(.0);
@@ -1243,11 +1319,11 @@ void PolyDataRemeshing::Finalize()
   cleaner->ConvertStripsToPolysOn();
   cleaner->Update();
   _Output = cleaner->GetOutput();
-  _Output->SetVerts(NULL);
-  _Output->SetLines(NULL);
+  _Output->SetVerts(nullptr);
+  _Output->SetLines(nullptr);
 
   // Recompute normals and ensure consistent order of vertices
-  vtkSmartPointer<vtkPolyDataNormals> normals = vtkSmartPointer<vtkPolyDataNormals>::New();
+  vtkNew<vtkPolyDataNormals> normals;
   SetVTKInput(normals, _Output);
   normals->SplittingOff();
   normals->AutoOrientNormalsOn();


### PR DESCRIPTION
The surface remeshing filter would not always preserve the topology of the input surface mesh. Also, the melting operations were not performed in an order that results in more regular output meshes.