### PR TITLE
fix: Always store binary data in big-endian order

### DIFF
--- a/Modules/Common/config/Settings.cmake
+++ b/Modules/Common/config/Settings.cmake
@@ -36,8 +36,6 @@
 # @ingroup BasisSettings
 ################################################################################
 
-set(BIG_ENDIAN_CONFIG 0)
-
 basis_set_config_option(WITH_MATLAB_CONFIG "${MATLAB_FOUND}")
 basis_set_config_option(WITH_VTK_CONFIG    "${VTK_FOUND}")
 basis_set_config_option(WITH_ZLIB_CONFIG   "${ZLIB_FOUND}")

--- a/Modules/Common/config/config.h.in
+++ b/Modules/Common/config/config.h.in
@@ -21,9 +21,6 @@
 #define MIRTK_CommonConfig_H
 
 
-/// Whether MIRTK Common module was built on big endian system
-#define MIRTK_Common_BIG_ENDIAN @BIG_ENDIAN_CONFIG@
-
 /// Whether MIRTK Common module was built with MATLAB support
 #define MIRTK_Common_WITH_MATLAB @WITH_MATLAB_CONFIG@
 

--- a/Modules/Common/include/mirtk/Memory.h
+++ b/Modules/Common/include/mirtk/Memory.h
@@ -41,8 +41,24 @@ using std::memmove;
 using std::memcmp;
 using std::swap;
 
+/// Byte order of each word in memory
+enum ByteOrder
+{
+  UnknownByteOrder,
+  LittleEndian,
+  BigEndian
+};
+
+/// Get byte order of this system
+ByteOrder GetByteOrder();
+
+/// Swap bytes of a single word
 void swap16(char *, char *, long);
+
+/// Swap bytes of two word
 void swap32(char *, char *, long);
+
+/// Swap bytes of four word
 void swap64(char *, char *, long);
 
 

--- a/Modules/Common/src/Cifstream.cc
+++ b/Modules/Common/src/Cifstream.cc
@@ -20,7 +20,7 @@
 #include "mirtk/Cifstream.h"
 
 #include "mirtk/Config.h"       // WINDOWS
-#include "mirtk/CommonConfig.h" // MIRTK_Common_BIG_ENDIAN, MIRTK_Common_WITH_ZLIB
+#include "mirtk/CommonConfig.h" // MIRTK_Common_WITH_ZLIB
 #include "mirtk/Memory.h"       // swap16, swap32
 
 #if MIRTK_Common_WITH_ZLIB
@@ -36,13 +36,9 @@ namespace mirtk {
 // -----------------------------------------------------------------------------
 Cifstream::Cifstream(const char *fname)
 :
-  _File(nullptr)
+  _File(nullptr),
+  _Swapped(GetByteOrder() == LittleEndian)
 {
-  #if MIRTK_Common_BIG_ENDIAN
-    _Swapped = false;
-  #else
-    _Swapped = true;
-  #endif
   if (fname) Open(fname);
 }
 

--- a/Modules/Common/src/Cofstream.cc
+++ b/Modules/Common/src/Cofstream.cc
@@ -20,7 +20,7 @@
 #include "mirtk/Cofstream.h"
 
 #include "mirtk/Config.h"       // WINDOWS
-#include "mirtk/CommonConfig.h" // MIRTK_Common_BIG_ENDIAN, MIRTK_Common_WITH_ZLIB
+#include "mirtk/CommonConfig.h" // MIRTK_Common_WITH_ZLIB
 #include "mirtk/Memory.h"       // swap16, swap32
 
 #if MIRTK_Common_WITH_ZLIB
@@ -33,17 +33,14 @@ namespace mirtk {
 
 // -----------------------------------------------------------------------------
 Cofstream::Cofstream(const char *fname)
+:
+  _File(nullptr),
+  #if MIRTK_Common_WITH_ZLIB
+    _ZFile(nullptr),
+  #endif
+  _Compressed(false),
+  _Swapped(GetByteOrder() == LittleEndian)
 {
-  _File = nullptr;
-#if MIRTK_Common_WITH_ZLIB
-  _ZFile = nullptr;
-#endif
-#if MIRTK_Common_BIG_ENDIAN
-  _Swapped = false;
-#else
-  _Swapped = true;
-#endif // MIRTK_Common_BIG_ENDIAN
-  _Compressed = false;
   if (fname) Open(fname);
 }
 

--- a/Modules/Common/src/Memory.cc
+++ b/Modules/Common/src/Memory.cc
@@ -27,6 +27,19 @@ namespace mirtk {
 // Swap bytes
 // ========================================================================
 
+// -----------------------------------------------------------------------------
+// See nifti_short_order implementation
+ByteOrder GetByteOrder()
+{
+  union {
+    unsigned char bb[2];
+    short         ss;
+  } fred;
+  fred.bb[0] = 1;
+  fred.bb[1] = 0;
+  return (fred.ss == 1 ? LittleEndian : BigEndian);
+}
+
 // ------------------------------------------------------------------------
 void swap16(char *a, char *b, long n)
 {

--- a/Modules/Numerics/config/Settings.cmake
+++ b/Modules/Numerics/config/Settings.cmake
@@ -44,8 +44,6 @@ elseif (NOT WITH_ARPACK AND WITH_UMFPACK)
   set(WITH_ARPACK ON CACHE BOOL "Request build with ARPACK library" FORCE)
 endif ()
 
-set(BIG_ENDIAN_CONFIG 0)
-
 basis_set_config_option(WITH_ARPACK_CONFIG  "${ARPACK_FOUND}")
 basis_set_config_option(WITH_UMFPACK_CONFIG "${UMFPACK_FOUND}")
 basis_set_config_option(WITH_MATLAB_CONFIG  "${MATLAB_FOUND}")

--- a/Modules/Numerics/config/config.h.in
+++ b/Modules/Numerics/config/config.h.in
@@ -21,9 +21,6 @@
 #define MIRTK_NumericsConfig_H
 
 
-/// Whether MIRTK Numerics module was built on big endian system
-#define MIRTK_Numerics_BIG_ENDIAN @BIG_ENDIAN_CONFIG@
-
 /// Whether MIRTK Numerics module was built with VTK
 #define MIRTK_Numerics_WITH_VTK @WITH_VTK_CONFIG@
 

--- a/Modules/Numerics/include/mirtk/Matrix.h
+++ b/Modules/Numerics/include/mirtk/Matrix.h
@@ -733,7 +733,7 @@ inline bool Matrix::operator ==(const Matrix &m) const
   const double *ptr1 = m   . RawPointer();
   const double *ptr2 = this->RawPointer();
   for (int i = 0; i < n; ++i, ++ptr1, ++ptr2) {
-    if ((*ptr2) != (*ptr1)) return false;
+    if (!fequal(*ptr2, *ptr1)) return false;
   }
   return true;
 }

--- a/Modules/Numerics/include/mirtk/Vector.h
+++ b/Modules/Numerics/include/mirtk/Vector.h
@@ -678,7 +678,7 @@ inline bool Vector::operator==(const Vector &v) const
 {
   if (_rows != v._rows) return false;
   for (int i = 0; i < _rows; ++i) {
-    if (_vector[i] != v._vector[i]) return false;
+    if (!fequal(_vector[i], v._vector[i])) return false;
   }
   return true;
 }

--- a/Modules/Numerics/test/CMakeLists.txt
+++ b/Modules/Numerics/test/CMakeLists.txt
@@ -22,5 +22,6 @@ macro(add_numerics_test class_name)
 endmacro ()
 
 
+add_numerics_test(Vector)
 add_numerics_test(Matrix)
 add_numerics_test(Polynomial)

--- a/Modules/Numerics/test/testMatrix.cc
+++ b/Modules/Numerics/test/testMatrix.cc
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2016 Imperial College London
+ * Copyright 2013-2016 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -298,6 +298,72 @@ TEST(Matrix, TranslationRotationScalingAndShearingToAffineParameters)
   EXPECT_DOUBLE_EQ( 0.7, sxy);
   EXPECT_DOUBLE_EQ(-1.1, sxz);
   EXPECT_DOUBLE_EQ( 1.5, syz);
+}
+
+// =============================================================================
+// I/O
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+TEST(Matrix, IO)
+{
+  // Using STL streams
+  {
+    // Write matrix to binary file
+    ofstream ofs("testMatrix1.bin", ios::binary);
+    ASSERT_TRUE(ofs.is_open());
+    Matrix m1 = AffineTestMatrix();
+    ofs << m1;
+    ASSERT_FALSE(ofs.fail());
+    ofs.close();
+    ASSERT_FALSE(ofs.is_open());
+    // Read binary file and check first few binary bytes to see if data
+    // is in big-endian order as expected
+    ifstream tmp("testMatrix1.bin", ios::binary);
+    ASSERT_TRUE(tmp.is_open());
+    char buffer[32];
+    tmp.read(buffer, 32);
+    tmp.close();
+    ASSERT_TRUE(strncmp(buffer, "irtkMatrix 4 x 4\n", 17) == 0);
+    EXPECT_EQ(buffer[17], (char) 63); // 3F
+    EXPECT_EQ(buffer[18], (char)234); // EA
+    EXPECT_EQ(buffer[19], (char)109); // 6D
+    // Read matrix from binary file stream
+    ifstream ifs("testMatrix1.bin", ios::binary);
+    ASSERT_TRUE(ifs.is_open());
+    Matrix m2;
+    ifs >> m2;
+    ASSERT_FALSE(ifs.fail());
+    ifs.close();
+    // Check that read matrix is the same that we saved before
+    ASSERT_TRUE(m1 == m2);
+  }
+  // Using MIRTK streams
+  {
+    // Write matrix to binary file
+    Cofstream ofs("testMatrix2.bin");
+    Matrix m1 = AffineTestMatrix();
+    ofs << m1;
+    ofs.Close();
+    // Read binary file and check first few binary bytes to see if data
+    ifstream tmp("testMatrix2.bin", ios::binary);
+    ASSERT_TRUE(tmp.is_open());
+    char buffer[32];
+    tmp.read(buffer, 32);
+    tmp.close();
+    ASSERT_TRUE(strncmp(buffer, "irtkMatrix", 11) == 0);
+    EXPECT_EQ(buffer[14], (char)4);
+    EXPECT_EQ(buffer[18], (char)4);
+    EXPECT_EQ(buffer[19], (char) 63); // 3F
+    EXPECT_EQ(buffer[20], (char)234); // EA
+    EXPECT_EQ(buffer[21], (char)109); // 6D
+    // Read matrix from binary file again
+    Cifstream ifs("testMatrix2.bin");
+    Matrix m2;
+    ifs >> m2;
+    ifs.Close();
+    ASSERT_TRUE(m1 == m2);
+  }
 }
 
 // =============================================================================

--- a/Modules/Numerics/test/testVector.cc
+++ b/Modules/Numerics/test/testVector.cc
@@ -1,0 +1,121 @@
+/*
+ * Medical Image Registration ToolKit (MIRTK)
+ *
+ * Copyright 2016 Imperial College London
+ * Copyright 2016 Andreas Schuh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "NumericsTest.h"
+
+#include "mirtk/Vector.h"
+using namespace mirtk;
+
+
+// =============================================================================
+// Auxiliary functions
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+Vector IncreasingTestVector(int n = 10)
+{
+  Vector v(n);
+  for (int i = 0; i < n; ++i) v(i) = double(i+1);
+  return v;
+}
+
+// =============================================================================
+// I/O
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+TEST(Vector, IO)
+{
+  // Using STL streams
+  {
+    // Write vector to binary file
+    ofstream ofs("testVector1.bin", ios::binary);
+    ASSERT_TRUE(ofs.is_open());
+    Vector v1 = IncreasingTestVector(10);
+    ofs << v1;
+    ASSERT_FALSE(ofs.fail());
+    ofs.close();
+    ASSERT_FALSE(ofs.is_open());
+    // Read binary file and check first few binary bytes to see if data
+    // is in big-endian order as expected
+    ifstream tmp("testVector1.bin", ios::binary);
+    ASSERT_TRUE(tmp.is_open());
+    char buffer[64];
+    tmp.read(buffer, 64);
+    tmp.close();
+    ASSERT_TRUE(strncmp(buffer, "irtkVector 10\n", 14) == 0);
+    EXPECT_EQ((char)63,  buffer[14]);
+    EXPECT_EQ((char)240, buffer[15]);
+    EXPECT_EQ((char)64,  buffer[22]);
+    EXPECT_EQ((char)0,   buffer[23]);
+    EXPECT_EQ((char)64,  buffer[30]);
+    EXPECT_EQ((char)8,   buffer[31]);
+    // Read vector from binary file stream
+    ifstream ifs("testVector1.bin", ios::binary);
+    ASSERT_TRUE(ifs.is_open());
+    Vector v2;
+    ifs >> v2;
+    ASSERT_FALSE(ifs.fail());
+    ifs.close();
+    // Check that read vector is the same that we saved before
+    ASSERT_TRUE(v1 == v2);
+  }
+  // Using MIRTK streams
+  {
+    // Write vector to binary file
+    Cofstream ofs("testVector2.bin");
+    Vector v1 = IncreasingTestVector(10);
+    ofs << v1;
+    ofs.Close();
+    // Read binary file and check first few binary bytes to see if data
+    ifstream tmp("testVector2.bin", ios::binary);
+    ASSERT_TRUE(tmp.is_open());
+    char buffer[64];
+    tmp.read(buffer, 64);
+    tmp.close();
+    ASSERT_TRUE(strncmp(buffer, "irtkVector", 11) == 0);
+    EXPECT_EQ((char)0,   buffer[11]);
+    EXPECT_EQ((char)0,   buffer[12]);
+    EXPECT_EQ((char)0,   buffer[13]);
+    EXPECT_EQ((char)10,  buffer[14]);
+    EXPECT_EQ((char)63,  buffer[15]);
+    EXPECT_EQ((char)240, buffer[16]);
+    EXPECT_EQ((char)64,  buffer[23]);
+    EXPECT_EQ((char)0,   buffer[24]);
+    EXPECT_EQ((char)64,  buffer[31]);
+    EXPECT_EQ((char)8,   buffer[32]);
+    // Read vector from binary file again
+    Cifstream ifs("testVector2.bin");
+    Vector v2;
+    ifs >> v2;
+    ifs.Close();
+    ASSERT_TRUE(v1 == v2);
+  }
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+int main(int argc, char *argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Check endianness of machine at runtime and swap bytes if necessary to store them in big endianness order. Unit tests for vector/matrix IO functions to be added to this PR soon.

Closes #217.