### PR TITLE
Enh: Documentation sidebar changes

### DIFF
--- a/Documentation/contents.rst
+++ b/Documentation/contents.rst
@@ -10,8 +10,8 @@ Table Of Contents
     :maxdepth: 4
 
     getstarted
-    modules
     commands
+    modules
     apidoc
     changelog
     download

--- a/Documentation/help.rst
+++ b/Documentation/help.rst
@@ -1,11 +1,9 @@
-.. title:: Help
-
 .. meta::
     :description: Report any issues with MIRTK or request new features on GitHub.
 
-============
-Getting Help
-============
+========
+Get Help
+========
 
 Please report bugs and request new or missing (M)IRTK features on GitHub:
 

--- a/Documentation/sidebar.rst
+++ b/Documentation/sidebar.rst
@@ -5,8 +5,8 @@
 
     Overview <index>
     getstarted
-    modules
     commands
+    modules
     Reference <apidoc>
 
 .. toctree::


### PR DESCRIPTION
- Change order of "Applications" and "Modules" pages in TOC and side bar such that the list of commands comes next to the "Get Started" guide/
- Rename "Getting Help" to "Get Help".