### PR TITLE
Add mirtk::PriorityQueue type alias for std::priority_queue

### DIFF
--- a/Modules/Common/include/mirtkCommon.h
+++ b/Modules/Common/include/mirtkCommon.h
@@ -38,6 +38,7 @@
 #include <mirtkOrderedMap.h>
 #include <mirtkUnorderedSet.h>
 #include <mirtkUnorderedMap.h>
+#include <mirtkPriorityQueue.h>
 #include <mirtkQueue.h>
 #include <mirtkStack.h>
 

--- a/Modules/Common/include/mirtkPriorityQueue.h
+++ b/Modules/Common/include/mirtkPriorityQueue.h
@@ -1,0 +1,35 @@
+/*
+ * Medical Image Registration ToolKit (MIRTK)
+ *
+ * Copyright 2013-2015 Imperial College London
+ * Copyright 2013-2015 Andreas Schuh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MIRTK_PriorityQueue_H
+#define MIRTK_PriorityQueue_H
+
+#include <vector>
+#include <queue>
+
+namespace mirtk {
+
+
+template <class T, class Compare = std::less<T> >
+using PriorityQueue = std::priority_queue<T, std::vector<T>, Compare>;
+
+
+} // namespace mirtk
+
+#endif // MIRTK_PriorityQueue_H

--- a/Modules/Common/src/CMakeLists.txt
+++ b/Modules/Common/src/CMakeLists.txt
@@ -57,6 +57,7 @@ set(HEADERS
   mirtkParallel.h
   mirtkPath.h
   mirtkProfiling.h
+  mirtkPriorityQueue.h
   mirtkQueue.h
   mirtkRandom.h
   mirtkStack.h

--- a/Modules/Image/include/mirtkBinaryVoxelFunction.h
+++ b/Modules/Image/include/mirtkBinaryVoxelFunction.h
@@ -203,7 +203,7 @@ public:
   Erode(const NeighborhoodOffsets &offsets) : _Offsets(offsets) {}
 
   template <class T>
-  void operator ()(int i, int j, int k, int l, const T *in, T *out)
+  void operator ()(int i, int j, int k, int, const T *in, T *out)
   {
     const T *ptr2offset;
     T &value = *out;
@@ -231,7 +231,7 @@ public:
   Dilate(const NeighborhoodOffsets &offsets) : _Offsets(offsets) {}
 
   template <class T>
-  void operator ()(int i, int j, int k, int l, const T *in, T *out)
+  void operator ()(int i, int j, int k, int, const T *in, T *out)
   {
     const T *ptr2offset;
     T &value = *out;


### PR DESCRIPTION
Not actually used, but add it anyway for sake of "completeness".