### PR TITLE
fix: MSVC warnins for TransformationInverse.cc Boost includes [Transformation]

### DIFF
--- a/Modules/Transformation/src/TransformationInverse.cc
+++ b/Modules/Transformation/src/TransformationInverse.cc
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+#define _SCL_SECURE_NO_WARNINGS
+
 #include "mirtk/Transformation.h"
 #include "mirtk/MultiLevelTransformation.h"
 #include "mirtk/Matrix.h"


### PR DESCRIPTION
Not much of a "fix", just a disabling of warnings.