### PR TITLE
fix: Build of system information functions with GCC and MSVC [Common]

### DIFF
--- a/Modules/Common/include/mirtk/System.h
+++ b/Modules/Common/include/mirtk/System.h
@@ -39,7 +39,7 @@ string GetTime();
 string GetDateTime();
 
 /// Get name of user executing this program
-string GetUserName();
+string GetUser();
 
 
 } // namespace mirtk

--- a/Modules/Common/src/System.cc
+++ b/Modules/Common/src/System.cc
@@ -23,7 +23,6 @@
 
 #include <chrono>
 #include <ctime>
-#include <iomanip>
 
 #ifdef WINDOWS
   #define VC_EXTRALEAN
@@ -58,9 +57,9 @@ string GetDate()
   typedef std::chrono::system_clock Clock;
   std::time_t now = Clock::to_time_t(Clock::now());
   tm info = localtime(now);
-  ostringstream os;
-  os << std::put_time(&info, "%d %b %Y");
-  return os.str();
+  char date_string[16];
+  strftime(date_string, 16, "%d %b %Y", &info);
+  return date_string;
 }
 
 // -----------------------------------------------------------------------------
@@ -69,9 +68,9 @@ string GetTime()
   typedef std::chrono::system_clock Clock;
   std::time_t now = Clock::to_time_t(Clock::now());
   tm info = localtime(now);
-  ostringstream os;
-  os << std::put_time(&info, "%H:%M:%S %Z");
-  return os.str();
+  char time_string[16];
+  strftime(time_string, 16, "%H:%M:%S %Z", &info);
+  return time_string;
 }
 
 // -----------------------------------------------------------------------------
@@ -80,13 +79,13 @@ string GetDateTime()
   typedef std::chrono::system_clock Clock;
   std::time_t now = Clock::to_time_t(Clock::now());
   tm info = localtime(now);
-  ostringstream os;
-  os << std::put_time(&info, "%c %Z");
-  return os.str();
+  char date_time_string[32];
+  strftime(date_time_string, 16, "%c %Z", &info);
+  return date_time_string;
 }
 
 // -----------------------------------------------------------------------------
-string GetUserName()
+string GetUser()
 {
 #ifdef WINDOWS
   char username[UNLEN+1];

--- a/Modules/IO/src/PointSetIO.cc
+++ b/Modules/IO/src/PointSetIO.cc
@@ -21,7 +21,7 @@
 
 #include "mirtk/Path.h"
 #include "mirtk/Stream.h"
-#include "mirtk/System.h" // GetUserName, GetDateTime
+#include "mirtk/System.h" // GetUser, GetDateTime
 #include "mirtk/Vtk.h"
 
 #include "vtkPoints.h"
@@ -1746,7 +1746,7 @@ bool WriteGIFTI(const char *fname, vtkPolyData *polydata, bool compress, bool as
 
   // Set UserName and Date
   gifti_add_to_meta(&gim->meta, GiftiMetaData::DATE()     ->GetName(), GetDateTime().c_str(), 1);
-  gifti_add_to_meta(&gim->meta, GiftiMetaData::USER_NAME()->GetName(), GetUserName().c_str(), 1);
+  gifti_add_to_meta(&gim->meta, GiftiMetaData::USER_NAME()->GetName(), GetUser().c_str(), 1);
 
   // Add point coordinates
   if (polydata->GetNumberOfPoints() > 0) {


### PR DESCRIPTION
Turns out GCC 4.8 does not implement the ```std::put_time``` manipulator yet.