### PR TITLE
Fix build with VTK 6.0.0

### DIFF
--- a/Applications/calculate-surface-spectrum.cc
+++ b/Applications/calculate-surface-spectrum.cc
@@ -25,8 +25,8 @@
 #include <mirtkPointCorrespondence.h>
 #include <mirtkFuzzyCorrespondence.h>
 #include <mirtkSpectralDecomposition.h>
+#include <mirtkVtkMath.h>
 
-#include <vtkMath.h>
 #include <vtkSmartPointer.h>
 #include <vtkPolyData.h>
 #include <vtkPointData.h>

--- a/Applications/evaluate-distance.cc
+++ b/Applications/evaluate-distance.cc
@@ -21,8 +21,8 @@
 #include <mirtkOptions.h>
 
 #include <mirtkPointSetUtils.h>
+#include <mirtkVtkMath.h>
 
-#include <vtkMath.h>
 #include <vtkPointSet.h>
 #include <vtkPolyData.h>
 #include <vtkPointData.h>

--- a/Applications/info.cc
+++ b/Applications/info.cc
@@ -36,6 +36,7 @@
 #  include <mirtkPolyhedron.h>
 #  include <mirtkPointSetUtils.h>
 #  include <mirtkDataStatistics.h>
+#  include <mirtkVtkMath.h>
 
 #  include <vtkSmartPointer.h>
 #  include <vtkPolyData.h>
@@ -45,7 +46,6 @@
 #  include <vtkCellData.h>
 #  include <vtkGenericCell.h>
 #  include <vtkOctreePointLocator.h>
-#  include <vtkMath.h>
 #  include <vtkUnsignedCharArray.h>
 #  include <vtkFloatArray.h>
 #  include <vtkDataSetSurfaceFilter.h>

--- a/Applications/offset-surface.cc
+++ b/Applications/offset-surface.cc
@@ -22,6 +22,7 @@
 
 #include <mirtkPointSetUtils.h>
 #include <mirtkPolyDataSmoothing.h>
+#include <mirtkVtkMath.h>
 
 #include <vtkSmartPointer.h>
 #include <vtkPolyData.h>
@@ -34,7 +35,6 @@
 #include <vtkContourFilter.h>
 #include <vtkPolyDataConnectivityFilter.h>
 #include <vtkCellLocator.h>
-#include <vtkMath.h>
 #include <vtkQuadricDecimation.h>
 
 using namespace mirtk;

--- a/Applications/remesh.cc
+++ b/Applications/remesh.cc
@@ -23,6 +23,7 @@
 #include <mirtkEdgeTable.h>
 #include <mirtkPointSetUtils.h>
 #include <mirtkPolyDataRemeshing.h>
+#include <mirtkVtkMath.h>
 
 #include <vtkSmartPointer.h>
 #include <vtkDataReader.h> // VTK_BINARY, VTK_ASCII defines
@@ -30,7 +31,6 @@
 #include <vtkPointData.h>
 #include <vtkCellArray.h>
 #include <vtkCellLocator.h>
-#include <vtkMath.h>
 
 using namespace mirtk;
 

--- a/Applications/smooth-surface.cc
+++ b/Applications/smooth-surface.cc
@@ -29,6 +29,7 @@
 #include <mirtkPointSetUtils.h>
 #include <mirtkPolyDataSmoothing.h>
 #include <mirtkPolyDataCurvature.h>
+#include <mirtkVtkMath.h>
 
 #include <vtkSmartPointer.h>
 #include <vtkFloatArray.h>
@@ -38,7 +39,6 @@
 #include <vtkIdList.h>
 #include <vtkPolyDataNormals.h>
 #include <vtkCurvatures.h>
-#include <vtkMath.h>
 #include <vtkDataSetAttributes.h>
 #include <vtkWindowedSincPolyDataFilter.h>
 

--- a/Modules/Common/include/mirtkVtkMath.h
+++ b/Modules/Common/include/mirtkVtkMath.h
@@ -1,0 +1,40 @@
+/*
+ * Medical Image Registration ToolKit (MIRTK)
+ *
+ * Copyright 2016 Imperial College London
+ * Copyright 2016 Andreas Schuh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MIRTK_VtkMath_H
+#define MIRTK_VtkMath_H
+
+
+// See http://www.paraview.org/Bug/view.php?id=14164
+#if VTK_MAJOR_VERSION == 6 && VTK_MINOR_VERSION == 0 && VTK_PATCH_VERSION == 0
+#  define isnan    ::std::isnan
+#  define isinf    ::std::isinf
+#  define isfinite ::std::isfinite
+#endif
+
+#include <vtkMath.h>
+
+#if VTK_MAJOR_VERSION == 6 && VTK_MINOR_VERSION == 0 && VTK_PATCH_VERSION == 0
+#  undef isnan
+#  undef isinf
+#  undef isfinite
+#endif
+
+
+#endif // MIRTK_VtkMath_H

--- a/Modules/Common/src/CMakeLists.txt
+++ b/Modules/Common/src/CMakeLists.txt
@@ -94,7 +94,7 @@ set(SOURCES
 )
 
 if (VTK_FOUND)
-  list(APPEND HEADERS mirtkVtk.h)
+  list(APPEND HEADERS mirtkVtk.h mirtkVtkMath.h)
   list(APPEND SOURCES mirtkVtk.cc)
   list(APPEND DEPENDS ${VTK_LIBRARIES})
 endif ()

--- a/Modules/PointSet/include/mirtkPointSetUtils.h
+++ b/Modules/PointSet/include/mirtkPointSetUtils.h
@@ -22,9 +22,7 @@
 
 #include <mirtkMath.h>
 #include <mirtkVtk.h>
-
-#include <vtkMath.h>
-#include <vtkSmartPointer.h>
+#include <mirtkVtkMath.h>
 
 class vtkDataSet;
 class vtkDataSetAttributes;

--- a/Modules/PointSet/include/mirtkTriangle.h
+++ b/Modules/PointSet/include/mirtkTriangle.h
@@ -20,8 +20,9 @@
 #ifndef MIRTK_Triangle_H
 #define MIRTK_Triangle_H
 
-#include <mirtkMath.h>
 #include <mirtkMemory.h>
+#include <mirtkMath.h>
+#include <mirtkVtkMath.h> // vtkMath.h otherwise included by vtkTriangle.h
 
 #include <vtkLine.h>
 #include <vtkPlane.h>

--- a/Modules/PointSet/src/mirtkClosestPointLabel.cc
+++ b/Modules/PointSet/src/mirtkClosestPointLabel.cc
@@ -28,8 +28,8 @@
 #include <mirtkParallel.h>
 #include <mirtkProfiling.h>
 #include <mirtkPointSetUtils.h>
+#include <mirtkVtkMath.h>
 
-#include <vtkMath.h>
 #include <vtkSmartPointer.h>
 #include <vtkPointData.h>
 #include <vtkCellData.h>

--- a/Modules/PointSet/src/mirtkEdgeConnectivity.cc
+++ b/Modules/PointSet/src/mirtkEdgeConnectivity.cc
@@ -26,8 +26,8 @@
 #include <mirtkParallel.h>
 #include <mirtkProfiling.h>
 #include <mirtkAlgorithm.h> // sort
+#include <mirtkVtkMath.h>
 
-#include <vtkMath.h>
 #include <vtkSmartPointer.h>
 #include <vtkGenericCell.h>
 

--- a/Modules/PointSet/src/mirtkPolyDataCurvature.cc
+++ b/Modules/PointSet/src/mirtkPolyDataCurvature.cc
@@ -28,6 +28,7 @@
 #include <mirtkParallel.h>
 #include <mirtkProfiling.h>
 #include <mirtkPointSetUtils.h>
+#include <mirtkVtkMath.h>
 
 #include <vtkPointData.h>
 #include <vtkCellData.h>
@@ -36,7 +37,6 @@
 #include <vtkPolyDataNormals.h>
 #include <vtkCurvatures.h>
 #include <vtkIdList.h>
-#include <vtkMath.h>
 
 #include <Eigen/Dense>
 #include <Eigen/Eigenvalues>

--- a/Modules/PointSet/src/mirtkPolyDataRemeshing.cc
+++ b/Modules/PointSet/src/mirtkPolyDataRemeshing.cc
@@ -27,8 +27,8 @@
 #include <mirtkPointSetUtils.h>
 #include <mirtkDataStatistics.h>
 #include <mirtkTransformation.h>
+#include <mirtkVtkMath.h>
 
-#include <vtkMath.h>
 #include <vtkIdList.h>
 #include <vtkCell.h>
 #include <vtkCellArray.h>

--- a/Modules/PointSet/src/mirtkPolyDataSmoothing.cc
+++ b/Modules/PointSet/src/mirtkPolyDataSmoothing.cc
@@ -19,14 +19,15 @@
 
 #include <mirtkPolyDataSmoothing.h>
 
-#include <mirtkVtk.h>
 #include <mirtkMath.h>
 #include <mirtkEdgeTable.h>
 #include <mirtkMatrix3x3.h>
 #include <mirtkVector3.h>
 #include <mirtkPointSetUtils.h>
 
-#include <vtkMath.h>
+#include <mirtkVtk.h>
+#include <mirtkVtkMath.h>
+
 #include <vtkPoints.h>
 #include <vtkIdList.h>
 #include <vtkCellArray.h>

--- a/Modules/PointSet/src/mirtkRobustPointMatch.cc
+++ b/Modules/PointSet/src/mirtkRobustPointMatch.cc
@@ -27,8 +27,8 @@
 #include <mirtkProfiling.h>
 #include <mirtkPointLocator.h>
 #include <mirtkSparseMatrix.h>
+#include <mirtkVtkMath.h>
 
-#include <vtkMath.h>
 #include <vtkSmartPointer.h>
 #include <vtkIdList.h>
 #include <vtkPointSet.h>

--- a/Modules/PointSet/src/mirtkSurfaceCollisions.cc
+++ b/Modules/PointSet/src/mirtkSurfaceCollisions.cc
@@ -26,8 +26,8 @@
 #include <mirtkPointLocator.h>
 #include <mirtkParallel.h>
 #include <mirtkProfiling.h>
+#include <mirtkVtkMath.h>
 
-#include <vtkMath.h>
 #include <vtkPlane.h>
 #include <vtkTriangle.h>
 

--- a/Modules/Registration/src/mirtkCurrentsDistance.cc
+++ b/Modules/Registration/src/mirtkCurrentsDistance.cc
@@ -25,6 +25,7 @@
 #include <mirtkParallel.h>
 #include <mirtkProfiling.h>
 #include <mirtkObjectFactory.h>
+#include <mirtkVtkMath.h>
 
 #include <vtkSmartPointer.h>
 #include <vtkPoints.h>
@@ -32,7 +33,6 @@
 #include <vtkFloatArray.h>
 #include <vtkPolyData.h>
 #include <vtkPointData.h>
-#include <vtkMath.h>
 // Due to a bug in vtkKdTreePointLocator, calling BuildLocator
 // is not sufficient to make FindClosestPoint thread-safe as it does
 // not call vtkBSPIntersections::BuildRegionsList


### PR DESCRIPTION
This PR fixes the build with VTK 6.0.0 using "macro injection" to fix the ambiguity of ```isnan``` and ```isinf``` in ```vtkMath.h```. Moreover, it updates the Packages submodules where the Deformable package also contains a fix for a bug that was only discovered by chance when building with VTK 6.0.0 because the ```vtkDataArray::GetArrayType``` function was not present in this release yet. But actually the code needed to call ```vtkDataArray::GetDataType``` instead anyway...

With this PR, the MIRTK can be build with the ```libvtk6-dev``` package on Ubuntu 14.04. No need for a custom VTK build.