### PR TITLE
Fix conversion of transformation to FSL warp

### DIFF
--- a/Applications/convert-dof.cc
+++ b/Applications/convert-dof.cc
@@ -1192,24 +1192,14 @@ int main(int argc, char *argv[])
   #endif 
 
   for (ALL_OPTIONS) {
-    if (OPTION("-input-format")) {
-      const char *arg = ARGUMENT;
-      if (!FromString(arg, format_in)) {
-        FatalError("Invalid -input-format file format argument: " << arg);
-        exit(1);
-      }
-    }
+    if (OPTION("-input-format")) PARSE_ARGUMENT(format_in);
     else if (OPTION("-format") || OPTION("-output-format")) {
-      const char *arg = ARGUMENT;
-      if (!FromString(arg, format_out)) {
-        FatalError("Invalid [-output]-format file format argument: " << arg);
-        exit(1);
-      }
+      PARSE_ARGUMENT(format_out);
     }
     else if (OPTION("-dofin")) dofin_name = ARGUMENT;
     else if (OPTION("-target")) target_name = ARGUMENT;
     else if (OPTION("-source")) source_name = ARGUMENT;
-    else if (OPTION("-steps")) steps = atoi(ARGUMENT);
+    else if (OPTION("-steps")) PARSE_ARGUMENT(steps);
     else if (OPTION("-Ts")) PARSE_ARGUMENT(ts);
     else if (OPTION("-ds")) {
       PARSE_ARGUMENT(dx);
@@ -1219,12 +1209,10 @@ int main(int argc, char *argv[])
     else if (OPTION("-dy")) PARSE_ARGUMENT(dy);
     else if (OPTION("-dz")) PARSE_ARGUMENT(dz);
     else if (OPTION("-xyz_units")) {
-      const char *arg = ARGUMENT;
       #if MIRTK_ImageIO_WITH_NIfTI
-        if (!FromString(arg, xyz_units)) {
-          FatalError("Invalid argument for option -xyz_units: " << arg);
-          exit(1);
-        }
+        PARSE_ARGUMENT(xyz_units);
+      #else
+        ARGUMENT; // unused, but needs to be parsed
       #endif // MIRTK_ImageIO_WITH_NIfTI
     }
     else HANDLE_STANDARD_OR_UNKNOWN_OPTION();

--- a/Applications/convert-dof.cc
+++ b/Applications/convert-dof.cc
@@ -75,14 +75,13 @@ void PrintHelp(const char *name)
   cout << "  f3d_disp_vel_field     Nifty Reg reg_f3d output image displacement field as stationary velocity field.\n";
   cout << "  f3d_spline_vel_grid    Nifty Reg reg_f3d output control point velocity field.\n";
   cout << "  =====================  =================================================================================\n";
-#if MIRTK_ImageIO_WITH_NIfTI
+#if !MIRTK_ImageIO_WITH_NIfTI
   cout << "\n";
-  cout << "  Note: Cannot convert from/to the following formats because of missing NIfTI module.\n";
-  cout << "        Rebuild the MIRTK with the NIfTI module enabled to use these formats.\n";
+  cout << "  Cannot convert from/to the following formats because the ImageIO module is missing NIfTI support:\n";
   cout << "\n";
-  cout << "  Not available: f3d*, fnirt\n";
+  cout << "    f3d*, fnirt\n";
   cout << "\n";
-#endif // MIRTK_ImageIO_WITH_NIfTI
+#endif // !MIRTK_ImageIO_WITH_NIfTI
   cout << "\n";
   cout << "Arguments:\n";
   cout << "  input    Input transformation file.\n";

--- a/Applications/convert-dof.cc
+++ b/Applications/convert-dof.cc
@@ -1363,7 +1363,7 @@ int main(int argc, char *argv[])
   }
 
   // Guess output file format
-  const string ext_out = Extension(input_name, EXT_LastWithoutGz); 
+  const string ext_out = Extension(output_name, EXT_LastWithoutGz);
   bool  ext_out_nifti  = (ext_out == ".nii" || ext_out == ".hdr" || ext_out == ".img");
   bool  is_linear      = (dynamic_cast<HomogeneousTransformation *>(dof.get()) != nullptr);
 


### PR DESCRIPTION
This PR contains a few minor fixes and changes of the ```convert-dof``` tool as well. The main fix is the conversion of a transformation to an FSL warp. The transformed point in the source image must be multiplied with the source image voxel size, not the target image voxel size, to convert to mm units. For the conversion to a relative warp, the target voxel size is needed, though.