### PR TITLE
enh: Do not add WITH_<Pkg> option when USE_<Pkg> variable set [BASIS]

### DIFF
--- a/CMake/Basis/CommonTools.cmake
+++ b/CMake/Basis/CommonTools.cmake
@@ -300,7 +300,11 @@ macro (basis_find_package PACKAGE)
       if (NOT DEFINED WITH_${PKG}_DEFAULT)
         set (WITH_${PKG}_DEFAULT OFF)
       endif ()
-      option (WITH_${PKG} "Build with optional ${PKG} dependency" ${WITH_${PKG}_DEFAULT})
+      if (DEFINED USE_${PKG} AND NOT DEFINED WITH_${PKG})
+        set (WITH_${PKG} ${WITH_${PKG}_DEFAULT})
+      else ()
+        option (WITH_${PKG} "Build with optional ${PKG} dependency" ${WITH_${PKG}_DEFAULT})
+      endif ()
     endif ()
     # look for external package only if required, built with optional dependency
     # enabled by user (cf. WITH_<PKG> option above) or deprecated -DUSE_<PKG>=ON


### PR DESCRIPTION
This change does not really affect MIRTK, but I came across this and made the change here anyway. To be pushed upstream.