### PR TITLE
enh: Rename ProbabilisticImageSimilarity to HistogramImageSimilarity [Registration]

### DIFF
--- a/Applications/src/evaluate-similarity.cc
+++ b/Applications/src/evaluate-similarity.cc
@@ -27,7 +27,7 @@
 #include "mirtk/EnergyMeasure.h"
 #include "mirtk/SimilarityMeasure.h"
 #include "mirtk/ImageSimilarity.h"
-#include "mirtk/ProbabilisticImageSimilarity.h"
+#include "mirtk/HistogramImageSimilarity.h"
 #include "mirtk/NearestNeighborInterpolateImageFunction.h"
 
 using namespace mirtk;
@@ -118,7 +118,7 @@ int DefaultNumberOfBins(const BaseImage *, double min_intensity, double max_inte
 // -----------------------------------------------------------------------------
 int main(int argc, char **argv)
 {
-  typedef ProbabilisticImageSimilarity::JointHistogramType JointHistogram;
+  typedef HistogramImageSimilarity::JointHistogramType JointHistogram;
   typedef RegisteredImage::VoxelType                       VoxelType;
 
   // Check command line
@@ -346,8 +346,8 @@ int main(int argc, char **argv)
     sim[i]->DivideByInitialValue(false);
     sim[i]->SkipTargetInitialization(true);
     sim[i]->SkipSourceInitialization(true);
-    ProbabilisticImageSimilarity *p;
-    p = dynamic_cast<ProbabilisticImageSimilarity *>(sim[i].get());
+    HistogramImageSimilarity *p;
+    p = dynamic_cast<HistogramImageSimilarity *>(sim[i].get());
     if (p != nullptr) {
       p->Samples(&samples);
       p->UseParzenWindow(parzen_window);

--- a/Modules/Registration/include/mirtk/HistogramImageSimilarity.h
+++ b/Modules/Registration/include/mirtk/HistogramImageSimilarity.h
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-#ifndef MIRTK_ProbabilisticImageSimilarity_H
-#define MIRTK_ProbabilisticImageSimilarity_H
+#ifndef MIRTK_HistogramImageSimilarity_H
+#define MIRTK_HistogramImageSimilarity_H
 
 #include "mirtk/ImageSimilarity.h"
 
@@ -37,9 +37,9 @@ namespace mirtk {
  * An estimate of the probabilities is obtained using a joint histogram and
  * cubic B-spline Parzen Windows for a continuous representation.
  */
-class ProbabilisticImageSimilarity : public ImageSimilarity
+class HistogramImageSimilarity : public ImageSimilarity
 {
-  mirtkAbstractMacro(ProbabilisticImageSimilarity);
+  mirtkAbstractMacro(HistogramImageSimilarity);
 
   // ---------------------------------------------------------------------------
   // Types
@@ -83,23 +83,23 @@ public:
   mirtkPublicAttributeMacro(int, NumberOfSourceBins);
 
   /// Copy attributes of this class from another instance
-  void CopyAttributes(const ProbabilisticImageSimilarity &);
+  void CopyAttributes(const HistogramImageSimilarity &);
 
   // ---------------------------------------------------------------------------
   // Construction/Destruction
 protected:
 
   /// Constructor
-  ProbabilisticImageSimilarity(const char * = "", double = 1.0);
+  HistogramImageSimilarity(const char * = "", double = 1.0);
 
   /// Copy constructor
-  ProbabilisticImageSimilarity(const ProbabilisticImageSimilarity &);
+  HistogramImageSimilarity(const HistogramImageSimilarity &);
 
   /// Assignment operator
-  ProbabilisticImageSimilarity &operator =(const ProbabilisticImageSimilarity &);
+  HistogramImageSimilarity &operator =(const HistogramImageSimilarity &);
 
   /// Destructor
-  virtual ~ProbabilisticImageSimilarity();
+  virtual ~HistogramImageSimilarity();
 
   // ---------------------------------------------------------------------------
   // Parameters
@@ -154,4 +154,4 @@ public:
 
 } // namespace mirtk
 
-#endif // MIRTK_ProbabilisticImageSimilarity_H
+#endif // MIRTK_HistogramImageSimilarity_H

--- a/Modules/Registration/include/mirtk/ImageCovariance.h
+++ b/Modules/Registration/include/mirtk/ImageCovariance.h
@@ -20,7 +20,7 @@
 #ifndef MIRTK_ImageCovariance_H
 #define MIRTK_ImageCovariance_H
 
-#include "mirtk/ProbabilisticImageSimilarity.h"
+#include "mirtk/HistogramImageSimilarity.h"
 
 
 namespace mirtk {
@@ -29,7 +29,7 @@ namespace mirtk {
 /**
  * Joint entropy image similarity measure
  */
-class ImageCovariance : public ProbabilisticImageSimilarity
+class ImageCovariance : public HistogramImageSimilarity
 {
   mirtkEnergyTermMacro(ImageCovariance, EM_CoVar);
 

--- a/Modules/Registration/include/mirtk/IntensityCorrelationRatioXY.h
+++ b/Modules/Registration/include/mirtk/IntensityCorrelationRatioXY.h
@@ -20,7 +20,7 @@
 #ifndef MIRTK_IntensityCorrelationRatioXY_H
 #define MIRTK_IntensityCorrelationRatioXY_H
 
-#include "mirtk/ProbabilisticImageSimilarity.h"
+#include "mirtk/HistogramImageSimilarity.h"
 
 
 namespace mirtk {
@@ -29,7 +29,7 @@ namespace mirtk {
 /**
  * Correlation ratio of target (X) and source (Y) image intensities
  */
-class IntensityCorrelationRatioXY : public ProbabilisticImageSimilarity
+class IntensityCorrelationRatioXY : public HistogramImageSimilarity
 {
   mirtkEnergyTermMacro(IntensityCorrelationRatioXY, EM_CR_XY);
 

--- a/Modules/Registration/include/mirtk/IntensityCorrelationRatioYX.h
+++ b/Modules/Registration/include/mirtk/IntensityCorrelationRatioYX.h
@@ -20,7 +20,7 @@
 #ifndef MIRTK_IntensityCorrelationRatioYX_H
 #define MIRTK_IntensityCorrelationRatioYX_H
 
-#include "mirtk/ProbabilisticImageSimilarity.h"
+#include "mirtk/HistogramImageSimilarity.h"
 
 
 namespace mirtk {
@@ -29,7 +29,7 @@ namespace mirtk {
 /**
  * Correlation ratio of target (X) and source (Y) image intensities
  */
-class IntensityCorrelationRatioYX : public ProbabilisticImageSimilarity
+class IntensityCorrelationRatioYX : public HistogramImageSimilarity
 {
   mirtkEnergyTermMacro(IntensityCorrelationRatioYX, EM_CR_YX);
 

--- a/Modules/Registration/include/mirtk/JointImageEntropy.h
+++ b/Modules/Registration/include/mirtk/JointImageEntropy.h
@@ -20,7 +20,7 @@
 #ifndef MIRTK_JointImageEntropy_H
 #define MIRTK_JointImageEntropy_H
 
-#include "mirtk/ProbabilisticImageSimilarity.h"
+#include "mirtk/HistogramImageSimilarity.h"
 
 
 namespace mirtk {
@@ -29,7 +29,7 @@ namespace mirtk {
 /**
  * Joint entropy image similarity measure
  */
-class JointImageEntropy : public ProbabilisticImageSimilarity
+class JointImageEntropy : public HistogramImageSimilarity
 {
   mirtkEnergyTermMacro(JointImageEntropy, EM_JE);
 

--- a/Modules/Registration/include/mirtk/LabelConsistency.h
+++ b/Modules/Registration/include/mirtk/LabelConsistency.h
@@ -20,7 +20,7 @@
 #ifndef MIRTK_LabelConsistency_H
 #define MIRTK_LabelConsistency_H
 
-#include "mirtk/ProbabilisticImageSimilarity.h"
+#include "mirtk/HistogramImageSimilarity.h"
 
 
 namespace mirtk {
@@ -29,7 +29,7 @@ namespace mirtk {
 /**
  * Label consistency image similarity measure
  */
-class LabelConsistency : public ProbabilisticImageSimilarity
+class LabelConsistency : public HistogramImageSimilarity
 {
   mirtkEnergyTermMacro(LabelConsistency, EM_LC);
 

--- a/Modules/Registration/include/mirtk/MutualImageInformation.h
+++ b/Modules/Registration/include/mirtk/MutualImageInformation.h
@@ -20,7 +20,7 @@
 #ifndef MIRTK_MutualImageInformation_H
 #define MIRTK_MutualImageInformation_H
 
-#include "mirtk/ProbabilisticImageSimilarity.h"
+#include "mirtk/HistogramImageSimilarity.h"
 
 
 namespace mirtk {
@@ -29,7 +29,7 @@ namespace mirtk {
 /**
  * Mutual information image similarity measure
  */
-class MutualImageInformation : public ProbabilisticImageSimilarity
+class MutualImageInformation : public HistogramImageSimilarity
 {
   mirtkEnergyTermMacro(MutualImageInformation, EM_MI);
 

--- a/Modules/Registration/include/mirtk/NormalizedMutualImageInformation.h
+++ b/Modules/Registration/include/mirtk/NormalizedMutualImageInformation.h
@@ -20,7 +20,7 @@
 #ifndef MIRTK_NormalizedMutualImageInformation_H
 #define MIRTK_NormalizedMutualImageInformation_H
 
-#include "mirtk/ProbabilisticImageSimilarity.h"
+#include "mirtk/HistogramImageSimilarity.h"
 
 
 namespace mirtk {
@@ -29,7 +29,7 @@ namespace mirtk {
 /**
  * Normalized mutual information image similarity measure
  */
-class NormalizedMutualImageInformation : public ProbabilisticImageSimilarity
+class NormalizedMutualImageInformation : public HistogramImageSimilarity
 {
   mirtkEnergyTermMacro(NormalizedMutualImageInformation, EM_NMI);
 

--- a/Modules/Registration/include/mirtk/Registration.h
+++ b/Modules/Registration/include/mirtk/Registration.h
@@ -25,7 +25,7 @@
 // Base classes
 #include "mirtk/DataFidelity.h"
 #include "mirtk/ImageSimilarity.h"
-#include "mirtk/ProbabilisticImageSimilarity.h"
+#include "mirtk/HistogramImageSimilarity.h"
 #include "mirtk/GradientFieldSimilarity.h"
 
 #if MIRTK_Registration_WITH_PointSet

--- a/Modules/Registration/src/CMakeLists.txt
+++ b/Modules/Registration/src/CMakeLists.txt
@@ -31,6 +31,7 @@ set(HEADERS
   GenericRegistrationFilter.h
   GenericRegistrationLogger.h
   GradientFieldSimilarity.h
+  HistogramImageSimilarity.h
   ImageCovariance.h
   ImageSimilarity.h
   IntensityCorrelationRatioXY.h
@@ -43,7 +44,6 @@ set(HEADERS
   NormalizedIntensityCrossCorrelation.h
   NormalizedMutualImageInformation.h
   PeakSignalToNoiseRatio.h
-  ProbabilisticImageSimilarity.h
   Registration.h
   RegistrationEnergy.h
   RegistrationFilter.h
@@ -58,6 +58,7 @@ set(SOURCES
   GenericRegistrationFilter.cc
   GenericRegistrationLogger.cc
   GradientFieldSimilarity.cc
+  HistogramImageSimilarity.cc
   ImageCovariance.cc
   ImageSimilarity.cc
   IntensityCorrelationRatioXY.cc
@@ -70,7 +71,6 @@ set(SOURCES
   NormalizedIntensityCrossCorrelation.cc
   NormalizedMutualImageInformation.cc
   PeakSignalToNoiseRatio.cc
-  ProbabilisticImageSimilarity.cc
   RegistrationConfig.cc
   RegistrationEnergy.cc
   RegistrationEnergyParser.h

--- a/Modules/Registration/src/HistogramImageSimilarity.cc
+++ b/Modules/Registration/src/HistogramImageSimilarity.cc
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-#include "mirtk/ProbabilisticImageSimilarity.h"
+#include "mirtk/HistogramImageSimilarity.h"
 
 #include "mirtk/Math.h"
 #include "mirtk/Deallocate.h"
@@ -32,21 +32,21 @@ namespace mirtk {
 // Auxiliary functor
 // =============================================================================
 
-namespace ProbabilisticImageSimilarityUtils {
+namespace HistogramImageSimilarityUtils {
 
 
 // -----------------------------------------------------------------------------
 /// Add samples to joint histogram (no rescaling required)
 class FillHistogram
 {
-  const ProbabilisticImageSimilarity               *_Similarity;
-  ProbabilisticImageSimilarity::JointHistogramType *_Histogram;
-  ProbabilisticImageSimilarity::JointHistogramType *_Output;
+  const HistogramImageSimilarity               *_Similarity;
+  HistogramImageSimilarity::JointHistogramType *_Histogram;
+  HistogramImageSimilarity::JointHistogramType *_Output;
 
 public:
 
-  FillHistogram(const ProbabilisticImageSimilarity               *sim,
-                ProbabilisticImageSimilarity::JointHistogramType *hist)
+  FillHistogram(const HistogramImageSimilarity               *sim,
+                HistogramImageSimilarity::JointHistogramType *hist)
   :
     _Similarity(sim), _Histogram(hist), _Output(hist)
   {}
@@ -59,7 +59,7 @@ public:
     _Output->GetMin  (&xmin,   &ymin);
     _Output->GetMax  (&xmax,   &ymax);
     _Output->GetWidth(&xwidth, &ywidth);
-    _Histogram = new ProbabilisticImageSimilarity::JointHistogramType(xmin, xmax, xwidth,
+    _Histogram = new HistogramImageSimilarity::JointHistogramType(xmin, xmax, xwidth,
                                                                       ymin, ymax, ywidth);
     if (_Histogram->NumberOfBinsX() != _Output->NumberOfBinsX() ||
         _Histogram->NumberOfBinsY() != _Output->NumberOfBinsY()) {
@@ -75,8 +75,8 @@ public:
   void join(const FillHistogram &rhs)
   {
     const int nbins = _Histogram->NumberOfBins();
-    ProbabilisticImageSimilarity::JointHistogramType::BinType *l = _Histogram->RawPointer();
-    ProbabilisticImageSimilarity::JointHistogramType::BinType *r = rhs._Histogram->RawPointer();
+    HistogramImageSimilarity::JointHistogramType::BinType *l = _Histogram->RawPointer();
+    HistogramImageSimilarity::JointHistogramType::BinType *r = rhs._Histogram->RawPointer();
     for (int i = 0; i < nbins; ++i, ++l, ++r) (*l) += (*r);
     _Histogram->NumberOfSamples(_Histogram->NumberOfSamples() + rhs._Histogram->NumberOfSamples());
   }
@@ -94,15 +94,15 @@ public:
 };
 
 
-} // namespace ProbabilisticImageSimilarityUtils
-using namespace ProbabilisticImageSimilarityUtils;
+} // namespace HistogramImageSimilarityUtils
+using namespace HistogramImageSimilarityUtils;
 
 // =============================================================================
 // Construction/Destruction
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-ProbabilisticImageSimilarity::ProbabilisticImageSimilarity(const char *name, double weight)
+HistogramImageSimilarity::HistogramImageSimilarity(const char *name, double weight)
 :
   ImageSimilarity(name, weight),
   _Samples  (new JointHistogramType()), _SamplesOwner(true),
@@ -113,7 +113,7 @@ ProbabilisticImageSimilarity::ProbabilisticImageSimilarity(const char *name, dou
 }
 
 // -----------------------------------------------------------------------------
-void ProbabilisticImageSimilarity::CopyAttributes(const ProbabilisticImageSimilarity &other)
+void HistogramImageSimilarity::CopyAttributes(const HistogramImageSimilarity &other)
 {
   if (_SamplesOwner) delete _Samples;
   _Samples            = (other._SamplesOwner ? new JointHistogramType(*other._Samples) : other._Samples);
@@ -124,7 +124,7 @@ void ProbabilisticImageSimilarity::CopyAttributes(const ProbabilisticImageSimila
 }
 
 // -----------------------------------------------------------------------------
-ProbabilisticImageSimilarity::ProbabilisticImageSimilarity(const ProbabilisticImageSimilarity &other)
+HistogramImageSimilarity::HistogramImageSimilarity(const HistogramImageSimilarity &other)
 :
   ImageSimilarity(other),
   _Samples  (nullptr),
@@ -134,7 +134,7 @@ ProbabilisticImageSimilarity::ProbabilisticImageSimilarity(const ProbabilisticIm
 }
 
 // -----------------------------------------------------------------------------
-ProbabilisticImageSimilarity &ProbabilisticImageSimilarity::operator =(const ProbabilisticImageSimilarity &other)
+HistogramImageSimilarity &HistogramImageSimilarity::operator =(const HistogramImageSimilarity &other)
 {
   if (this != &other) {
     ImageSimilarity::operator =(other);
@@ -144,7 +144,7 @@ ProbabilisticImageSimilarity &ProbabilisticImageSimilarity::operator =(const Pro
 }
 
 // -----------------------------------------------------------------------------
-ProbabilisticImageSimilarity::~ProbabilisticImageSimilarity()
+HistogramImageSimilarity::~HistogramImageSimilarity()
 {
   if (_SamplesOwner) Delete(_Samples);
   Delete(_Histogram);
@@ -155,7 +155,7 @@ ProbabilisticImageSimilarity::~ProbabilisticImageSimilarity()
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-bool ProbabilisticImageSimilarity::SetWithPrefix(const char *param, const char *value)
+bool HistogramImageSimilarity::SetWithPrefix(const char *param, const char *value)
 {
   if (strcmp(param, "No. of bins") == 0) {
     if (!FromString(value, _NumberOfTargetBins) && _NumberOfTargetBins < 1) return false;
@@ -172,7 +172,7 @@ bool ProbabilisticImageSimilarity::SetWithPrefix(const char *param, const char *
 }
 
 // -----------------------------------------------------------------------------
-ParameterList ProbabilisticImageSimilarity::Parameter() const
+ParameterList HistogramImageSimilarity::Parameter() const
 {
   ParameterList params = ImageSimilarity::Parameter();
   if (_NumberOfTargetBins == _NumberOfSourceBins) {
@@ -189,7 +189,7 @@ ParameterList ProbabilisticImageSimilarity::Parameter() const
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-int ProbabilisticImageSimilarity
+int HistogramImageSimilarity
 ::DefaultNumberOfBins(const BaseImage *image, double min_intensity, double max_intensity)
 {
   if (IsNaN(min_intensity) || IsNaN(max_intensity)) {
@@ -206,7 +206,7 @@ int ProbabilisticImageSimilarity
 }
 
 // -----------------------------------------------------------------------------
-void ProbabilisticImageSimilarity::Initialize()
+void HistogramImageSimilarity::Initialize()
 {
   // Initialize base class
   ImageSimilarity::Initialize();
@@ -259,7 +259,7 @@ void ProbabilisticImageSimilarity::Initialize()
 }
 
 // -----------------------------------------------------------------------------
-void ProbabilisticImageSimilarity::Update(bool gradient)
+void HistogramImageSimilarity::Update(bool gradient)
 {
   // Update base class and moving image(s)
   ImageSimilarity::Update(gradient);
@@ -286,7 +286,7 @@ void ProbabilisticImageSimilarity::Update(bool gradient)
 }
 
 // -----------------------------------------------------------------------------
-void ProbabilisticImageSimilarity::Exclude(const blocked_range3d<int> &region)
+void HistogramImageSimilarity::Exclude(const blocked_range3d<int> &region)
 {
   for (int k = region.pages().begin(); k < region.pages().end(); ++k)
   for (int j = region.rows ().begin(); j < region.rows ().end(); ++j)
@@ -299,7 +299,7 @@ void ProbabilisticImageSimilarity::Exclude(const blocked_range3d<int> &region)
 }
 
 // -----------------------------------------------------------------------------
-void ProbabilisticImageSimilarity::Include(const blocked_range3d<int> &region)
+void HistogramImageSimilarity::Include(const blocked_range3d<int> &region)
 {
   bool changed = false;
   for (int k = region.pages().begin(); k < region.pages().end(); ++k)
@@ -322,7 +322,7 @@ void ProbabilisticImageSimilarity::Include(const blocked_range3d<int> &region)
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-void ProbabilisticImageSimilarity::Print(Indent indent) const
+void HistogramImageSimilarity::Print(Indent indent) const
 {
   ImageSimilarity::Print(indent);
 
@@ -340,7 +340,7 @@ void ProbabilisticImageSimilarity::Print(Indent indent) const
 }
 
 // -----------------------------------------------------------------------------
-void ProbabilisticImageSimilarity::WriteDataSets(const char *p, const char *suffix, bool all) const
+void HistogramImageSimilarity::WriteDataSets(const char *p, const char *suffix, bool all) const
 {
   ImageSimilarity::WriteDataSets(p, suffix, all);
 

--- a/Modules/Registration/src/ImageCovariance.cc
+++ b/Modules/Registration/src/ImageCovariance.cc
@@ -36,14 +36,14 @@ mirtkAutoRegisterEnergyTermMacro(ImageCovariance);
 // -----------------------------------------------------------------------------
 ImageCovariance::ImageCovariance(const char *name)
 :
-  ProbabilisticImageSimilarity(name)
+  HistogramImageSimilarity(name)
 {
 }
 
 // -----------------------------------------------------------------------------
 ImageCovariance::ImageCovariance(const ImageCovariance &other)
 :
-  ProbabilisticImageSimilarity(other)
+  HistogramImageSimilarity(other)
 {
 }
 
@@ -65,7 +65,7 @@ double ImageCovariance::Evaluate()
 // -----------------------------------------------------------------------------
 double ImageCovariance::RawValue(double value) const
 {
-  return -ProbabilisticImageSimilarity::RawValue(value);
+  return -HistogramImageSimilarity::RawValue(value);
 }
 
 

--- a/Modules/Registration/src/IntensityCorrelationRatioXY.cc
+++ b/Modules/Registration/src/IntensityCorrelationRatioXY.cc
@@ -37,7 +37,7 @@ mirtkAutoRegisterEnergyTermMacro(IntensityCorrelationRatioXY);
 IntensityCorrelationRatioXY
 ::IntensityCorrelationRatioXY(const char *name)
 :
-  ProbabilisticImageSimilarity(name)
+  HistogramImageSimilarity(name)
 {
 }
 
@@ -45,7 +45,7 @@ IntensityCorrelationRatioXY
 IntensityCorrelationRatioXY
 ::IntensityCorrelationRatioXY(const IntensityCorrelationRatioXY &other)
 :
-  ProbabilisticImageSimilarity(other)
+  HistogramImageSimilarity(other)
 {
 }
 

--- a/Modules/Registration/src/IntensityCorrelationRatioYX.cc
+++ b/Modules/Registration/src/IntensityCorrelationRatioYX.cc
@@ -37,7 +37,7 @@ mirtkAutoRegisterEnergyTermMacro(IntensityCorrelationRatioYX);
 IntensityCorrelationRatioYX
 ::IntensityCorrelationRatioYX(const char *name)
 :
-  ProbabilisticImageSimilarity(name)
+  HistogramImageSimilarity(name)
 {
 }
 
@@ -45,7 +45,7 @@ IntensityCorrelationRatioYX
 IntensityCorrelationRatioYX
 ::IntensityCorrelationRatioYX(const IntensityCorrelationRatioYX &other)
 :
-  ProbabilisticImageSimilarity(other)
+  HistogramImageSimilarity(other)
 {
 }
 

--- a/Modules/Registration/src/JointImageEntropy.cc
+++ b/Modules/Registration/src/JointImageEntropy.cc
@@ -36,14 +36,14 @@ mirtkAutoRegisterEnergyTermMacro(JointImageEntropy);
 // -----------------------------------------------------------------------------
 JointImageEntropy::JointImageEntropy(const char *name)
 :
-  ProbabilisticImageSimilarity(name)
+  HistogramImageSimilarity(name)
 {
 }
 
 // -----------------------------------------------------------------------------
 JointImageEntropy::JointImageEntropy(const JointImageEntropy &other)
 :
-  ProbabilisticImageSimilarity(other)
+  HistogramImageSimilarity(other)
 {
 }
 
@@ -65,7 +65,7 @@ double JointImageEntropy::Evaluate()
 // -----------------------------------------------------------------------------
 double JointImageEntropy::RawValue(double value) const
 {
-  return -ProbabilisticImageSimilarity::RawValue(value);
+  return -HistogramImageSimilarity::RawValue(value);
 }
 
 

--- a/Modules/Registration/src/LabelConsistency.cc
+++ b/Modules/Registration/src/LabelConsistency.cc
@@ -36,14 +36,14 @@ mirtkAutoRegisterEnergyTermMacro(LabelConsistency);
 // -----------------------------------------------------------------------------
 LabelConsistency::LabelConsistency(const char *name)
 :
-  ProbabilisticImageSimilarity(name)
+  HistogramImageSimilarity(name)
 {
 }
 
 // -----------------------------------------------------------------------------
 LabelConsistency::LabelConsistency(const LabelConsistency &other)
 :
-  ProbabilisticImageSimilarity(other)
+  HistogramImageSimilarity(other)
 {
 }
 
@@ -81,7 +81,7 @@ void LabelConsistency::Initialize()
   }
 
   // Initialize base class
-  ProbabilisticImageSimilarity::Initialize();
+  HistogramImageSimilarity::Initialize();
 }
 
 // =============================================================================

--- a/Modules/Registration/src/MutualImageInformation.cc
+++ b/Modules/Registration/src/MutualImageInformation.cc
@@ -37,7 +37,7 @@ mirtkAutoRegisterEnergyTermMacro(MutualImageInformation);
 MutualImageInformation
 ::MutualImageInformation(const char *name)
 :
-  ProbabilisticImageSimilarity(name)
+  HistogramImageSimilarity(name)
 {
 }
 
@@ -45,7 +45,7 @@ MutualImageInformation
 MutualImageInformation
 ::MutualImageInformation(const MutualImageInformation &other)
 :
-  ProbabilisticImageSimilarity(other)
+  HistogramImageSimilarity(other)
 {
 }
 
@@ -67,7 +67,7 @@ double MutualImageInformation::Evaluate()
 // -----------------------------------------------------------------------------
 double MutualImageInformation::RawValue(double value) const
 {
-  return -ProbabilisticImageSimilarity::RawValue(value);
+  return -HistogramImageSimilarity::RawValue(value);
 }
 
 

--- a/Modules/Registration/src/NormalizedMutualImageInformation.cc
+++ b/Modules/Registration/src/NormalizedMutualImageInformation.cc
@@ -126,7 +126,7 @@ using namespace NormalizedMutualImageInformationUtils;
 NormalizedMutualImageInformation
 ::NormalizedMutualImageInformation(const char *name)
 :
-  ProbabilisticImageSimilarity(name)
+  HistogramImageSimilarity(name)
 {
 }
 
@@ -134,7 +134,7 @@ NormalizedMutualImageInformation
 NormalizedMutualImageInformation
 ::NormalizedMutualImageInformation(const NormalizedMutualImageInformation &other)
 :
-  ProbabilisticImageSimilarity(other)
+  HistogramImageSimilarity(other)
 {
 }
 
@@ -156,7 +156,7 @@ double NormalizedMutualImageInformation::Evaluate()
 // -----------------------------------------------------------------------------
 double NormalizedMutualImageInformation::RawValue(double value) const
 {
-  return 2.0 - ProbabilisticImageSimilarity::RawValue(value);
+  return 2.0 - HistogramImageSimilarity::RawValue(value);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
This is the base class name used by the IRTK. The previous ProbabilisticImageSimiarity name also lead to some confusion whether this was some other kind of probabilistic similarity measure. The name HistogramImageSimilarity should be less confusing.