### PR TITLE
Fix calculate divide by zero

### DIFF
--- a/Applications/calculate.cc
+++ b/Applications/calculate.cc
@@ -82,13 +82,18 @@ void PrintHelp(const char *name)
   cout << "  -threshold-above <value>          Clamp values greator or equal a given threshold." << endl;
   cout << "  -rescale <min> <max>              Linearly rescale values to the interval [min, max]." << endl;
   cout << "  -inside <float>                   Set new value for all currently unmasked data values." << endl;
-  cout << "  -outside <float>                  Set new value for all currently masked data values." << endl;
+  cout << "  -outside, -pad <float>            Set new value for all currently masked data values." << endl;
   cout << "  -out <file> [<type>]              Write current data sequence to file in the format of the input file." << endl;
   cout << "                                    Output data type can be: uchar, short, ushort, int, uint, float, double." << endl;
   cout << "  -add <float|file>                 Add constant value or data sequence read from specified file." << endl;
   cout << "  -sub <float|file>                 Subtract constant value or data sequence read from specified file." << endl;
   cout << "  -mul <float|file>                 Multiply by constant value or data sequence read from specified file." << endl;
   cout << "  -div <float|file>                 Divide by constant value or data sequence read from specified file." << endl;
+  cout << "                                    When dividing by zero values in the input file, the result is NaN." << endl;
+  cout << "                                    Use :option:`-mask` with argument NaN and :option:`-outside` to replace" << endl;
+  cout << "                                    these undefined values by a constant such as zero." << endl;
+  cout << "  -div-with-zero <file>             Same as :option:`-div` but set result to zero instead of NaN in case of" << endl;
+  cout << "                                    a division by zero due to a zero value in the specified file." << endl;
   cout << "  -abs                              Take absolute values." << endl;
   cout << "  -pow <exponent>                   Raise values to the power of the given exponent." << endl;
   cout << "  -sq -square                       Raise values to the power of 2 (i.e, -pow 2)." << endl;
@@ -362,6 +367,8 @@ int main(int argc, char **argv)
       } else {
         ops.push_back(unique_ptr<Op>(new Div(arg)));
       }
+    } else if (OPTION("-div-with-zero")) {
+      ops.push_back(unique_ptr<Op>(new DivWithZero(ARGUMENT)));
     } else if (OPTION("-abs")) {
       ops.push_back(unique_ptr<Op>(new Abs()));
     } else if (OPTION("-pow") || OPTION("-power")) {

--- a/Modules/Image/include/mirtkDataFunctions.h
+++ b/Modules/Image/include/mirtkDataFunctions.h
@@ -532,7 +532,7 @@ public:
   /// Transform data value and/or mask data value by setting *mask = false
   virtual double Op(double value, double constant, bool &mask) const
   {
-    if (( _FileName.empty() && fequal(value, constant)) ||
+    if (( _FileName.empty() && (fequal(value, constant) || (IsNaN(value) && IsNaN(constant)))) ||
         (!_FileName.empty() && constant == .0)) {
       mask = false;
     }

--- a/Modules/Image/include/mirtkDataFunctions.h
+++ b/Modules/Image/include/mirtkDataFunctions.h
@@ -495,6 +495,29 @@ public:
 };
 
 // -----------------------------------------------------------------------------
+/// Element-wise division
+class DivWithZero : public ElementWiseBinaryOp
+{
+public:
+
+  /// Constructor
+  DivWithZero(const char *fname) : ElementWiseBinaryOp(fname) {}
+
+  /// Transform data value and/or mask data value by setting *mask = false
+  virtual double Op(double value, double constant, bool &) const
+  {
+    return (constant != .0 ? value / constant : .0);
+  }
+
+  /// Process given data (not thread-safe!)
+  virtual void Process(int n, double *data, bool *mask = NULL)
+  {
+    ElementWiseBinaryOp::Process(n, data, mask);
+    parallel_for(blocked_range<int>(0, n), *this);
+  }
+};
+
+// -----------------------------------------------------------------------------
 /// Mask values
 class Mask : public ElementWiseBinaryOp
 {

--- a/Modules/Image/include/mirtkDataFunctions.h
+++ b/Modules/Image/include/mirtkDataFunctions.h
@@ -483,7 +483,7 @@ public:
   /// Transform data value and/or mask data value by setting *mask = false
   virtual double Op(double value, double constant, bool &) const
   {
-    return value / constant;
+    return (constant != .0 ? value / constant : numeric_limits<double>::quiet_NaN());
   }
 
   /// Process given data (not thread-safe!)


### PR DESCRIPTION
Fixes the result of a division by zero, which is NaN in any case even when for IEEE floating point numbers the result is +/- Inf. Also fixes the ```-mask``` operation to support the value ```NaN``` which can be used to mask such undefined devision results. Adds further a new ```-div-with-zero``` option to the calculate command for the common use case of dividing one image by another and replacing resulting NaNs by zero.