### PR TITLE
Enh: Add postfix to debug libraries and static libraries on Windows

### DIFF
--- a/CMake/Modules/mirtkAddLibrary.cmake
+++ b/CMake/Modules/mirtkAddLibrary.cmake
@@ -63,6 +63,7 @@ function(mirtk_add_library)
       SOVERSION     "${PROJECT_SOVERSION}"
       OUTPUT_NAME   "${PROJECT_PACKAGE_NAME}${PROJECT_NAME}"
       DEFINE_SYMBOL "MIRTK_${PROJECT_NAME}_EXPORTS"
+      DEBUG_POSTFIX D
   )
   target_include_directories(${target_uid}
     PUBLIC $<BUILD_INTERFACE:${PROJECT_INCLUDE_DIR}>

--- a/CMake/Modules/mirtkAddLibrary.cmake
+++ b/CMake/Modules/mirtkAddLibrary.cmake
@@ -70,8 +70,14 @@ function(mirtk_add_library)
            $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>
     PRIVATE ${PROJECT_CODE_DIR}
   )
-  if (TARGET_AUTO_REGISTER AND BUILD_SHARED_LIBS)
-    target_compile_definitions(${target_uid} PRIVATE MIRTK_AUTO_REGISTER)
+  if (BUILD_SHARED_LIBS)
+    if (TARGET_AUTO_REGISTER)
+      target_compile_definitions(${target_uid} PRIVATE MIRTK_AUTO_REGISTER)
+    endif ()
+  else ()
+    if (WIN32)
+      set_target_properties(${target_uid} PROPERTIES SUFFIX "_s.lib")
+    endif ()
   endif ()
   # VTK 7.0.0 adds its CMake modules directory to CMAKE_MODULE_PATH
   # and this directory contains a GenerateExportHeader.cmake module

--- a/ThirdParty/LBFGS/CMakeLists.txt
+++ b/ThirdParty/LBFGS/CMakeLists.txt
@@ -10,5 +10,6 @@ basis_add_library(lbfgs STATIC
 
 set_target_properties(lbfgs PROPERTIES
   ARCHIVE_OUTPUT_NAME       MIRTKlbfgs
+  DEBUG_POSTFIX             D
   POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS}
 )

--- a/ThirdParty/NiftiCLib/CMakeLists.txt
+++ b/ThirdParty/NiftiCLib/CMakeLists.txt
@@ -32,5 +32,6 @@ endif ()
 
 set_target_properties(${target_uid} PROPERTIES
   ARCHIVE_OUTPUT_NAME       MIRTKnifticlib
+  DEBUG_POSTFIX             D
   POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS}
 )


### PR DESCRIPTION
This allows the installation of both optimised and debug libraries as well as static and shared libraries in the same destination. The use of static libraries is generally not recommended and hence there is currently no option to build both static and shared libraries at the same time. They may be installed to the same directory, however, after build with different CMake configurations.