### PR TITLE
fix: Use 'str' instead of 'basestring' for compatibility with Python 3 [Applications]

### DIFF
--- a/Applications/lib/python/mirtk/subprocess.py.in
+++ b/Applications/lib/python/mirtk/subprocess.py.in
@@ -48,8 +48,8 @@ else:                              libexec_ext = ['']
 # ----------------------------------------------------------------------------
 def path(argv, quiet=False):
     """Get full path of MIRTK command executable."""
-    if isinstance(argv, basestring): command = argv
-    else:                            command = argv[0]
+    if isinstance(argv, str): command = argv
+    else:                     command = argv[0]
     fpath = None
     for ext in libexec_ext:
         p = os.path.join(libexec_dir, config, command + ext)


### PR DESCRIPTION
Closes #209.