### PR TITLE
enh: Use libvtk6-dev Ubuntu package for Docker image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+.*
+Dockerfile
 build*
 Build*
 xcode*
@@ -8,5 +10,3 @@ nbproject/private
 nbproject/configurations.xml
 CMakeLists.txt.user*
 **/.DS_Store
-.project
-.cproject

--- a/CMake/CMakeLists.txt
+++ b/CMake/CMakeLists.txt
@@ -116,15 +116,15 @@ set (
 # MIRTK CMake modules
 set (
   CMAKE_MODULES
-    "MIRTKTools.cmake"           # includes MIRTK command definitions
-    "MIRTKPolicies.cmake"        # common CMake policies
-    "MIRTKAddLibrary.cmake"      # defines mirtk_add_library
-    "MIRTKAddExecutable.cmake"   # defines mirtk_add_executable
-    "MIRTKAddTest.cmake"         # defines mirtk_add_test
-    "MIRTKGetTargetName.cmake"   # defines mirtk_get_target_name
-    "MIRTKProjectBegin.cmake"    # defines mirtk_project_begin
-    "MIRTKProjectEnd.cmake"      # defines mirtk_project_end
-    "MIRTKConfigureModule.cmake" # defines mirtk_configure_module
+    "mirtkTools.cmake"           # includes MIRTK command definitions
+    "mirtkPolicies.cmake"        # common CMake policies
+    "mirtkAddLibrary.cmake"      # defines mirtk_add_library
+    "mirtkAddExecutable.cmake"   # defines mirtk_add_executable
+    "mirtkAddTest.cmake"         # defines mirtk_add_test
+    "mirtkGetTargetName.cmake"   # defines mirtk_get_target_name
+    "mirtkProjectBegin.cmake"    # defines mirtk_project_begin
+    "mirtkProjectEnd.cmake"      # defines mirtk_project_end
+    "mirtkConfigureModule.cmake" # defines mirtk_configure_module
 )
 
 # ----------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,22 @@
 ## Build of Docker image for execution of MIRTK commands within a Docker
-## container with all modules and their prerequisites available in the image
-
+## container with all MIRTK modules and applications available in the image
 FROM ubuntu:14.04
 
 MAINTAINER Andreas Schuh <andreas.schuh.84@gmail.com>
 LABEL Description="Medical Image Registration ToolKit (MIRTK)" Vendor="BioMedIA"
 
+# When no VTK_VERSION is set, the official libvtk6-dev package is used.
+# Note, however, that this results in a Docker image that is about twice
+# the size of the image when a custom VTK build without Qt, wrappers,
+# and unused VTK modules is used instead! It is recommended to build
+# the Docker image with "--build-arg VTK_VERSION=6.3.0" option.
+ARG VTK_VERSION
+
+# Whether to build and run MIRTK tests before installation ("--build-arg BUILD_TESTING=ON")
+ARG BUILD_TESTING=OFF
+
+# Install prerequisites
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      wget \
       gcc \
       g++ \
       make \
@@ -16,45 +25,53 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       freeglut3-dev \
       libarpack2-dev \
       libflann-dev \
-      libgtest-dev \
       libnifti-dev \
       libpng-dev \
       libsuitesparse-dev \
       libtbb-dev \
-      libvtk6-dev \
       zlib1g-dev \
+    && \
+    if [ ${BUILD_TESTING} = ON ]; then \
+      apt-get install -y libgtest-dev \
+      && mkdir /usr/src/gtest/build \
+      && cd /usr/src/gtest/build \
+      && cmake .. \
+      && make \
+      && mv -f libgtest.a libgtest_main.a /usr/lib \
+      && cd /usr/src \
+      && rm -rf /usr/src/gtest/build; \
+    fi \
+    && \
+    if [ -z ${VTK_VERSION} ]; then \
+      apt-get install -y libvtk6-dev; \
+    else \
+      VTK_RELEASE=`echo ${VTK_VERSION} | sed s/\.[0-9]*$//` \
+      && apt-get install -y wget \
+      && cd /usr/src \
+      && wget http://www.vtk.org/files/release/${VTK_RELEASE}/VTK-${VTK_VERSION}.tar.gz \
+      && tar -xvzf VTK-${VTK_VERSION}.tar.gz \
+      && rm -f VTK-${VTK_VERSION}.tar.gz \
+      && mkdir VTK-${VTK_VERSION}/Build \
+      && cd VTK-${VTK_VERSION}/Build \
+      && cmake \
+        -D CMAKE_INSTALL_PREFIX=/usr/local \
+        -D CMAKE_BUILD_TYPE=Release \
+        -D CMAKE_CXX_FLAGS=-std=c++11 \
+        -D VTK_USE_SYSTEM_PNG=ON \
+        -D VTK_USE_SYSTEM_ZLIB=ON \
+        -D BUILD_SHARED_LIBS=ON \
+        -D BUILD_EXAMPLES=OFF \
+        -D BUILD_TESTING=OFF \
+        -D BUILD_DOCUMENTATION=OFF \
+        .. \
+      && make install \
+      && cd /usr/src \
+      && rm -rf /usr/src/VTK-${VTK_VERSION} \
+      && ldconfig; \
+    fi \
     && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir /usr/src/gtest/build \
-    && cd /usr/src/gtest/build \
-    && cmake .. \
-    && make \
-    && mv -f libgtest.a libgtest_main.a /usr/lib \
-    && cd /usr/src \
-    && rm -rf /usr/src/gtest/build
-
-#RUN cd /usr/src \
-#    && wget http://www.vtk.org/files/release/6.3/VTK-6.3.0.tar.gz \
-#    && tar -xzf VTK-6.3.0.tar.gz \
-#    && rm -f VTK-6.3.0.tar.gz \
-#    && mkdir VTK-6.3.0/Build \
-#    && cd VTK-6.3.0/Build \
-#    && cmake \
-#      -D CMAKE_INSTALL_PREFIX=/usr/local \
-#      -D CMAKE_BUILD_TYPE=Release \
-#      -D CMAKE_CXX_FLAGS=-std=c++11 \
-#      -D VTK_USE_SYSTEM_PNG=ON \
-#      -D VTK_USE_SYSTEM_ZLIB=ON \
-#      -D BUILD_SHARED_LIBS=ON \
-#      -D BUILD_EXAMPLES=OFF \
-#      -D BUILD_TESTING=OFF \
-#      -D BUILD_DOCUMENTATION=OFF \
-#      .. \
-#    && make install \
-#    && cd /usr/src \
-#    && rm -rf /usr/src/VTK-6.3.0 \
-#    && ldconfig
-
+# Build and install MIRTK
 COPY . /usr/src/MIRTK
 RUN mkdir /usr/src/MIRTK/Build \
     && cd /usr/src/MIRTK/Build \
@@ -64,7 +81,7 @@ RUN mkdir /usr/src/MIRTK/Build \
       -D BUILD_ALL_MODULES=ON \
       -D BUILD_SHARED_LIBS=ON \
       -D BUILD_APPLICATIONS=ON \
-      -D BUILD_TESTING=OFF \
+      -D BUILD_TESTING=${BUILD_TESTING} \
       -D BUILD_DOCUMENTATION=OFF \
       -D BUILD_CHANGELOG=OFF \
       -D WITH_ARPACK=ON \
@@ -78,11 +95,15 @@ RUN mkdir /usr/src/MIRTK/Build \
       -D WITH_VTK=ON \
       -D WITH_ZLIB=ON \
       .. \
+    && if [ ${BUILD_TESTING} = ON ]; then make && make test; fi \
     && make install \
     && cd /usr/src \
     && rm -rf /usr/src/MIRTK
 
+# Make "mirtk" the default executable for application containers
 ENTRYPOINT ["python", "/usr/local/bin/mirtk"]
 CMD ["help"]
 
+# Assume user data volume to be mounted at /data
+#   docker run --volume=/path/to/data:/data
 WORKDIR /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       libpng-dev \
       libsuitesparse-dev \
       libtbb-dev \
+      libvtk6-dev \
       zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
@@ -32,27 +33,27 @@ RUN mkdir /usr/src/gtest/build \
     && cd /usr/src \
     && rm -rf /usr/src/gtest/build
 
-RUN cd /usr/src \
-    && wget http://www.vtk.org/files/release/6.3/VTK-6.3.0.tar.gz \
-    && tar -xzf VTK-6.3.0.tar.gz \
-    && rm -f VTK-6.3.0.tar.gz \
-    && mkdir VTK-6.3.0/Build \
-    && cd VTK-6.3.0/Build \
-    && cmake \
-      -D CMAKE_INSTALL_PREFIX=/usr/local \
-      -D CMAKE_BUILD_TYPE=Release \
-      -D CMAKE_CXX_FLAGS=-std=c++11 \
-      -D VTK_USE_SYSTEM_PNG=ON \
-      -D VTK_USE_SYSTEM_ZLIB=ON \
-      -D BUILD_SHARED_LIBS=ON \
-      -D BUILD_EXAMPLES=OFF \
-      -D BUILD_TESTING=OFF \
-      -D BUILD_DOCUMENTATION=OFF \
-      .. \
-    && make install \
-    && cd /usr/src \
-    && rm -rf /usr/src/VTK-6.3.0 \
-    && ldconfig
+#RUN cd /usr/src \
+#    && wget http://www.vtk.org/files/release/6.3/VTK-6.3.0.tar.gz \
+#    && tar -xzf VTK-6.3.0.tar.gz \
+#    && rm -f VTK-6.3.0.tar.gz \
+#    && mkdir VTK-6.3.0/Build \
+#    && cd VTK-6.3.0/Build \
+#    && cmake \
+#      -D CMAKE_INSTALL_PREFIX=/usr/local \
+#      -D CMAKE_BUILD_TYPE=Release \
+#      -D CMAKE_CXX_FLAGS=-std=c++11 \
+#      -D VTK_USE_SYSTEM_PNG=ON \
+#      -D VTK_USE_SYSTEM_ZLIB=ON \
+#      -D BUILD_SHARED_LIBS=ON \
+#      -D BUILD_EXAMPLES=OFF \
+#      -D BUILD_TESTING=OFF \
+#      -D BUILD_DOCUMENTATION=OFF \
+#      .. \
+#    && make install \
+#    && cd /usr/src \
+#    && rm -rf /usr/src/VTK-6.3.0 \
+#    && ldconfig
 
 COPY . /usr/src/MIRTK
 RUN mkdir /usr/src/MIRTK/Build \
@@ -81,7 +82,7 @@ RUN mkdir /usr/src/MIRTK/Build \
     && cd /usr/src \
     && rm -rf /usr/src/MIRTK
 
-ENTRYPOINT ["/usr/bin/python", "/usr/local/bin/mirtk"]
+ENTRYPOINT ["python", "/usr/local/bin/mirtk"]
 CMD ["help"]
 
 WORKDIR /data


### PR DESCRIPTION
While this reduces the build time of the Docker image, it pretty much doubles the size of the resulting image (>1.4GB instead of about 600MB) because the ```libvtk6-dev``` package contains all VTK modules and thus depends also on Qt. It further contains Python, Java, and Tcl wrappers. These are not needed by MIRTK and thus it's better to build the Docker image with a custom VTK build.