### PR TITLE
fix: Remove non-working Docker image layers badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ Medical Image Registration ToolKit
 ==================================
 
 [![Build Status](https://travis-ci.org/BioMedIA/MIRTK.svg?branch=master)](https://travis-ci.org/BioMedIA/MIRTK)
-[![](https://badge.imagelayers.io/biomedia/mirtk:latest.svg)](https://imagelayers.io/?images=biomedia/mirtk:latest)
 &nbsp;
 [![Join the chat at https://gitter.im/BioMedIA/MIRTK](https://badges.gitter.im/BioMedIA/MIRTK.svg)](https://gitter.im/BioMedIA/MIRTK?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/240)
<!-- Reviewable:end -->
