### PR TITLE
Morphological commands should be able to process any type of image

### DIFF
--- a/Applications/close-image.cc
+++ b/Applications/close-image.cc
@@ -99,8 +99,11 @@ int main(int argc, char *argv[])
     case MIRTK_VOXEL_BINARY:  Close<BinaryPixel>(image.get(), iterations, connectivity); break;
     case MIRTK_VOXEL_GREY:    Close<GreyPixel  >(image.get(), iterations, connectivity); break;
     case MIRTK_VOXEL_REAL:    Close<RealPixel  >(image.get(), iterations, connectivity); break;
-    default:
-      FatalError("Unsupported voxel type: " << ToString(image->GetDataType()));
+    default: {
+      RealImage other(*image);
+      Close<RealPixel>(&other, iterations, connectivity);
+      *image = other;
+    } break;
   }
   if (verbose) cout << "done" << endl;
 

--- a/Applications/close-image.cc
+++ b/Applications/close-image.cc
@@ -62,8 +62,54 @@ void PrintHelp(const char *name)
 template <class TVoxel>
 void Close(BaseImage *image, int iterations, ConnectivityType connectivity)
 {
-  Dilate<TVoxel>(image, iterations, connectivity);
-  Erode <TVoxel>(image, iterations, connectivity);
+  int i1, j1, k1, i2, j2, k2;
+  image->PutBackgroundValueAsDouble(.0);
+  image->BoundingBox(i1, j1, k1, i2, j2, k2);
+
+  i1 -= iterations;
+  j1 -= iterations;
+  k1 -= iterations;
+  i2 += iterations;
+  j2 += iterations;
+  k2 += iterations;
+
+  if (i1 < 0 || i2 >= image->X() ||
+      j1 < 0 || j2 >= image->Y() ||
+      k1 < 0 || k2 >= image->Z()) {
+
+    GenericImage<TVoxel> padded(i2 - i1 + 1, j2 - j1 + 1, k2 - k1 + 1);
+
+    i1 += iterations;
+    j1 += iterations;
+    k1 += iterations;
+    i2 -= iterations;
+    j2 -= iterations;
+    k2 -= iterations;
+
+    for (int k = k1; k <= k2; ++k)
+    for (int j = j1; j <= j2; ++j)
+    for (int i = i1; i <= i2; ++i) {
+      padded(i - i1 + iterations, j - j1 + iterations, k - k1 + iterations)
+          = static_cast<TVoxel>(image->GetAsDouble(i, j, k));
+    }
+
+    Dilate<TVoxel>(&padded, iterations, connectivity);
+    Erode <TVoxel>(&padded, iterations, connectivity);
+
+    for (int k = k1; k <= k2; ++k)
+    for (int j = j1; j <= j2; ++j)
+    for (int i = i1; i <= i2; ++i) {
+      image->PutAsDouble(i, j, k, static_cast<double>(padded(i - i1 + iterations,
+                                                             j - j1 + iterations,
+                                                             k - k1 + iterations)));
+    }
+
+  } else {
+
+    Dilate<TVoxel>(image, iterations, connectivity);
+    Erode <TVoxel>(image, iterations, connectivity);
+
+  }
 }
 
 // =============================================================================

--- a/Applications/convert-image.cc
+++ b/Applications/convert-image.cc
@@ -65,13 +65,17 @@ int main(int argc, char *argv[])
   double max_value  = numeric_limits<double>::quiet_NaN();
 
   for (ALL_OPTIONS) {
-    if      (OPTION("-char")   == 0) voxel_type = MIRTK_VOXEL_CHAR;
-    else if (OPTION("-uchar")  == 0) voxel_type = MIRTK_VOXEL_UNSIGNED_CHAR;
-    else if (OPTION("-short")  == 0) voxel_type = MIRTK_VOXEL_SHORT;
-    else if (OPTION("-ushort") == 0) voxel_type = MIRTK_VOXEL_UNSIGNED_SHORT;
-    else if (OPTION("-float")  == 0) voxel_type = MIRTK_VOXEL_FLOAT;
-    else if (OPTION("-double") == 0) voxel_type = MIRTK_VOXEL_DOUBLE;
-    else if (OPTION("-rescale") == 0) {
+    if      (OPTION("-char"))   voxel_type = MIRTK_VOXEL_CHAR;
+    else if (OPTION("-uchar"))  voxel_type = MIRTK_VOXEL_UNSIGNED_CHAR;
+    else if (OPTION("-short"))  voxel_type = MIRTK_VOXEL_SHORT;
+    else if (OPTION("-ushort")) voxel_type = MIRTK_VOXEL_UNSIGNED_SHORT;
+    else if (OPTION("-float"))  voxel_type = MIRTK_VOXEL_FLOAT;
+    else if (OPTION("-double")) voxel_type = MIRTK_VOXEL_DOUBLE;
+    else if (OPTION("-binary")) voxel_type = MIRTK_VOXEL_BINARY;
+    else if (OPTION("-byte"))   voxel_type = MIRTK_VOXEL_BYTE;
+    else if (OPTION("-grey"))   voxel_type = MIRTK_VOXEL_GREY;
+    else if (OPTION("-real"))   voxel_type = MIRTK_VOXEL_REAL;
+    else if (OPTION("-rescale")) {
       PARSE_ARGUMENT(min_value);
       PARSE_ARGUMENT(max_value);
     }

--- a/Applications/dilate-image.cc
+++ b/Applications/dilate-image.cc
@@ -86,8 +86,11 @@ int main(int argc, char *argv[])
     case MIRTK_VOXEL_BINARY:  Dilate<BinaryPixel>(image.get(), iterations, connectivity); break;
     case MIRTK_VOXEL_GREY:    Dilate<GreyPixel  >(image.get(), iterations, connectivity); break;
     case MIRTK_VOXEL_REAL:    Dilate<RealPixel  >(image.get(), iterations, connectivity); break;
-    default:
-      FatalError("Unsupported voxel type: " << ToString(image->GetDataType()));
+    default: {
+      RealImage other(*image);
+      Dilate<RealPixel>(&other, iterations, connectivity);
+      *image = other;
+    } break;
   }
   if (verbose) cout << "done" << endl;
 

--- a/Applications/erode-image.cc
+++ b/Applications/erode-image.cc
@@ -86,8 +86,11 @@ int main(int argc, char *argv[])
     case MIRTK_VOXEL_BINARY:  Erode<BinaryPixel>(image.get(), iterations, connectivity); break;
     case MIRTK_VOXEL_GREY:    Erode<GreyPixel  >(image.get(), iterations, connectivity); break;
     case MIRTK_VOXEL_REAL:    Erode<RealPixel  >(image.get(), iterations, connectivity); break;
-    default:
-      FatalError("Unsupported voxel type: " << ToString(image->GetDataType()));
+    default: {
+      RealImage other(*image);
+      Erode<RealPixel>(&other, iterations, connectivity);
+      *image = other;
+    } break;
   }
   if (verbose) cout << "done" << endl;
 

--- a/Modules/Image/include/mirtkBaseImage.h
+++ b/Modules/Image/include/mirtkBaseImage.h
@@ -542,6 +542,15 @@ public:
   /// Whether any voxel is within background
   bool HasBackground() const;
 
+  /// Get 2D bounding box of image foreground
+  void BoundingBox(int &, int &, int &, int &) const;
+
+  /// Get 3D bounding box of image foreground
+  void BoundingBox(int &, int &, int &, int &, int &, int &) const;
+
+  /// Get 3D+t bounding box of image foreground
+  void BoundingBox(int &, int &, int &, int &, int &, int &, int &, int &) const;
+
   /// Determine center of mass of image foreground
   ///
   /// \param[out] center Centroid of image foreground.

--- a/Modules/Image/src/mirtkBaseImage.cc
+++ b/Modules/Image/src/mirtkBaseImage.cc
@@ -558,6 +558,116 @@ void BaseImage::ClearMask(bool force)
 }
 
 // -----------------------------------------------------------------------------
+void BaseImage::BoundingBox(int &i1, int &j1,
+                            int &i2, int &j2) const
+{
+  // Determine lower bound along x axis: i1
+  i1 = _attr._x;
+  for (int l = 0; l < _attr._t; ++l)
+  for (int k = 0; k < _attr._z; ++k)
+  for (int j = 0; j < _attr._y; ++j)
+  for (int i = 0; i < _attr._x; ++i) {
+    if (this->IsForeground(i, j, k, l)) {
+      if (i < i1) i1 = i;
+      break;
+    }
+  }
+  // Determine upper bound along x axis: i2
+  i2 = -1;
+  for (int l = 0; l < _attr._t; ++l)
+  for (int k = 0; k < _attr._z; ++k)
+  for (int j = 0; j < _attr._y; ++j)
+  for (int i = _attr._x - 1; i >= i1; --i) {
+    if (this->IsForeground(i, j, k, l)) {
+      if (i > i2) i2 = i;
+      break;
+    }
+  }
+  // Determine lower bound along y axis: j1
+  j1 = _attr._y;
+  for (int l = 0; l < _attr._t; ++l)
+  for (int k = 0; k < _attr._z; ++k)
+  for (int i = i1; i <= i2; ++i)
+  for (int j = 0; j < _attr._y; ++j) {
+    if (this->IsForeground(i, j, k, l)) {
+      if (j < j1) j1 = j;
+      break;
+    }
+  }
+  // Determine upper bound along y axis: j2
+  j2 = -1;
+  for (int l = 0; l < _attr._t; ++l)
+  for (int k = 0; k < _attr._z; ++k)
+  for (int i = i1; i <= i2; ++i)
+  for (int j = _attr._y - 1; j >= j1; --j) {
+    if (this->IsForeground(i, j, k, l)) {
+      if (j > j2) j2 = j;
+      break;
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+void BaseImage::BoundingBox(int &i1, int &j1, int &k1,
+                            int &i2, int &j2, int &k2) const
+{
+  // Get 2D bounding box
+  this->BoundingBox(i1, j1, i2, j2);
+  // Determine lower bound along z axis: k1
+  k1 = _attr._z;
+  for (int l = 0; l < _attr._t; ++l)
+  for (int j = j1; j <= j2; ++j)
+  for (int i = i1; i <= i2; ++i)
+  for (int k = 0; k < _attr._z; ++k) {
+    if (this->IsForeground(i, j, k, l)) {
+      if (k < k1) k1 = k;
+      break;
+    }
+  }
+  // Determine upper bound along z axis: k2
+  k2 = -1;
+  for (int l = 0; l < _attr._t; ++l)
+  for (int j = j1; j <= j2; ++j)
+  for (int i = i1; i <= i2; ++i)
+  for (int k = _attr._z - 1; k >= k1; --k) {
+    if (this->IsForeground(i, j, k, l)) {
+      if (k > k2) k2 = k;
+      break;
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+void BaseImage::BoundingBox(int &i1, int &j1, int &k1, int &l1,
+                            int &i2, int &j2, int &k2, int &l2) const
+{
+  // Get spatial bounding box
+  this->BoundingBox(i1, j1, k1, i2, j2, k2);
+  // Determine lower bound along t axis: l1
+  l1 = _attr._t;
+  for (int k = k1; k <= k2; ++k)
+  for (int j = j1; j <= j2; ++j)
+  for (int i = i1; i <= i2; ++i)
+  for (int l = 0; l < _attr._t; ++l) {
+    if (this->IsForeground(i, j, k, l)) {
+      if (l < l1) l1 = l;
+      break;
+    }
+  }
+  // Determine upper bound along t axis: l2
+  l2 = -1;
+  for (int k = k1; k <= k2; ++k)
+  for (int j = j1; j <= j2; ++j)
+  for (int i = i1; i <= i2; ++i)
+  for (int l = _attr._t - 1; l >= l1; --l) {
+    if (this->IsForeground(i, j, k, l)) {
+      if (l > l2) l2 = l;
+      break;
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
 int BaseImage::CenterOfForeground(Point &center) const
 {
   int n = 0;

--- a/Modules/Image/src/mirtkVoxel.cc
+++ b/Modules/Image/src/mirtkVoxel.cc
@@ -37,7 +37,7 @@ template <> string ToString(const ImageDataType &value, int w, char c, bool left
     case MIRTK_VOXEL_UNSIGNED_INT:   str = "uint"; break;
     case MIRTK_VOXEL_FLOAT:          str = "float"; break;
     case MIRTK_VOXEL_DOUBLE:         str = "double"; break;
-    case MIRTK_VOXEL_RGB:            str = "RGB"; break;
+    case MIRTK_VOXEL_RGB:            str = "rgb"; break;
     case MIRTK_VOXEL_FLOAT1:         str = "float1"; break;
     case MIRTK_VOXEL_FLOAT2:         str = "float2"; break;
     case MIRTK_VOXEL_FLOAT3:         str = "float3"; break;
@@ -64,11 +64,29 @@ template <> string ToString(const ImageDataType &value, int w, char c, bool left
 // -----------------------------------------------------------------------------
 template <> bool FromString(const char *str, ImageDataType &value)
 {
-  value = static_cast<ImageDataType>(MIRKT_VOXEL_LAST - 1);
-  while (value != MIRTK_VOXEL_UNKNOWN) {
-    if (ToString(value) == str) break;
-    value = static_cast<ImageDataType>(value - 1);
+  const string lstr = ToLower(str);
+  value = MIRTK_VOXEL_UNKNOWN;
+
+  if      (lstr == "binary")  value = MIRTK_VOXEL_BINARY;
+  else if (lstr == "grey")    value = MIRTK_VOXEL_GREY;
+  else if (lstr == "real")    value = MIRTK_VOXEL_REAL;
+  else if (lstr == "real1")   value = MIRTK_VOXEL_REAL1;
+  else if (lstr == "real2")   value = MIRTK_VOXEL_REAL2;
+  else if (lstr == "real3")   value = MIRTK_VOXEL_REAL3;
+  else if (lstr == "real4")   value = MIRTK_VOXEL_REAL4;
+  else if (lstr == "real2x2") value = MIRTK_VOXEL_REAL2x2;
+  else if (lstr == "real3x3") value = MIRTK_VOXEL_REAL3x3;
+  else if (lstr == "real3x4") value = MIRTK_VOXEL_REAL3x4;
+  else if (lstr == "real4x4") value = MIRTK_VOXEL_REAL4x4;
+
+  if (value == MIRTK_VOXEL_UNKNOWN) {
+    value = static_cast<ImageDataType>(MIRKT_VOXEL_LAST - 1);
+    while (value != MIRTK_VOXEL_UNKNOWN) {
+      if (ToString(value) == lstr) break;
+      value = static_cast<ImageDataType>(value - 1);
+    }
   }
+
   return value != MIRTK_VOXEL_UNKNOWN;
 }
 

--- a/Modules/ImageIO/src/mirtkNiftiImageReader.cc
+++ b/Modules/ImageIO/src/mirtkNiftiImageReader.cc
@@ -337,16 +337,16 @@ void NiftiImageReader::ReadHeader()
       _DataType = MIRTK_VOXEL_UNSIGNED_SHORT;
       _Bytes    = 2;
       break;
-    case NIFTI_TYPE_FLOAT32:
-      _DataType = MIRTK_VOXEL_FLOAT;
-      _Bytes    = 4;
-      break;
     case NIFTI_TYPE_INT32:
       _DataType = MIRTK_VOXEL_INT;
       _Bytes    = 4;
       break;
     case NIFTI_TYPE_UINT32:
       _DataType = MIRTK_VOXEL_UNSIGNED_INT;
+      _Bytes    = 4;
+      break;
+    case NIFTI_TYPE_FLOAT32:
+      _DataType = MIRTK_VOXEL_FLOAT;
       _Bytes    = 4;
       break;
     case NIFTI_TYPE_FLOAT64:

--- a/Modules/ImageIO/src/mirtkNiftiImageWriter.cc
+++ b/Modules/ImageIO/src/mirtkNiftiImageWriter.cc
@@ -115,6 +115,11 @@ void NiftiImageWriter::Initialize()
   // Init header
   const void *data = _Input->GetDataPointer();
   switch (_Input->GetDataType()) {
+    case MIRTK_VOXEL_CHAR: {
+      _Nifti->Initialize(nx, ny, nz, nt, xsize, ysize, zsize, tsize,
+                         NIFTI_TYPE_INT8, qmat, smat, torigin, data);
+      break;
+    }
     case MIRTK_VOXEL_UNSIGNED_CHAR: {
       _Nifti->Initialize(nx, ny, nz, nt, xsize, ysize, zsize, tsize,
                          NIFTI_TYPE_UINT8, qmat, smat, torigin, data);
@@ -187,7 +192,7 @@ void NiftiImageWriter::Initialize()
       break;
     }
     default:
-      cerr << this->NameOfClass() << "::Initialize(): Unsupported voxel type" << endl;
+      cerr << this->NameOfClass() << "::Initialize(): Unsupported voxel type: " << _Input->GetDataType() << endl;
       exit(1);
   }
 


### PR DESCRIPTION
The morphological image commands were limited to only common voxel types. Now they can process any type of images. Moreover, the convert-image command now also has the options ```-binary```, ```-real```...