### PR TITLE
fix: Make convert-mris work with both VTK 5 and >=6 [Applications]

### DIFF
--- a/Applications/src/convert-mris.py
+++ b/Applications/src/convert-mris.py
@@ -78,7 +78,10 @@ def convert_mris(input_name, output_name):
   if output_name.endswith('.vtp'): writer = vtkXMLPolyDataWriter()
   else:                            writer = vtkPolyDataWriter()
   writer.SetFileName(output_name)
-  writer.SetInput(surface)
+  try:
+    writer.SetInputData(surface)
+  except:
+    writer.SetInput(surface)
   writer.Write()
   if temp_name != output_name:
     remove(temp_name)


### PR DESCRIPTION
Modify `convert-mris` script so it works either with VTK 5 or VTK 6/7.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/271)
<!-- Reviewable:end -->
