### PR TITLE
Various smaller "fixes" and enhancements

### DIFF
--- a/Modules/Image/include/mirtkBaseImage.h
+++ b/Modules/Image/include/mirtkBaseImage.h
@@ -215,6 +215,18 @@ public:
   int GetT() const;
 
   /// Returns the size of a voxel in the x-direction
+  double XSize() const;
+
+  /// Returns the size of a voxel in the y-direction
+  double YSize() const;
+
+  /// Returns the size of a voxel in the z-direction
+  double ZSize() const;
+
+  /// Returns the size of a voxel in the t-direction
+  double TSize() const;
+
+  /// Returns the size of a voxel in the x-direction
   double GetXSize() const;
 
   /// Returns the size of a voxel in the y-direction
@@ -883,6 +895,30 @@ inline int BaseImage::GetZ() const
 inline int BaseImage::GetT() const
 {
   return _attr._t;
+}
+
+// -----------------------------------------------------------------------------
+inline double BaseImage::XSize() const
+{
+  return _attr._dx;
+}
+
+// -----------------------------------------------------------------------------
+inline double BaseImage::YSize() const
+{
+  return _attr._dy;
+}
+
+// -----------------------------------------------------------------------------
+inline double BaseImage::ZSize() const
+{
+  return _attr._dz;
+}
+
+// -----------------------------------------------------------------------------
+inline double BaseImage::TSize() const
+{
+  return _attr._dt;
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/PointSet/include/mirtkImplicitSurfaceUtils.h
+++ b/Modules/PointSet/include/mirtkImplicitSurfaceUtils.h
@@ -282,7 +282,7 @@ inline int Intersections(Array<double> &d, const double p[3], const double e[3],
 // -----------------------------------------------------------------------------
 /// Determine surface distance at a point in a specified direction
 ///
-/// \returns Surface distance in specified direction, clamped to \p maxw.
+/// \returns Surface distance in specified direction, clamped to \p maxd.
 inline double ForwardDistance(const double p[3], const double e1[3],
                               double mind, double minh, double maxd,
                               const DistanceFunction &distance, double offset = .0,
@@ -294,7 +294,7 @@ inline double ForwardDistance(const double p[3], const double e1[3],
 // -----------------------------------------------------------------------------
 /// Determine surface distance at a point in a specified direction
 ///
-/// \returns Surface distance in specified direction, clamped to \p maxw.
+/// \returns Surface distance in specified direction, clamped to \p maxd.
 inline double ForwardDistance(const double p[3], const double e1[3],
                               double minh, double maxd,
                               const DistanceFunction &distance, double offset = .0,
@@ -307,7 +307,7 @@ inline double ForwardDistance(const double p[3], const double e1[3],
 // -----------------------------------------------------------------------------
 /// Determine surface distance at a point in a specified direction
 ///
-/// \returns Surface distance in specified direction, clamped to \p maxw.
+/// \returns Surface distance in specified direction, clamped to \p maxd.
 inline double BackwardDistance(const double p[3], const double e1[3],
                                double mind, double minh, double maxd,
                                const DistanceFunction &distance, double offset = .0,
@@ -320,7 +320,7 @@ inline double BackwardDistance(const double p[3], const double e1[3],
 // -----------------------------------------------------------------------------
 /// Determine surface distance at a point in a specified direction
 ///
-/// \returns Surface distance in specified direction, clamped to \p maxw.
+/// \returns Surface distance in specified direction, clamped to \p maxd.
 inline double BackwardDistance(const double p[3], const double e1[3],
                                double minh, double maxd,
                                const DistanceFunction &distance, double offset = .0,
@@ -333,7 +333,7 @@ inline double BackwardDistance(const double p[3], const double e1[3],
 // -----------------------------------------------------------------------------
 /// Determine surface distance at a point in a specified direction
 ///
-/// \returns Surface distance in specified direction, clamped to \p maxw.
+/// \returns Surface distance in specified direction, clamped to \p maxd.
 inline double Distance(const double p[3], const double e1[3],
                        double mind, double minh, double maxd,
                        const DistanceFunction &distance, double offset = .0,
@@ -347,7 +347,7 @@ inline double Distance(const double p[3], const double e1[3],
 // -----------------------------------------------------------------------------
 /// Determine surface distance at a point in a specified direction
 ///
-/// \returns Surface distance in specified direction, clamped to \p maxw.
+/// \returns Surface distance in specified direction, clamped to \p maxd.
 inline double Distance(const double p[3], const double e1[3],
                        double minh, double maxd,
                        const DistanceFunction &distance, double offset = .0,
@@ -355,6 +355,32 @@ inline double Distance(const double p[3], const double e1[3],
 {
   const double mind = Evaluate(distance, p, offset);
   return Distance(p, e1, mind, minh, maxd, distance, offset, tol);
+}
+
+// -----------------------------------------------------------------------------
+/// Determine signed surface distance at a point in normal direction
+///
+/// \returns Signed surface distance in normal direction, clamped to \p maxd.
+inline double SignedDistance(const double p[3], const double n[3],
+                             double mind, double minh, double maxd,
+                             const DistanceFunction &distance, double offset = .0,
+                             double tol = 1e-3)
+{
+  if (mind < .0) return -ForwardDistance(p, n, mind, minh, maxd, distance, offset, tol);
+  else           return BackwardDistance(p, n, mind, minh, maxd, distance, offset, tol);
+}
+
+// -----------------------------------------------------------------------------
+/// Determine signed surface distance at a point in normal direction
+///
+/// \returns Signed surface distance in normal direction, clamped to \p maxw.
+inline double SignedDistance(const double p[3], const double n[3],
+                             double minh, double maxd,
+                             const DistanceFunction &distance, double offset = .0,
+                             double tol = 1e-3)
+{
+  const double mind = Evaluate(distance, p, offset);
+  return SignedDistance(p, n, mind, minh, maxd, distance, offset, tol);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/PointSet/src/mirtkPolyDataRemeshing.cc
+++ b/Modules/PointSet/src/mirtkPolyDataRemeshing.cc
@@ -263,6 +263,7 @@ inline vtkIdType PolyDataRemeshing
 
   // Get other cell adjacent to this edge
   const vtkIdType neighborCellId = GetCellEdgeNeighbor(cellId, ptId1, ptId2);
+  if (neighborCellId == -1) return -1;
 
   // Get points which are adjacent to both edge points
   vtkSmartPointer<vtkIdList> ptIds1 = vtkSmartPointer<vtkIdList>::New();


### PR DESCRIPTION
- Add BaseImage::XSize() et al. property getters.
- Add ImplicitSurfaceUtils::SignedDistance functions.
- Add ConvolveForegroundInX et al. voxel functions. Didn't really end up using these because probably the corresponding 3D convolution is no longer separable in this way. These should only be used in a single dimension. What I am saying, use with care, don't just use blindly.
- Make ConstImageIterator::Move useable with pointer types different from VoxelType.