### PR TITLE
Fix units parsing and tests build

### DIFF
--- a/Modules/Common/src/String.cc
+++ b/Modules/Common/src/String.cc
@@ -209,7 +209,11 @@ string ParameterUnits(const string &str, string *name, const char *dflt)
     }
   }
   if (name) {
-    *name = Trim(trimmed.substr(0u, trimmed.size() - units.size() - 2u));
+    if (units.empty()) {
+      *name = trimmed;
+    } else {
+      *name = Trim(trimmed.substr(0u, trimmed.size() - units.size() - 2u));
+    }
   }
   if (units.empty()) return dflt;
   return StandardUnits(units);

--- a/Modules/Common/src/String.cc
+++ b/Modules/Common/src/String.cc
@@ -225,6 +225,7 @@ string ValueUnits(const string &str, string *value, const char *dflt)
     const string last = parts.back();
     const auto pos = last.find_first_of("0123456789");
     if (pos != string::npos) {
+      const auto pos = last.find_last_of("0123456789");
       parts.back() = last.substr(0u, pos + 1u);
       parts.push_back(last.substr(pos + 1u));
     }

--- a/Modules/Common/test/testString.cc
+++ b/Modules/Common/test/testString.cc
@@ -163,6 +163,16 @@ TEST(String, ParameterUnits)
     EXPECT_EQ(string("mm"), ParameterUnits("  Resolution    [MM]", &name));
     EXPECT_EQ("Resolution", name);
   }
+  {
+    string name;
+    EXPECT_EQ(string(""), ParameterUnits("Resolution", &name));
+    EXPECT_EQ("Resolution", name);
+  }
+  {
+    string name;
+    EXPECT_EQ(string(""), ParameterUnits("Resolution of image 1", &name));
+    EXPECT_EQ("Resolution of image 1", name);
+  }
   EXPECT_EQ(string("rel"), ParameterUnits("Resolution [relative]  \t"));
 }
 

--- a/Modules/Common/test/testString.cc
+++ b/Modules/Common/test/testString.cc
@@ -184,6 +184,11 @@ TEST(String, ValueUnits)
   }
   {
     string value;
+    EXPECT_EQ(string("mm"), ValueUnits("  1.5mm", &value));
+    EXPECT_EQ(string("1.5"), value);
+  }
+  {
+    string value;
     EXPECT_EQ(string("mm"), ValueUnits("  1 2 3  [mm]", &value));
     EXPECT_EQ(string("1 2 3"), value);
   }

--- a/Modules/Numerics/test/CMakeLists.txt
+++ b/Modules/Numerics/test/CMakeLists.txt
@@ -18,7 +18,7 @@
 # ============================================================================
 
 macro(add_numerics_test class_name)
-  mirtk_add_test(${class_name} SOURCES mirtkNumericsTest.h DEPENDS LibNumerics)
+  mirtk_add_test(${class_name} SOURCES NumericsTest.h DEPENDS LibNumerics)
 endmacro ()
 
 

--- a/Modules/Numerics/test/testMatrix.cc
+++ b/Modules/Numerics/test/testMatrix.cc
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-#include "mirtkNumericsTest.h"
+#include "NumericsTest.h"
 
 #include "mirtk/Matrix.h"
 using namespace mirtk;

--- a/Modules/Numerics/test/testPolynomial.cc
+++ b/Modules/Numerics/test/testPolynomial.cc
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-#include "mirtkNumericsTest.h"
+#include "NumericsTest.h"
 
 #include "mirtk/Polynomial.h"
 using namespace mirtk;

--- a/Modules/Registration/src/NormalizedIntensityCrossCorrelation.cc
+++ b/Modules/Registration/src/NormalizedIntensityCrossCorrelation.cc
@@ -82,27 +82,6 @@ int ParseValues(const char *str, const char *format, double *x, double *y, doubl
 }
 
 // -----------------------------------------------------------------------------
-NormalizedIntensityCrossCorrelation::Units ParseUnits(const char *value)
-{
-  // Start at end of string
-  const size_t len = strlen(value);
-  const char    *p = value + len;
-  // Skip trailing whitespaces
-  while (p != value && (*(p-1) == ' ' || *(p-1) == '\t')) --p;
-  // Skip lowercase letters
-  while (p != value && *(p-1) >= 'a' && *(p-1) <= 'z') --p;
-  // Check if value ends with unit specification
-  if (strcmp(p, "mm") == 0) {
-    return NormalizedIntensityCrossCorrelation::UNITS_MM;
-  }
-  if (strcmp(p, "vox") == 0 || strcmp(p, "voxel") == 0 || strcmp(p, "voxels") == 0)
-  {
-    return NormalizedIntensityCrossCorrelation::UNITS_Voxel;
-  }
-  return NormalizedIntensityCrossCorrelation::UNITS_Default;
-}
-
-// -----------------------------------------------------------------------------
 // Kernel: Gaussian
 // -----------------------------------------------------------------------------
 

--- a/Modules/Registration/src/NormalizedIntensityCrossCorrelation.cc
+++ b/Modules/Registration/src/NormalizedIntensityCrossCorrelation.cc
@@ -62,22 +62,22 @@ namespace NormalizedIntensityCrossCorrelationUtil {
 typedef NormalizedIntensityCrossCorrelation::RealImage RealImage;
 
 // -----------------------------------------------------------------------------
-int ParseValues(const char *str, const char *format, int *x, int *y, int *z)
+int ParseValues(const char *str, int *x, int *y, int *z)
 {
 #ifdef WINDOWS
-  return sscanf_s(str, format, x, y, z);
+  return sscanf_s(str, "%d %d %d", x, y, z);
 #else
-  return sscanf(str, format, x, y, z);
+  return sscanf(str, "%d %d %d", x, y, z);
 #endif
 }
 
 // -----------------------------------------------------------------------------
-int ParseValues(const char *str, const char *format, double *x, double *y, double *z)
+int ParseValues(const char *str, double *x, double *y, double *z)
 {
 #ifdef WINDOWS
-  return sscanf_s(str, format, x, y, z);
+  return sscanf_s(str, "%lf %lf %lf", x, y, z);
 #else
-  return sscanf(str, format, x, y, z);
+  return sscanf(str, "%lf %lf %lf", x, y, z);
 #endif
 }
 
@@ -615,7 +615,7 @@ bool NormalizedIntensityCrossCorrelation::SetWithPrefix(const char *param, const
 
       if (type == "sigma") {
         double sx = 0, sy = 0, sz = 0;
-        int n = ParseValues(value, "%lf %lf %lf", &sx, &sy, &sz);
+        int n = ParseValues(value, &sx, &sy, &sz);
         if (n == 0) return false;
         if (n == 1) sz = sy = sx;
         if (units != "signed") {
@@ -631,7 +631,7 @@ bool NormalizedIntensityCrossCorrelation::SetWithPrefix(const char *param, const
         return false; // makes only sense for "Local window size"
       } else if (type == "vox") {
         int rx = 0, ry = 0, rz = 0;
-        int n = ParseValues(value, "%d %d %d", &rx, &ry, &rz);
+        int n = ParseValues(value, &rx, &ry, &rz);
         if (n == 0) return false;
         if (n == 1) rz = ry = rx;
         if (units != "vox" || rx < 0 || ry < 0 || rz < 0) return false;
@@ -642,7 +642,7 @@ bool NormalizedIntensityCrossCorrelation::SetWithPrefix(const char *param, const
         return true;
       } else if (type == "mm") {
         double rx = .0, ry = .0, rz = .0;
-        int n = ParseValues(value, "%lf %lf %lf", &rx, &ry, &rz);
+        int n = ParseValues(value, &rx, &ry, &rz);
         if (n == 0) return false;
         if (n == 1) rz = ry = rx;
         if (units != "mm" || rx < .0 || ry < .0 || rz < .0) return false;
@@ -653,7 +653,7 @@ bool NormalizedIntensityCrossCorrelation::SetWithPrefix(const char *param, const
         return true;
       } else if (type == "box") {
         double rx = .0, ry = .0, rz = .0;
-        int n = ParseValues(value, "%lf %lf %lf", &rx, &ry, &rz);
+        int n = ParseValues(value, &rx, &ry, &rz);
         if (n == 0) return false;
         if (n == 1) rz = ry = rx;
         if (units != "signed") {
@@ -672,7 +672,7 @@ bool NormalizedIntensityCrossCorrelation::SetWithPrefix(const char *param, const
 
       if (type == "sigma") {
         double sx = 0, sy = 0, sz = 0;
-        int n = ParseValues(value, "%lf %lf %lf", &sx, &sy, &sz);
+        int n = ParseValues(value, &sx, &sy, &sz);
         if (n == 0) return false;
         if (n == 1) sz = sy = sx;
         if (units != "signed") {
@@ -686,7 +686,7 @@ bool NormalizedIntensityCrossCorrelation::SetWithPrefix(const char *param, const
         return true;
       } else if (type == "fwhm") {
         double sx = 0, sy = 0, sz = 0;
-        int n = ParseValues(value, "%lf %lf %lf", &sx, &sy, &sz);
+        int n = ParseValues(value, &sx, &sy, &sz);
         if (n == 0) return false;
         if (n == 1) sz = sy = sx;
         if (units != "signed") {
@@ -700,7 +700,7 @@ bool NormalizedIntensityCrossCorrelation::SetWithPrefix(const char *param, const
         return true;
       } else if (type == "fwtm") {
         double sx = 0, sy = 0, sz = 0;
-        int n = ParseValues(value, "%lf %lf %lf", &sx, &sy, &sz);
+        int n = ParseValues(value, &sx, &sy, &sz);
         if (n == 0) return false;
         if (n == 1) sz = sy = sx;
         if (units != "signed") {
@@ -714,7 +714,7 @@ bool NormalizedIntensityCrossCorrelation::SetWithPrefix(const char *param, const
         return true;
       } else if (type == "vox") {
         int sx = 0, sy = 0, sz = 0;
-        int n = ParseValues(value, "%d %d %d", &sx, &sy, &sz);
+        int n = ParseValues(value, &sx, &sy, &sz);
         if (n == 0) return false;
         if (n == 1) sz = sy = sx;
         if (units != "vox" || sx < 0 || sy < 0 || sz < 0) return false;
@@ -725,7 +725,7 @@ bool NormalizedIntensityCrossCorrelation::SetWithPrefix(const char *param, const
         return true;
       } else if (type == "mm") {
         double sx = .0, sy = .0, sz = .0;
-        int n = ParseValues(value, "%lf %lf %lf", &sx, &sy, &sz);
+        int n = ParseValues(value, &sx, &sy, &sz);
         if (n == 0) return false;
         if (n == 1) sz = sy = sx;
         if (units != "mm" || sx < 0 || sy < 0 || sz < 0) return false;
@@ -736,7 +736,7 @@ bool NormalizedIntensityCrossCorrelation::SetWithPrefix(const char *param, const
         return true;
       } else if (type == "box") {
         double sx = .0, sy = .0, sz = .0;
-        int n = ParseValues(value, "%lf %lf %lf", &sx, &sy, &sz);
+        int n = ParseValues(value, &sx, &sy, &sz);
         if (n == 0) return false;
         if (n == 1) sz = sy = sx;
         if (units != "signed") {


### PR DESCRIPTION
- Fix bugs in ```ParameterUnits``` and ```ValueUnits``` functions.
- Fix build configuration of Numerics module tests.
- Remove obsolete LNCC auxiliary function.