### PR TITLE
Change version to 1.1.0

### DIFF
--- a/BasisProject.cmake
+++ b/BasisProject.cmake
@@ -52,7 +52,7 @@ basis_project (
   # --------------------------------------------------------------------------
   # meta-data
   NAME         "MIRTK"
-  VERSION      "1.0.1" # Version of core (+ external) modules
+  VERSION      "1.1.0" # Version of core (+ external) modules
   SOVERSION    "0"     # API yet unstable
   AUTHORS      "Andreas Schuh"
   DESCRIPTION  "Medical Image Registration ToolKit"


### PR DESCRIPTION
Version 1.0.1 will be skipped because not only bug fixes have been merged into the develop branch. No need for a separate bug fix release.