### PR TITLE
Fix missing using std with isinf and isnan.

### DIFF
--- a/Modules/Common/include/mirtk/Math.h
+++ b/Modules/Common/include/mirtk/Math.h
@@ -86,7 +86,8 @@ MIRTKCU_API inline bool IsNaN(double x)
 #ifdef WINDOWS
   return (_isnan(x) != 0);
 #else
-  return ::isnan(x);
+  using std::isnan;
+  return isnan(x);
 #endif
 }
 
@@ -97,7 +98,8 @@ MIRTKCU_API inline bool IsInf(double x)
 #ifdef WINDOWS
   return !_finite(x);
 #else
-  return ::isinf(x);
+  using std::isinf;
+  return isinf(x);
 #endif
 }
 


### PR DESCRIPTION
Tried to compile on Ubuntu 16.04. Hit a bug with non-declaration of `isnan` and `isinf`. This patch fixes the error.