### PR TITLE
Update the help section of documentation.

### DIFF
--- a/Documentation/help.rst
+++ b/Documentation/help.rst
@@ -1,9 +1,9 @@
 .. meta::
     :description: Report any issues with MIRTK or request new features on GitHub.
 
-========
-Get Help
-========
+================
+Help and support
+================
 
 Please report bugs and request new or missing (M)IRTK features on GitHub:
 
@@ -12,5 +12,5 @@ Please report bugs and request new or missing (M)IRTK features on GitHub:
 - `View or report issues with VolumetricMapping module <https://github.com/MIRTK/VolumetricMapping/issues>`__.
 
 For all other support and help with getting the MIRTK up and running, please send a message to the
-`mailing list (doc-biomedic-irtk@imperial.ac.uk) <https://mailman.ic.ac.uk/mailman/listinfo/doc-biomedic-irtk>`__
+`mailing list (mirtk-user@imperial.ac.uk) <https://mailman.ic.ac.uk/mailman/listinfo/mirtk-user>`__
 (subscription required).


### PR DESCRIPTION
This PR updates the link of the community support mailing-list for `doc-biomedic-irtk` to the new `mirtk-user`. I also took this opportunity to correct the "Get help" title to something with less of a [double meaning](https://www.mentalhealth.org.uk/your-mental-health/getting-help).