### PR TITLE
Enh/python3 compatibility

### DIFF
--- a/Applications/convert-mris.py
+++ b/Applications/convert-mris.py
@@ -37,6 +37,7 @@ Arguments:
   output   Output VTK surface file. Must have extension .vtk or .vtp.
 
 """
+from __future__ import absolute_import, print_function, unicode_literals
 
 from subprocess import check_call, check_output, STDOUT
 from sys import argv, exit
@@ -85,6 +86,6 @@ def convert_mris(input_name, output_name):
 # ----------------------------------------------------------------------------------------------------------------------
 if __name__ == "__main__":
   if len(argv) != 3:
-    print "usage: " + basename(argv[0]) + " <surf> <output>"
+    print("usage: " + basename(argv[0]) + " <surf> <output>")
     exit(1)
   convert_mris(abspath(argv[1]), abspath(argv[2]))

--- a/Applications/help-rst.py
+++ b/Applications/help-rst.py
@@ -44,7 +44,7 @@ def export_library_path(paths):
         key = 'DYLD_LIBRARY_PATH'
     else:
         key = 'LD_LIBRARY_PATH'
-    paths = filter(bool, _LIBRARY_PATH)
+    paths = list(filter(bool, _LIBRARY_PATH))
     user_path = os.environ.get(key, '')
     if user_path: paths.append(user_path)
     os.environ[key] = ':'.join(paths)

--- a/CMake/Basis/get_python_lib.py
+++ b/CMake/Basis/get_python_lib.py
@@ -14,6 +14,8 @@
 # @brief Auxiliary Python script to get installation directory for site packages.
 ##############################################################################
 
+from __future__ import absolute_import, print_function, unicode_literals
+
 try:
     # this uses the same as packages which use easy_install for the installation
     # and returns also the proper site-packages directory on Ubuntu
@@ -38,8 +40,8 @@ try:
     except distutils.errors.DistutilsError:
         pass
 
-    print e.install_dir.rstrip('/\\')
+    print(e.install_dir.rstrip('/\\'))
 except:
     # however, if the setuptools are not installed, fall back to the distutils
     import distutils.sysconfig
-    print distutils.sysconfig.get_python_lib().rstrip('/\\')
+    print(distutils.sysconfig.get_python_lib().rstrip('/\\'))

--- a/CMake/Basis/updatefile.py
+++ b/CMake/Basis/updatefile.py
@@ -33,6 +33,15 @@
 #
 # @ingroup CMakeHelpers
 
+from __future__ import absolute_import, print_function, unicode_literals
+
+# monkey-patch input to behave like raw_input in Python 2.
+# See: http://python3porting.com/differences.html#input-and-raw-input
+try:
+    input = raw_input
+except NameError:
+    pass
+
 # modules
 import os
 import sys
@@ -51,35 +60,35 @@ tokenKeepTemplate = "REMOVE_THIS_STRING_IF_YOU_WANT_TO_KEEP_YOUR_CHANGES"
 # ****************************************************************************
 def version (progName):
     """Print version information."""
-    print progName + "1.0.0"
+    print(progName + "1.0.0")
 
 # ****************************************************************************
 def usage (progName):
-    print "Usage:"
-    print "  " + progName + " [options]"
-    print
-    print "Required options:"
-    print "  [-i --in]       : Filename of original file"
-    print "  [-t --template] : Filename of template file"
-    print
-    print "Options:"
-    print "  [-o --out]     Filename of output file. If this option is not given,"
-    print "                 changes are not applied and the exit code can be used"
-    print "                 to check whether changes would have been applied."
-    print "  [-f --force]   Force overwrite of output file. Otherwise ask user."
-    print
-    print "Return value:"
-    print "  0   Merged output differs from input file and output file was"
-    print "      written successfully if option -o or --out was given"
-    print "  1   Failed to read or write file"
-    print "  2   Nothing changed, input file not overwritten"
-    print "  3   Merged output differs from input file but user chose not"
-    print "      to overwrite input file"
-    print "Example:"
-    print "  " + progName + " -i CMakeLists.txt -t CMakeLists.txt.template -o CMakeLists.txt"
-    print
-    print "Contact:"
-    print "  SBIA Group <sbia-software at uphs.upenn.edu>"
+    print("Usage:")
+    print("  " + progName + " [options]")
+    print()
+    print("Required options:")
+    print("  [-i --in]       : Filename of original file")
+    print("  [-t --template] : Filename of template file")
+    print()
+    print("Options:")
+    print("  [-o --out]     Filename of output file. If this option is not given,")
+    print("                 changes are not applied and the exit code can be used")
+    print("                 to check whether changes would have been applied.")
+    print("  [-f --force]   Force overwrite of output file. Otherwise ask user.")
+    print()
+    print("Return value:")
+    print("  0   Merged output differs from input file and output file was")
+    print("      written successfully if option -o or --out was given")
+    print("  1   Failed to read or write file")
+    print("  2   Nothing changed, input file not overwritten")
+    print("  3   Merged output differs from input file but user chose not")
+    print("      to overwrite input file")
+    print("Example:")
+    print("  " + progName + " -i CMakeLists.txt -t CMakeLists.txt.template -o CMakeLists.txt")
+    print()
+    print("Contact:")
+    print("  SBIA Group <sbia-software at uphs.upenn.edu>")
 
 # ****************************************************************************
 def help (progName):
@@ -97,8 +106,8 @@ def extractCustomizedSections (input):
         next = input.find (tokenCustomStart, start)
         end  = input.find (tokenCustomEnd,   start)
         if end == -1 or (next != -1 and end > next):
-            print "WARNING: Found begin of customized section without end token '" + tokenCustomEnd + "'"
-            print "WARNING: Will keep template section instead"
+            print("WARNING: Found begin of customized section without end token '" + tokenCustomEnd + "'")
+            print("WARNING: Will keep template section instead")
             custom.append (tokenKeepTemplate)
         else:
             custom.append (input [start:end])
@@ -143,8 +152,8 @@ def extractLicenseSections (input):
         next = input.find (tokenLicenseStart, start)
         end  = input.find (tokenLicenseEnd,   start)
         if end == -1 or (next != -1 and end > next):
-            print "WARNING: Found begin of license section without end token '" + tokenLicenseEnd + "'"
-            print "WARNING: Will keep template section instead"
+            print("WARNING: Found begin of license section without end token '" + tokenLicenseEnd + "'")
+            print("WARNING: Will keep template section instead")
             license.append (tokenKeepTemplate)
         else:
             license.append (input [start:end])
@@ -205,7 +214,7 @@ def run (inputFile, templateFile, outputFile, force):
                 sys.stdout.write ("Template of file '" + inputFile + "' has been modified.\n")
                 sys.stdout.write ("Do you want to apply the changes (basis-custom sections remain unchanged)? ")
                 sys.stdout.flush ()
-                apply = raw_input ()
+                apply = input ()
 	        if apply != "y" and apply != "yes":
                     return 3
             except EOFError:
@@ -236,16 +245,16 @@ if __name__ == "__main__":
     # get options
     try:
         opts, files = getopt.gnu_getopt (sys.argv [1:], "uhvVfi:t:o:",
-          ["usage","help","version","verbose","force","in=","template=","out="])
-    except getopt.GetoptError, err:
+          ["usage", "help", "version", "verbose", "force", "in=", "template=", "out="])
+    except getopt.GetoptError as err:
         usage (progName)
-        print str(err)
+        print(str(err))
         sys.exit(1)
     # parse command line options
     for o, a in opts:
         if o in ["-V", "--verbose"]:
             verbosity += 1
-        elif o in ["-h", "--help","-u","--usage"]:
+        elif o in ["-h", "--help", "-u", "--usage"]:
             help (progName)
             sys.exit(0)
         elif o in ["-v", "--version", "--Version"]:

--- a/Modules/Image/src/mirtkForEachVoxelFunction.py
+++ b/Modules/Image/src/mirtkForEachVoxelFunction.py
@@ -1,5 +1,7 @@
 #! /usr/bin/env python
 
+from __future__ import absolute_import, print_function, unicode_literals
+
 import sys
 
 # ------------------------------------------------------------------------------
@@ -44,7 +46,7 @@ def get_source_name(arity):
 # ------------------------------------------------------------------------------
 # parse command-line arguments
 if len(sys.argv) != 3:
-  print "usage: " + sys.argv[0] + ' <arity> <file>'
+  print("usage: " + sys.argv[0] + ' <arity> <file>')
   sys.exit(1)
 try:
   arity = int(sys.argv[1])


### PR DESCRIPTION
This PR fixes compatibility issues with Python 3 found by the `2to3` conversion tool, whilst keeping compatibility with Python 2.7. Changes applied to BASIS files are recorded separately to ease forwarding to upstream BASIS development.