### PR TITLE
doc: Fix reference to renamed VolumetricMapping module [ChangeLog]

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -30,7 +30,7 @@ Release 1.0.0 (Jan 15)
 ~~~~~~~~~~~~~~~~~~~~~~
 
 - First stable release of the refactored IRTK support libraries and new :doc:`Registration framework </modules/registration>`.
-- Includes extension packages for :doc:`volumetric mapping </modules/volumetricmapping>` and a :doc:`deformable surface framework </modules/deformable>`.
+- Includes extension packages for :doc:`volumetric mapping </modules/mapping>` and a :doc:`deformable surface framework </modules/deformable>`.
 
 
 .. _v1.0rc2:


### PR DESCRIPTION
Also related to PR #266.