### PR TITLE
enh: Use also Clang compiler for Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: cpp
-compiler: g++
+
+compiler:
+  - g++
+  - clang
 
 os:
   - linux
@@ -10,9 +13,6 @@ sudo: required
 
 before_install: Testing/Travis/before_install.sh
 script:         Testing/Travis/script.sh
-
-env:
-  - tests=off
 
 notifications:
   email: false


### PR DESCRIPTION
Remove `tests=off` environment variable from `.travis.yml`. Instead, set this variable in the [Settings](https://travis-ci.org/BioMedIA/MIRTK/settings).