### PR TITLE
enh: Rename unique_ptr to UniquePtr, and shared_ptr to SharedPtr

### DIFF
--- a/Applications/src/average-dofs.cc
+++ b/Applications/src/average-dofs.cc
@@ -402,7 +402,7 @@ int main(int argc, char **argv)
 
   // Average displacement fields sampled in specified target image domain
   if (!avgdofs && target_name) {
-    unique_ptr<BaseImage> target(BaseImage::New(target_name));
+    UniquePtr<BaseImage> target(BaseImage::New(target_name));
     attr = target->GetImageAttributes();
   // Otherwise, determine common type of local input transformations
   // if a mix of transformations is given, use attributes of first FFD
@@ -411,7 +411,7 @@ int main(int argc, char **argv)
     if (verbose) cout << "Checking type of input transformations...", cout.flush();
     for (size_t i = 0; i < dofin.size(); ++i) {
       if (dofin[i] == identity_name) continue;
-      unique_ptr<Transformation> t(Transformation::New(dofin[i].c_str()));
+      UniquePtr<Transformation> t(Transformation::New(dofin[i].c_str()));
       Transformation           *p    = t.get();
       MultiLevelTransformation *mffd = dynamic_cast<MultiLevelTransformation *>(t.get());
       if (mffd) {
@@ -496,7 +496,7 @@ int main(int argc, char **argv)
   for (size_t i = 0; i < dofin.size(); ++i) {
     if (dofin[i] == identity_name) continue;
     // Read transformation from file
-    unique_ptr<Transformation> t(Transformation::New(dofin[i].c_str()));
+    UniquePtr<Transformation> t(Transformation::New(dofin[i].c_str()));
     // Determine actual type of transformation
     HomogeneousTransformation   *global     = NULL;
     RigidTransformation         *rigid      = NULL;

--- a/Applications/src/bisect-dof.cc
+++ b/Applications/src/bisect-dof.cc
@@ -51,7 +51,7 @@ void PrintHelp(const char *name)
 int main(int argc, char *argv[])
 {
   REQUIRES_POSARGS(2);
-  unique_ptr<Transformation> dof(Transformation::New(POSARG(1)));
+  UniquePtr<Transformation> dof(Transformation::New(POSARG(1)));
   HomogeneousTransformation *lin = dynamic_cast<HomogeneousTransformation *>(dof.get());
   if (!lin) {
     FatalError("Input transformation must be either Rigid, Similarity, or Affine");

--- a/Applications/src/calculate-exponential-map.cc
+++ b/Applications/src/calculate-exponential-map.cc
@@ -138,14 +138,14 @@ int main(int argc, char **argv)
   }
 
   // Read input velocities
-  unique_ptr<RealImage> v;
+  UniquePtr<RealImage> v;
 
   if (velo_fname) {
     v.reset(new RealImage(velo_fname));
   } else {
     RealImage vx(vx_fname);
     RealImage vy(vy_fname);
-    unique_ptr<RealImage> vz(vz_fname ? new RealImage(vz_fname) : nullptr);
+    UniquePtr<RealImage> vz(vz_fname ? new RealImage(vz_fname) : nullptr);
 
     ImageAttributes attr = vx.Attributes();
     if (attr._t > 1) {
@@ -168,7 +168,7 @@ int main(int argc, char **argv)
   }
 
   // Instantiate filter which implements the desired integration method
-  unique_ptr<VelocityToDisplacementField<RealPixel> > vtod;
+  UniquePtr<VelocityToDisplacementField<RealPixel> > vtod;
 
   if (strcmp(IntegrationMethod, "SS") == 0) {
     vtod.reset(new VelocityToDisplacementFieldSS<RealPixel>());

--- a/Applications/src/calculate-lie-bracket.cc
+++ b/Applications/src/calculate-lie-bracket.cc
@@ -124,14 +124,14 @@ int main(int argc, char **argv)
   }
 
   // Read input vector fields
-  unique_ptr<ImageType> x, y;
+  UniquePtr<ImageType> x, y;
 
   if (x_fname) {
     x.reset(new ImageType(x_fname));
   } else {
     ImageType xx(xx_fname);
     ImageType xy(xy_fname);
-    unique_ptr<ImageType> xz(xz_fname ? new ImageType(xz_fname) : NULL);
+    UniquePtr<ImageType> xz(xz_fname ? new ImageType(xz_fname) : NULL);
 
     ImageAttributes attr = xx.Attributes();
     if (attr._t > 1) {
@@ -160,7 +160,7 @@ int main(int argc, char **argv)
   } else {
     ImageType yx(yx_fname);
     ImageType yy(yy_fname);
-    unique_ptr<Image> yz(yz_fname ? new ImageType(yz_fname) : NULL);
+    UniquePtr<Image> yz(yz_fname ? new ImageType(yz_fname) : NULL);
 
     ImageAttributes attr = yx.Attributes();
     if (attr._t > 1) {

--- a/Applications/src/calculate-logarithmic-map.cc
+++ b/Applications/src/calculate-logarithmic-map.cc
@@ -150,14 +150,14 @@ int main(int argc, char *argv[])
   }
 
   // Read input displacements
-  unique_ptr<RealImage> d;
+  UniquePtr<RealImage> d;
 
   if (disp_fname) {
     d.reset(new RealImage(disp_fname));
   } else {
     RealImage dx(dx_fname);
     RealImage dy(dy_fname);
-    unique_ptr<RealImage> dz(dz_fname ? new RealImage(dz_fname) : nullptr);
+    UniquePtr<RealImage> dz(dz_fname ? new RealImage(dz_fname) : nullptr);
 
     ImageAttributes attr = dx.Attributes();
     if (attr._t > 1) {
@@ -179,7 +179,7 @@ int main(int argc, char *argv[])
   }
 
   // Instantiate exponential filter
-  unique_ptr<VelocityToDisplacementField<RealPixel> > exp;
+  UniquePtr<VelocityToDisplacementField<RealPixel> > exp;
   if (strcmp(IntegrationMethod, "SS") == 0) {
     exp.reset(new VelocityToDisplacementFieldSS<RealPixel>());
   } else if (strcmp(IntegrationMethod, "RKE1")         == 0 ||

--- a/Applications/src/calculate-surface-spectrum.cc
+++ b/Applications/src/calculate-surface-spectrum.cc
@@ -310,7 +310,7 @@ int main(int argc, char *argv[])
 
   // Transform first surface by specified transformation
   if (dofin_name) {
-    unique_ptr<Transformation> dof(Transformation::New(dofin_name));
+    UniquePtr<Transformation> dof(Transformation::New(dofin_name));
     RegisteredSurface transformed;
     transformed.InputSurface(surface[0]);
     transformed.Transformation(dof.get());
@@ -399,7 +399,7 @@ int main(int argc, char *argv[])
     target.Update();
     source.Update();
 
-    unique_ptr<PointCorrespondence> cmap(PointCorrespondence::New(ctype));
+    UniquePtr<PointCorrespondence> cmap(PointCorrespondence::New(ctype));
     cmap->FromTargetToSource(true);
     cmap->FromSourceToTarget(true);
     cmap->Parameter(cparam);

--- a/Applications/src/calculate.cc
+++ b/Applications/src/calculate.cc
@@ -345,7 +345,7 @@ int main(int argc, char **argv)
   Array<string> header;
   Array<string> prefix;
 
-  Array<unique_ptr<Op> > ops;
+  Array<UniquePtr<Op> > ops;
 
   for (ARGUMENTS_AFTER(1)) {
     if (OPTION("-append")) {
@@ -365,7 +365,7 @@ int main(int argc, char **argv)
       while (HAS_ARGUMENT) header.push_back(ARGUMENT);
     // Masking
     } else if (OPTION("-label")) {
-      ops.push_back(unique_ptr<Op>(new ResetMask(true)));
+      ops.push_back(UniquePtr<Op>(new ResetMask(true)));
       do {
         const char *arg = ARGUMENT;
         const Array<string> parts = Split(arg, "..");
@@ -382,160 +382,160 @@ int main(int argc, char **argv)
         if (IsNaN(a) || IsNaN(b)) {
           FatalError("Invalid -label argument: " << arg);
         }
-        ops.push_back(unique_ptr<Op>(new MaskInsideInterval(a, b)));
+        ops.push_back(UniquePtr<Op>(new MaskInsideInterval(a, b)));
       } while (HAS_ARGUMENT);
-      ops.push_back(unique_ptr<Op>(new InvertMask()));
+      ops.push_back(UniquePtr<Op>(new InvertMask()));
     } else if (OPTION("-mask-all")) {
-      ops.push_back(unique_ptr<Op>(new ResetMask(false)));
+      ops.push_back(UniquePtr<Op>(new ResetMask(false)));
     } else if (OPTION("-reset-mask")) {
-      ops.push_back(unique_ptr<Op>(new ResetMask(true)));
+      ops.push_back(UniquePtr<Op>(new ResetMask(true)));
     } else if (OPTION("-invert-mask")) {
-      ops.push_back(unique_ptr<Op>(new InvertMask()));
+      ops.push_back(UniquePtr<Op>(new InvertMask()));
     } else if (OPTION("-mask")) {
       double c;
       do {
         const char *arg = ARGUMENT;
-        if (FromString(arg, c)) ops.push_back(unique_ptr<Op>(new Mask(c)));
-        else                    ops.push_back(unique_ptr<Op>(new Mask(arg)));
+        if (FromString(arg, c)) ops.push_back(UniquePtr<Op>(new Mask(c)));
+        else                    ops.push_back(UniquePtr<Op>(new Mask(arg)));
       } while (HAS_ARGUMENT);
     } else if (OPTION("-threshold-outside") || OPTION("-mask-outside")) {
       PARSE_ARGUMENT(a);
       PARSE_ARGUMENT(b);
-      ops.push_back(unique_ptr<Op>(new MaskOutsideOpenInterval(a, b)));
+      ops.push_back(UniquePtr<Op>(new MaskOutsideOpenInterval(a, b)));
     } else if (OPTION("-threshold-outside-percentiles") || OPTION("-threshold-outside-pcts") ||
                OPTION("-mask-outside-percentiles")      || OPTION("-mask-outside-pcts")) {
       PARSE_ARGUMENT(p);
       Statistic *a = new Percentile(p);
       a->Hidden(verbose < 1);
-      ops.push_back(unique_ptr<Op>(a));
+      ops.push_back(UniquePtr<Op>(a));
       PARSE_ARGUMENT(p);
       Statistic *b = new Percentile(p);
       b->Hidden(verbose < 1);
-      ops.push_back(unique_ptr<Op>(b));
+      ops.push_back(UniquePtr<Op>(b));
       Op *op = new MaskOutsideOpenInterval(&a->Value(), &b->Value());
-      ops.push_back(unique_ptr<Op>(op));
+      ops.push_back(UniquePtr<Op>(op));
     } else if (OPTION("-threshold")) {
       PARSE_ARGUMENT(a);
       if (HAS_ARGUMENT) PARSE_ARGUMENT(b);
       else b = inf;
-      ops.push_back(unique_ptr<Op>(new MaskOutsideInterval(a, b)));
+      ops.push_back(UniquePtr<Op>(new MaskOutsideInterval(a, b)));
     } else if (OPTION("-percentile-threshold") || OPTION("-pct-threshold")) {
       PARSE_ARGUMENT(p);
       Statistic *a = new Percentile(p);
       a->Hidden(verbose < 1);
-      ops.push_back(unique_ptr<Op>(a));
+      ops.push_back(UniquePtr<Op>(a));
       Op *op = new MaskOutsideInterval(&a->Value(), inf);
-      ops.push_back(unique_ptr<Op>(op));
+      ops.push_back(UniquePtr<Op>(op));
     } else if (OPTION("-threshold-percentiles") || OPTION("-threshold-pcts")) {
       PARSE_ARGUMENT(p);
       Statistic *a = new Percentile(p);
       a->Hidden(verbose < 1);
-      ops.push_back(unique_ptr<Op>(a));
+      ops.push_back(UniquePtr<Op>(a));
       PARSE_ARGUMENT(p);
       Statistic *b = new Percentile(p);
       b->Hidden(verbose < 1);
-      ops.push_back(unique_ptr<Op>(b));
+      ops.push_back(UniquePtr<Op>(b));
       Op *op = new MaskOutsideInterval(&a->Value(), &b->Value());
-      ops.push_back(unique_ptr<Op>(op));
+      ops.push_back(UniquePtr<Op>(op));
     } else if (OPTION("-threshold-inside") || OPTION("-mask-inside")) {
       PARSE_ARGUMENT(a);
       PARSE_ARGUMENT(b);
-      ops.push_back(unique_ptr<Op>(new MaskInsideInterval(a, b)));
+      ops.push_back(UniquePtr<Op>(new MaskInsideInterval(a, b)));
     } else if (OPTION("-threshold-inside-percentiles") || OPTION("-threshold-inside-pcts") ||
                OPTION("-mask-inside-percentiles")      || OPTION("-mask-inside-pcts")) {
       PARSE_ARGUMENT(p);
       Statistic *a = new Percentile(p);
       a->Hidden(verbose < 1);
-      ops.push_back(unique_ptr<Op>(a));
+      ops.push_back(UniquePtr<Op>(a));
       PARSE_ARGUMENT(p);
       Statistic *b = new Percentile(p);
       b->Hidden(verbose < 1);
-      ops.push_back(unique_ptr<Op>(b));
+      ops.push_back(UniquePtr<Op>(b));
       Op *op = new MaskInsideInterval(&a->Value(), &b->Value());
-      ops.push_back(unique_ptr<Op>(op));
+      ops.push_back(UniquePtr<Op>(op));
     } else if (OPTION("-threshold-lt") || OPTION("-lower-threshold") || OPTION("-mask-lt")) {
       PARSE_ARGUMENT(a);
-      ops.push_back(unique_ptr<Op>(new MaskOutsideInterval(a, inf)));
+      ops.push_back(UniquePtr<Op>(new MaskOutsideInterval(a, inf)));
     } else if (OPTION("-threshold-lt-percentile")    || OPTION("-threshold-lt-pct") ||
                OPTION("-lower-percentile-threshold") || OPTION("-lower-pct-threshold") ||
                OPTION("-mask-lt-percentile")         || OPTION("-mask-lt-pct")) {
       PARSE_ARGUMENT(p);
       Statistic *a = new Percentile(p);
       a->Hidden(verbose < 1);
-      ops.push_back(unique_ptr<Op>(a));
-      ops.push_back(unique_ptr<Op>(new MaskOutsideInterval(&a->Value(), inf)));
+      ops.push_back(UniquePtr<Op>(a));
+      ops.push_back(UniquePtr<Op>(new MaskOutsideInterval(&a->Value(), inf)));
     } else if (OPTION("-threshold-le") || OPTION("-mask-below") || OPTION("-mask-le")) {
       PARSE_ARGUMENT(a);
-      ops.push_back(unique_ptr<Op>(new MaskOutsideOpenInterval(a, inf)));
+      ops.push_back(UniquePtr<Op>(new MaskOutsideOpenInterval(a, inf)));
     } else if (OPTION("-threshold-le-percentile") || OPTION("-threshold-le-pct") ||
                OPTION("-mask-below-percentile")   || OPTION("-mask-below-pct") ||
                OPTION("-mask-le-percentile")      || OPTION("-mask-le-pct")) {
       PARSE_ARGUMENT(p);
       Statistic *a = new Percentile(p);
       a->Hidden(verbose < 1);
-      ops.push_back(unique_ptr<Op>(a));
-      ops.push_back(unique_ptr<Op>(new MaskOutsideOpenInterval(&a->Value(), inf)));
+      ops.push_back(UniquePtr<Op>(a));
+      ops.push_back(UniquePtr<Op>(new MaskOutsideOpenInterval(&a->Value(), inf)));
     } else if (OPTION("-threshold-ge") || OPTION("-mask-above") || OPTION("-mask-ge")) {
       PARSE_ARGUMENT(b);
-      ops.push_back(unique_ptr<Op>(new MaskOutsideOpenInterval(-inf, b)));
+      ops.push_back(UniquePtr<Op>(new MaskOutsideOpenInterval(-inf, b)));
     } else if (OPTION("-threshold-ge-percentile") || OPTION("-threshold-ge-pct") ||
                OPTION("-mask-above-percentile")   || OPTION("-mask-above-pct") ||
                OPTION("-mask-ge-percentile")      || OPTION("-mask-ge-pct")) {
       PARSE_ARGUMENT(p);
       Statistic *b = new Percentile(p);
       b->Hidden(verbose < 1);
-      ops.push_back(unique_ptr<Op>(b));
-      ops.push_back(unique_ptr<Op>(new MaskOutsideOpenInterval(-inf, &b->Value())));
+      ops.push_back(UniquePtr<Op>(b));
+      ops.push_back(UniquePtr<Op>(new MaskOutsideOpenInterval(-inf, &b->Value())));
     } else if (OPTION("-threshold-gt") || OPTION("-upper-threshold") || OPTION("-mask-gt")) {
       PARSE_ARGUMENT(b);
-      ops.push_back(unique_ptr<Op>(new MaskOutsideInterval(-inf, b)));
+      ops.push_back(UniquePtr<Op>(new MaskOutsideInterval(-inf, b)));
     } else if (OPTION("-threshold-gt-percentile")    || OPTION("-threshold-gt-pct") ||
                OPTION("-upper-percentile-threshold") || OPTION("-upper-pct-threshold") ||
                OPTION("-mask-gt-percentile")         || OPTION("-mask-gt-pct")) {
       PARSE_ARGUMENT(p);
       Statistic *b = new Percentile(p);
       b->Hidden(verbose < 1);
-      ops.push_back(unique_ptr<Op>(b));
-      ops.push_back(unique_ptr<Op>(new MaskOutsideInterval(-inf, &b->Value())));
+      ops.push_back(UniquePtr<Op>(b));
+      ops.push_back(UniquePtr<Op>(new MaskOutsideInterval(-inf, &b->Value())));
     } else if (OPTION("-even")) {
-      ops.push_back(unique_ptr<Op>(new MaskOddValues()));
+      ops.push_back(UniquePtr<Op>(new MaskOddValues()));
     } else if (OPTION("-odd")) {
-      ops.push_back(unique_ptr<Op>(new MaskEvenValues()));
+      ops.push_back(UniquePtr<Op>(new MaskEvenValues()));
     // Clamping
     } else if (OPTION("-clamp")) {
       PARSE_ARGUMENT(a);
       PARSE_ARGUMENT(b);
-      ops.push_back(unique_ptr<Op>(new Clamp(a, b)));
+      ops.push_back(UniquePtr<Op>(new Clamp(a, b)));
     } else if (OPTION("-clamp-percentiles") || OPTION("-clamp-pcts")) {
       PARSE_ARGUMENT(p);
       Statistic *a = new Percentile(p);
       a->Hidden(verbose < 1);
-      ops.push_back(unique_ptr<Op>(a));
+      ops.push_back(UniquePtr<Op>(a));
       PARSE_ARGUMENT(p);
       Statistic *b = new Percentile(p);
       b->Hidden(verbose < 1);
-      ops.push_back(unique_ptr<Op>(b));
-      ops.push_back(unique_ptr<Op>(new Clamp(&a->Value(), &b->Value())));
+      ops.push_back(UniquePtr<Op>(b));
+      ops.push_back(UniquePtr<Op>(new Clamp(&a->Value(), &b->Value())));
     } else if (OPTION("-clamp-lt") || OPTION("-clamp-below")) {
       PARSE_ARGUMENT(a);
-      ops.push_back(unique_ptr<Op>(new LowerThreshold(a)));
+      ops.push_back(UniquePtr<Op>(new LowerThreshold(a)));
     } else if (OPTION("-clamp-lt-percentile")    || OPTION("-clamp-lt-pct") ||
                OPTION("-clamp-below-percentile") || OPTION("-clamp-below-pct")) {
       PARSE_ARGUMENT(p);
       Statistic *a = new Percentile(p);
       a->Hidden(verbose < 1);
-      ops.push_back(unique_ptr<Op>(a));
-      ops.push_back(unique_ptr<Op>(new LowerThreshold(&a->Value())));
+      ops.push_back(UniquePtr<Op>(a));
+      ops.push_back(UniquePtr<Op>(new LowerThreshold(&a->Value())));
     } else if (OPTION("-clamp-gt") || OPTION("-clamp-above")) {
       PARSE_ARGUMENT(b);
-      ops.push_back(unique_ptr<Op>(new UpperThreshold(b)));
+      ops.push_back(UniquePtr<Op>(new UpperThreshold(b)));
     } else if (OPTION("-clamp-gt-percentile")    || OPTION("-clamp-gt-pct") ||
                OPTION("-clamp-above-percentile") || OPTION("-clamp-above-pct")) {
       PARSE_ARGUMENT(p);
       Statistic *b = new Percentile(p);
       b->Hidden(verbose < 1);
-      ops.push_back(unique_ptr<Op>(b));
-      ops.push_back(unique_ptr<Op>(new UpperThreshold(&b->Value())));
+      ops.push_back(UniquePtr<Op>(b));
+      ops.push_back(UniquePtr<Op>(new UpperThreshold(&b->Value())));
     } else if (OPTION("-rescale")) {
       double min, max;
       if (!FromString(ARGUMENT, min)) {
@@ -546,50 +546,50 @@ int main(int argc, char **argv)
         cerr << "Invalid -rescale maximum, must be a number!" << endl;
         exit(1);
       }
-      ops.push_back(unique_ptr<Op>(new Rescale(min, max)));
+      ops.push_back(UniquePtr<Op>(new Rescale(min, max)));
     } else if (OPTION("-set") || OPTION("-inside")) {
       double inside_value;
       if (!FromString(ARGUMENT, inside_value)) {
         cerr << "Invalid -inside value, must be a number!" << endl;
         exit(1);
       }
-      ops.push_back(unique_ptr<Op>(new SetInsideValue(inside_value)));
+      ops.push_back(UniquePtr<Op>(new SetInsideValue(inside_value)));
     } else if (OPTION("-pad") || OPTION("-outside")) {
       double outside_value;
       if (!FromString(ARGUMENT, outside_value)) {
         cerr << "Invalid -outside value, must be a number!" << endl;
         exit(1);
       }
-      ops.push_back(unique_ptr<Op>(new SetOutsideValue(outside_value)));
+      ops.push_back(UniquePtr<Op>(new SetOutsideValue(outside_value)));
     // Data transformations
     } else if (OPTION("-binarize")) {
       PARSE_ARGUMENT(a);
       if (HAS_ARGUMENT) PARSE_ARGUMENT(b);
       else b = inf;
-      ops.push_back(unique_ptr<Op>(new Binarize(a, b)));
+      ops.push_back(UniquePtr<Op>(new Binarize(a, b)));
     } else if (OPTION("-add") || OPTION("-plus") || OPTION("+")) {
       const char *arg = ARGUMENT;
       double c;
       if (FromString(arg, c)) {
-        ops.push_back(unique_ptr<Op>(new Add(c)));
+        ops.push_back(UniquePtr<Op>(new Add(c)));
       } else {
-        ops.push_back(unique_ptr<Op>(new Add(arg)));
+        ops.push_back(UniquePtr<Op>(new Add(arg)));
       }
     } else if (OPTION("-sub") || OPTION("-subtract") || OPTION("-minus") || OPTION("-")) {
       const char *arg = ARGUMENT;
       double c;
       if (FromString(arg, c)) {
-        ops.push_back(unique_ptr<Op>(new Sub(c)));
+        ops.push_back(UniquePtr<Op>(new Sub(c)));
       } else {
-        ops.push_back(unique_ptr<Op>(new Sub(arg)));
+        ops.push_back(UniquePtr<Op>(new Sub(arg)));
       }
     } else if (OPTION("-mul") || OPTION("-multiply-by") || OPTION("-times") || OPTION("*")) {
       const char *arg = ARGUMENT;
       double c;
       if (FromString(arg, c)) {
-        ops.push_back(unique_ptr<Op>(new Mul(c)));
+        ops.push_back(UniquePtr<Op>(new Mul(c)));
       } else {
-        ops.push_back(unique_ptr<Op>(new Mul(arg)));
+        ops.push_back(UniquePtr<Op>(new Mul(arg)));
       }
     } else if (OPTION("-div") || OPTION("-divide-by") || OPTION("-over") || OPTION("/")) {
       const char *arg = ARGUMENT;
@@ -599,14 +599,14 @@ int main(int argc, char **argv)
           cerr << "Invalid -div argument, value must not be zero!" << endl;
           exit(1);
         }
-        ops.push_back(unique_ptr<Op>(new Div(c)));
+        ops.push_back(UniquePtr<Op>(new Div(c)));
       } else {
-        ops.push_back(unique_ptr<Op>(new Div(arg)));
+        ops.push_back(UniquePtr<Op>(new Div(arg)));
       }
     } else if (OPTION("-div-with-zero")) {
-      ops.push_back(unique_ptr<Op>(new DivWithZero(ARGUMENT)));
+      ops.push_back(UniquePtr<Op>(new DivWithZero(ARGUMENT)));
     } else if (OPTION("-abs")) {
-      ops.push_back(unique_ptr<Op>(new Abs()));
+      ops.push_back(UniquePtr<Op>(new Abs()));
     } else if (OPTION("-pow") || OPTION("-power")) {
       const char *arg = ARGUMENT;
       double exponent;
@@ -614,13 +614,13 @@ int main(int argc, char **argv)
         cerr << "Invalid -power value, must be a number!" << endl;
         exit(1);
       }
-      ops.push_back(unique_ptr<Op>(new Pow(exponent)));
+      ops.push_back(UniquePtr<Op>(new Pow(exponent)));
     } else if (OPTION("-sqrt")) {
-      ops.push_back(unique_ptr<Op>(new Pow(.5)));
+      ops.push_back(UniquePtr<Op>(new Pow(.5)));
     } else if (OPTION("-square") || OPTION("-sq")) {
-      ops.push_back(unique_ptr<Op>(new Pow(2.0)));
+      ops.push_back(UniquePtr<Op>(new Pow(2.0)));
     } else if (OPTION("-exp")) {
-      ops.push_back(unique_ptr<Op>(new Exp()));
+      ops.push_back(UniquePtr<Op>(new Exp()));
     } else if (OPTION("-log") || OPTION("-log2") || OPTION("-loge") || OPTION("-log10") || OPTION("-lb") || OPTION("-ln") || OPTION("-lg")) {
       a = numeric_limits<double>::min();
       if (HAS_ARGUMENT) {
@@ -654,7 +654,7 @@ int main(int argc, char **argv)
       } else if (strcmp(OPTNAME, "-loge")  == 0 || strcmp(OPTNAME, "-ln") == 0) {
         op = new Ln(a);
       }
-      ops.push_back(unique_ptr<Op>(op));
+      ops.push_back(UniquePtr<Op>(op));
     } else if (OPTION("-o") || OPTION("-out") || OPTION("-output") || OPTION("=")) {
       const char *fname = ARGUMENT;
       int dtype = datatype;
@@ -667,34 +667,34 @@ int main(int argc, char **argv)
         }
       }
       #if MIRTK_Image_WITH_VTK
-        ops.push_back(unique_ptr<Op>(new Write(fname, dtype, attr, dataset, scalars_name)));
+        ops.push_back(UniquePtr<Op>(new Write(fname, dtype, attr, dataset, scalars_name)));
       #else
-        ops.push_back(unique_ptr<Op>(new Write(fname, dtype, attr)));
+        ops.push_back(UniquePtr<Op>(new Write(fname, dtype, attr)));
       #endif
     // Data statistics
     } else if (OPTION("-mean") || OPTION("-average") || OPTION("-avg")) {
-      ops.push_back(unique_ptr<Op>(new Mean()));
+      ops.push_back(UniquePtr<Op>(new Mean()));
     } else if (OPTION("-sigma") || OPTION("-stddev") || OPTION("-stdev") || OPTION("-std") || OPTION("-sd")) {
-      ops.push_back(unique_ptr<Op>(new StDev()));
+      ops.push_back(UniquePtr<Op>(new StDev()));
     } else if (OPTION("-normal-distribution") ||
                OPTION("-mean+sigma") || OPTION("-mean+stddev") || OPTION("-mean+stdev") || OPTION("-mean+std") || OPTION("-mean+sd") ||
                OPTION("-avg+sigma")  || OPTION("-avg+stddev")  || OPTION("-avg+stdev")  || OPTION("-avg+std")  || OPTION("-avg+sd")) {
-      ops.push_back(unique_ptr<Op>(new NormalDistribution()));
+      ops.push_back(UniquePtr<Op>(new NormalDistribution()));
     } else if (OPTION("-variance") || OPTION("-var")) {
-      ops.push_back(unique_ptr<Op>(new Var()));
+      ops.push_back(UniquePtr<Op>(new Var()));
     } else if (OPTION("-minimum")  || OPTION("-min")) {
-      ops.push_back(unique_ptr<Op>(new Min()));
+      ops.push_back(UniquePtr<Op>(new Min()));
     } else if (OPTION("-maximum")  || OPTION("-max")) {
-      ops.push_back(unique_ptr<Op>(new Max()));
+      ops.push_back(UniquePtr<Op>(new Max()));
     } else if (OPTION("-extrema") || OPTION("-minmax")) {
-      ops.push_back(unique_ptr<Op>(new Extrema()));
+      ops.push_back(UniquePtr<Op>(new Extrema()));
     } else if (OPTION("-range")) {
-      ops.push_back(unique_ptr<Op>(new Range()));
+      ops.push_back(UniquePtr<Op>(new Range()));
     } else if (OPTION("-percentile") || OPTION("-pct") || OPTION("-p")) {
       do {
         int p;
         if (FromString(ARGUMENT, p) && 0 <= p && p <= 100) {
-          ops.push_back(unique_ptr<Op>(new Percentile(p)));
+          ops.push_back(UniquePtr<Op>(new Percentile(p)));
         } else {
           cerr << "Invalid -percentile value, must be integer in the range [0, 100]!" << endl;
           exit(1);
@@ -704,7 +704,7 @@ int main(int argc, char **argv)
       do {
         int p;
         if (FromString(ARGUMENT, p) && 0 <= p && p <= 100) {
-          ops.push_back(unique_ptr<Op>(new LowerPercentileMean(p)));
+          ops.push_back(UniquePtr<Op>(new LowerPercentileMean(p)));
         } else {
           cerr << "Invalid -lower-percentile-mean value, must be integer in the range [0, 100]!" << endl;
           exit(1);
@@ -714,7 +714,7 @@ int main(int argc, char **argv)
       do {
         int p;
         if (FromString(ARGUMENT, p) && 0 <= p && p <= 100) {
-          ops.push_back(unique_ptr<Op>(new UpperPercentileMean(p)));
+          ops.push_back(UniquePtr<Op>(new UpperPercentileMean(p)));
         } else {
           cerr << "Invalid -upper-percentile-mean value, must be integer in the range [0, 100]!" << endl;
           exit(1);
@@ -737,10 +737,10 @@ int main(int argc, char **argv)
 
   // Default statistics to compute
   if (ops.empty()) {
-    ops.push_back(unique_ptr<Statistic>(new Mean()));
-    ops.push_back(unique_ptr<Statistic>(new StDev()));
-    ops.push_back(unique_ptr<Statistic>(new Extrema()));
-    ops.push_back(unique_ptr<Statistic>(new Range()));
+    ops.push_back(UniquePtr<Statistic>(new Mean()));
+    ops.push_back(UniquePtr<Statistic>(new StDev()));
+    ops.push_back(UniquePtr<Statistic>(new Extrema()));
+    ops.push_back(UniquePtr<Statistic>(new Range()));
   }
 
   // Initial data mask

--- a/Applications/src/close-image.cc
+++ b/Applications/src/close-image.cc
@@ -138,7 +138,7 @@ int main(int argc, char *argv[])
   }
 
   InitializeIOLibrary();
-  unique_ptr<BaseImage> image(BaseImage::New(input_name));
+  UniquePtr<BaseImage> image(BaseImage::New(input_name));
 
   if (verbose) cout << "Closing ... ", cout.flush();
   switch (image->GetDataType()) {

--- a/Applications/src/concatenate-dofs.cc
+++ b/Applications/src/concatenate-dofs.cc
@@ -209,7 +209,7 @@ int main(int argc, char **argv)
     if (verbose) {
       cout << "Reading transformation " << n << ": " << POSARG(n) << endl;
     }
-    unique_ptr<Transformation> dof(Transformation::New(POSARG(n)));
+    UniquePtr<Transformation> dof(Transformation::New(POSARG(n)));
     if ((aff = dynamic_cast<HomogeneousTransformation *>(dof.get()))) {
       post->PutMatrix(post->GetMatrix() * aff->GetMatrix());
       --N; // remove transformation from composition chain
@@ -231,7 +231,7 @@ int main(int argc, char **argv)
     if (verbose) {
       cout << "Reading transformation " << n << " from " << POSARG(n) << endl;
     }
-    unique_ptr<Transformation> dof(Transformation::New(POSARG(n)));
+    UniquePtr<Transformation> dof(Transformation::New(POSARG(n)));
     aff    = dynamic_cast<HomogeneousTransformation                  *>(dof.get());
     ffd    = dynamic_cast<FreeFormTransformation                     *>(dof.get());
     mffd   = dynamic_cast<MultiLevelFreeFormTransformation           *>(dof.get());

--- a/Applications/src/concatenate-images.cc
+++ b/Applications/src/concatenate-images.cc
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
   InitializeIOLibrary();
  
   // Get attributes of first input image
-  unique_ptr<BaseImage> ref(BaseImage::New(input_names[0]));
+  UniquePtr<BaseImage> ref(BaseImage::New(input_names[0]));
   if (ref->T() > 1) {
     FatalError("Input images must be either 2D (nz == 1) or 3D (nz == 1 and nt == 1)!");
   }
@@ -152,7 +152,7 @@ int main(int argc, char *argv[])
       origin[0] = ref->GetTOrigin();
     }
     for (int i = 1; i < n; ++i) {
-      unique_ptr<BaseImage> image(BaseImage::New(input_names[i]));
+      UniquePtr<BaseImage> image(BaseImage::New(input_names[i]));
       p = image->GetOrigin();
       if (twod) {
         Point p = image->GetOrigin();
@@ -179,7 +179,7 @@ int main(int argc, char *argv[])
   ImageAttributes out_attr = ref->Attributes();
   if (twod) out_attr._z = n; // spacing and origin set later below
   else      out_attr._t = n;
-  unique_ptr<BaseImage> output(BaseImage::New(ref->GetDataType()));
+  UniquePtr<BaseImage> output(BaseImage::New(ref->GetDataType()));
   output->Initialize(out_attr);
 
   // Concatenate images
@@ -193,7 +193,7 @@ int main(int argc, char *argv[])
       output->PutAsDouble(i, j, 0, 0, ref->GetAsDouble(i, j));
     }
     for (int k = 1; k < n; ++k) {
-      unique_ptr<BaseImage> image(BaseImage::New(input_names[pos[k]]));
+      UniquePtr<BaseImage> image(BaseImage::New(input_names[pos[k]]));
       if (image->Z() != 1 || image->T() != 1) {
         if (verbose) cout << " failed" << endl;
         FatalError("Input image " << k+1 << " is not 2D!");
@@ -230,7 +230,7 @@ int main(int argc, char *argv[])
       output->PutAsDouble(i, j, k, 0, ref->GetAsDouble(i, j, k));
     }
     for (int l = 1; l < n; ++l) {
-      unique_ptr<BaseImage> image(BaseImage::New(input_names[pos[l]]));
+      UniquePtr<BaseImage> image(BaseImage::New(input_names[pos[l]]));
       if (image->T() != 1) {
         if (verbose) cout << " failed" << endl;
         FatalError("Input image " << l+1 << " is not 3D!");

--- a/Applications/src/convert-dof.cc
+++ b/Applications/src/convert-dof.cc
@@ -526,7 +526,7 @@ Transformation *ToLinearFFD(const GenericImage<double> &disp,
 
   double xaxis[3], yaxis[3], zaxis[3];
   disp.GetOrientation(xaxis, yaxis, zaxis);
-  unique_ptr<LinearFreeFormTransformation> ffd;
+  UniquePtr<LinearFreeFormTransformation> ffd;
   ffd.reset(new LinearFreeFormTransformation3D(0, 0, 0, disp.X() - 1, disp.Y() - 1, disp.Z() - 1,
                                                dx, dy, dz, xaxis, yaxis, zaxis));
 
@@ -552,7 +552,7 @@ Transformation *ToLinearFFD(const GenericImage<double> &disp,
     }
   }
 
-  unique_ptr<MultiLevelFreeFormTransformation> dof;
+  UniquePtr<MultiLevelFreeFormTransformation> dof;
   dof.reset(new MultiLevelFreeFormTransformation());
   dof->PushLocalTransformation(ffd.release());
   return dof.release();
@@ -652,7 +652,7 @@ Transformation *ReadFLIRT(const char *fname, const ImageAttributes &target,
   S2(2, 2) = 1.0 / source._dz;
   S2(3, 3) = 1.0;
 
-  unique_ptr<AffineTransformation> dof(new AffineTransformation());
+  UniquePtr<AffineTransformation> dof(new AffineTransformation());
   dof->PutMatrix(s2w * S2 * A.Inverse() * S1 * w2t);
   return dof.release();
 }
@@ -689,7 +689,7 @@ Transformation *ReadAladin(const char *fname)
   #endif // WINDOWS
   m(3, 0) = m(3, 1) = m(3, 2) = .0; m(3, 3) = 1.0;
   fclose(f);
-  unique_ptr<AffineTransformation> dof(new AffineTransformation);
+  UniquePtr<AffineTransformation> dof(new AffineTransformation);
   dof->PutMatrix(m);
   return dof.release();
 }
@@ -737,7 +737,7 @@ Transformation *ReadF3D(const char *fname, const char *dofin_name = NULL,
     }
 
     // Initialize output transformation
-    unique_ptr<MultiLevelFreeFormTransformation> mffd(new MultiLevelFreeFormTransformation());
+    UniquePtr<MultiLevelFreeFormTransformation> mffd(new MultiLevelFreeFormTransformation());
 
     // Subtract -dofin displacement
     if (dofin_name) {
@@ -824,7 +824,7 @@ Transformation *ReadXFM(const char *fname)
   }
   m(3, 0) = m(3, 1) = m(3, 2) = .0; m(3, 3) = 1.0;
   ifs.close();
-  unique_ptr<AffineTransformation> dof(new AffineTransformation);
+  UniquePtr<AffineTransformation> dof(new AffineTransformation);
   dof->PutMatrix(m);
   return dof.release();
 }
@@ -964,7 +964,7 @@ double ApproximateAsNew(const Transformation *dofin,
                         FFDIMParams           ffdim  = FFDIMParams(),
                         BCHParams             bch    = BCHParams())
 {
-  unique_ptr<Transformation> itmp;
+  UniquePtr<Transformation> itmp;
 
   // Just copy parameters whenever possible
   if (dofout->CopyFrom(dofin)) return .0;
@@ -1346,7 +1346,7 @@ bool WriteMIRTK(const char *fname, Transformation *dof,
   }
 
   // Instantiate output MFFD (if any)
-  unique_ptr<MultiLevelTransformation> omffd;
+  UniquePtr<MultiLevelTransformation> omffd;
   switch (mffd_type) {
     case MFFD_None:
       break;
@@ -1399,7 +1399,7 @@ bool WriteMIRTK(const char *fname, Transformation *dof,
   }
 
   // Otherwise, approximate input transformation by new output transformation
-  unique_ptr<Transformation> odof(Transformation::New(type));
+  UniquePtr<Transformation> odof(Transformation::New(type));
 
   // When output type is a homogeneous coordinate transformation,
   // convert input transformation such that only global part remains
@@ -1724,7 +1724,7 @@ bool WriteF3D(const char *fname, const Transformation *dof,
   (ffd  = dynamic_cast<const BSplineFreeFormTransformation3D  *>(dof)) ||
   (mffd = dynamic_cast<const MultiLevelFreeFormTransformation *>(dof));
 
-  unique_ptr<MultiLevelFreeFormTransformation> new_mffd;
+  UniquePtr<MultiLevelFreeFormTransformation> new_mffd;
   if (lin) {
     new_mffd.reset(new MultiLevelFreeFormTransformation());
     new_mffd->GetGlobalTransformation()->PutMatrix(lin->GetMatrix());
@@ -2165,7 +2165,7 @@ int main(int argc, char *argv[])
   }
 
   // Read input transformation
-  unique_ptr<Transformation> dof;
+  UniquePtr<Transformation> dof;
   switch (format_in) {
 
     // Image

--- a/Applications/src/convert-image.cc
+++ b/Applications/src/convert-image.cc
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
 
   // Read image
   InitializeIOLibrary();
-  unique_ptr<BaseImage> input(BaseImage::New(input_name));
+  UniquePtr<BaseImage> input(BaseImage::New(input_name));
   if (voxel_type == MIRTK_VOXEL_UNKNOWN) {
     voxel_type = input->GetDataType();
   }
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
   }
 
   // Convert image
-  unique_ptr<BaseImage> output(BaseImage::New(voxel_type));
+  UniquePtr<BaseImage> output(BaseImage::New(voxel_type));
   *output = *input;
 
   // Write image

--- a/Applications/src/cut-brain.cc
+++ b/Applications/src/cut-brain.cc
@@ -246,7 +246,7 @@ int main(int argc, char *argv[])
 
   // Read input image
   InitializeIOLibrary();
-  unique_ptr<BaseImage> image(BaseImage::New(image_name));
+  UniquePtr<BaseImage> image(BaseImage::New(image_name));
 
   // Compute parameters of cutting plane
   BinaryImage hemi;
@@ -272,11 +272,11 @@ int main(int argc, char *argv[])
 
   // Write left/right hemisphere
   if (left_name) {
-    unique_ptr<BaseImage> left(Pad(image.get(), hemi, mask, b, n, RH, padding));
+    UniquePtr<BaseImage> left(Pad(image.get(), hemi, mask, b, n, RH, padding));
     left->Write(left_name);
   }
   if (right_name) {
-    unique_ptr<BaseImage> right(Pad(image.get(), hemi, mask, b, n, LH, padding));
+    UniquePtr<BaseImage> right(Pad(image.get(), hemi, mask, b, n, LH, padding));
     right->Write(right_name);
   }
 

--- a/Applications/src/dilate-image.cc
+++ b/Applications/src/dilate-image.cc
@@ -79,7 +79,7 @@ int main(int argc, char *argv[])
   }
 
   InitializeIOLibrary();
-  unique_ptr<BaseImage> image(BaseImage::New(input_name));
+  UniquePtr<BaseImage> image(BaseImage::New(input_name));
 
   if (verbose) cout << "Dilating ... ", cout.flush();
   switch (image->GetDataType()) {

--- a/Applications/src/downsample-image.cc
+++ b/Applications/src/downsample-image.cc
@@ -90,12 +90,12 @@ int main(int argc, char **argv)
   // Read input image
   if (verbose) cout << "Reading image ... "; cout.flush();
   InitializeIOLibrary();
-  unique_ptr<BaseImage> input(BaseImage::New(input_name));
+  UniquePtr<BaseImage> input(BaseImage::New(input_name));
   if (verbose) cout << "done." << endl;
 
   // Downsample image
   if (verbose) cout << "Downsampling image ... ";
-  unique_ptr<BaseImage> output;
+  UniquePtr<BaseImage> output;
   for (int i = 0; i < iter; ++i) {
     if (i > 0) input.swap(output);
     switch (input->GetScalarType()) {

--- a/Applications/src/edit-image.cc
+++ b/Applications/src/edit-image.cc
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
   const char *output_name = POSARG(2);
 
   InitializeIOLibrary();
-  unique_ptr<BaseImage> image(BaseImage::New(input_name));
+  UniquePtr<BaseImage> image(BaseImage::New(input_name));
 
   double origin[4];
   double xsize, ysize, zsize, tsize;
@@ -166,7 +166,7 @@ int main(int argc, char *argv[])
     #ifdef HAVE_MIRTK_Transformation
     else if (OPTION("-dofin") || OPTION("-dofin_i") || OPTION("-putdof") || OPTION("-putdof_i")) {
       Matrix m;
-      unique_ptr<Transformation> dof(Transformation::New(ARGUMENT));
+      UniquePtr<Transformation> dof(Transformation::New(ARGUMENT));
       HomogeneousTransformation *lin  = dynamic_cast<HomogeneousTransformation *>(dof.get());
       MultiLevelTransformation  *mffd = dynamic_cast<MultiLevelTransformation  *>(dof.get());
       if      (lin)  m = lin->GetMatrix();

--- a/Applications/src/erode-image.cc
+++ b/Applications/src/erode-image.cc
@@ -79,7 +79,7 @@ int main(int argc, char *argv[])
   }
 
   InitializeIOLibrary();
-  unique_ptr<BaseImage> image(BaseImage::New(input_name));
+  UniquePtr<BaseImage> image(BaseImage::New(input_name));
 
   if (verbose) cout << "Dilating ... ", cout.flush();
   switch (image->GetDataType()) {

--- a/Applications/src/evaluate-similarity.cc
+++ b/Applications/src/evaluate-similarity.cc
@@ -251,7 +251,7 @@ int main(int argc, char **argv)
   if (verbose > 1) cout << " done" << endl;
 
   // Read input transformation
-  unique_ptr<Transformation> dofin;
+  UniquePtr<Transformation> dofin;
   if (dofin_name) {
     if (verbose > 1) cout << "Reading source transformation from " << dofin_name << "...", cout.flush();
     dofin.reset(Transformation::New(dofin_name));
@@ -342,7 +342,7 @@ int main(int argc, char **argv)
 
   // Initialize similarity measures
   if (verbose > 1) cout << "Initializing similarity measures...", cout.flush();
-  Array<unique_ptr<ImageSimilarity> > sim(metric.size());
+  Array<UniquePtr<ImageSimilarity> > sim(metric.size());
   bool use_shared_histogram = false;
   JointHistogram samples;
 

--- a/Applications/src/extract-image-region.cc
+++ b/Applications/src/extract-image-region.cc
@@ -148,7 +148,7 @@ int main(int argc, char **argv)
 
   // Read input image
   InitializeIOLibrary();
-  unique_ptr<BaseImage> in(BaseImage::New(input_name));
+  UniquePtr<BaseImage> in(BaseImage::New(input_name));
 
   // Parse optional arguments and adjust image region accordingly
   int    xmargin = 0, ymargin = 0, zmargin = 0, tmargin = 0;
@@ -330,7 +330,7 @@ int main(int argc, char **argv)
   attr._yorigin = .0;
   attr._zorigin = .0;
   attr._torigin = in->ImageToTime(t1);
-  unique_ptr<BaseImage> out(BaseImage::New(in->GetDataType()));
+  UniquePtr<BaseImage> out(BaseImage::New(in->GetDataType()));
   out->Initialize(attr);
 
   // Adjust spatial origin (i.e., image center)

--- a/Applications/src/extract-pointset-surface.cc
+++ b/Applications/src/extract-pointset-surface.cc
@@ -338,7 +338,7 @@ int main(int argc, char *argv[])
       max_shock_dist = abs(max_shock_dist) * AverageEdgeLength(surface);
     }
     if (verbose > 1) cout << "  Maximum shock distance = " << max_shock_dist << endl;
-    unique_ptr<DistanceImage> dmap;
+    UniquePtr<DistanceImage> dmap;
     if (shock_dmap_name) dmap.reset(new DistanceImage(shock_dmap_name));
     RemoveShocks(surface, max_shock_dist, dmap.get());
     if (verbose) {

--- a/Applications/src/flip-image.cc
+++ b/Applications/src/flip-image.cc
@@ -67,7 +67,7 @@ int main(int argc, char **argv)
   const char *output_name = POSARG(2);
 
   InitializeIOLibrary();
-  unique_ptr<BaseImage> image(BaseImage::New(input_name));
+  UniquePtr<BaseImage> image(BaseImage::New(input_name));
 
   for (ALL_OPTIONS) {
     if      (OPTION("-xy") || OPTION("-yx")) image->FlipXY(true);

--- a/Applications/src/init-dof.cc
+++ b/Applications/src/init-dof.cc
@@ -505,7 +505,7 @@ int main(int argc, char **argv)
     // Write affine transformation as free-form deformation
     } else if (nonrigid) {
 
-      unique_ptr<FreeFormTransformation3D> ffd;
+      UniquePtr<FreeFormTransformation3D> ffd;
       if (diffeomorphic) ffd.reset(BSplineSVFFD(dof, attr, sx, sy, sz));
       else               ffd.reset(BSplineFFD  (dof, attr, sx, sy, sz));
       if (verbose) {
@@ -745,7 +745,7 @@ int main(int argc, char **argv)
 
       } else {
 
-        unique_ptr<FreeFormTransformation3D> ffd;
+        UniquePtr<FreeFormTransformation3D> ffd;
         if (diffeomorphic) ffd.reset(new BSplineFreeFormTransformationSV(attr, sx, sy, sz));
         else               ffd.reset(new BSplineFreeFormTransformation3D(attr, sx, sy, sz));
 

--- a/Applications/src/invert-dof.cc
+++ b/Applications/src/invert-dof.cc
@@ -67,7 +67,7 @@ int main(int argc, char **argv)
   }
 
   // Read transformation
-  unique_ptr<Transformation> dof(Transformation::New(dofin_name));
+  UniquePtr<Transformation> dof(Transformation::New(dofin_name));
 
   HomogeneousTransformation                  *lin    = NULL;
   BSplineFreeFormTransformationSV            *svffd  = NULL;

--- a/Applications/src/match-points.cc
+++ b/Applications/src/match-points.cc
@@ -164,7 +164,7 @@ int main(int argc, char **argv)
   if (verbose) cout << " done" << endl;
 
   // Read target transformation
-  unique_ptr<Transformation> dof;
+  UniquePtr<Transformation> dof;
   if (dofin_name) {
     if (verbose) cout << "Reading transformation...", cout.flush();
     dof.reset(Transformation::New(dofin_name));
@@ -190,7 +190,7 @@ int main(int argc, char **argv)
 
   // Initialize point correspondence map
   if (verbose) cout << "Initialize correspondence map...", cout.flush();
-  unique_ptr<PointCorrespondence> cmap(PointCorrespondence::New(ctype));
+  UniquePtr<PointCorrespondence> cmap(PointCorrespondence::New(ctype));
   cmap->FromTargetToSource(true);
   cmap->FromSourceToTarget(false);
   cmap->Parameter(param);

--- a/Applications/src/open-image.cc
+++ b/Applications/src/open-image.cc
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
   }
 
   InitializeIOLibrary();
-  unique_ptr<BaseImage> image(BaseImage::New(input_name));
+  UniquePtr<BaseImage> image(BaseImage::New(input_name));
 
   if (verbose) cout << "Opening ... ", cout.flush();
   switch (image->GetDataType()) {

--- a/Applications/src/reflect-image.cc
+++ b/Applications/src/reflect-image.cc
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
   const char *output_name = POSARG(2);
 
   InitializeIOLibrary();
-  unique_ptr<BaseImage> image(BaseImage::New(input_name));
+  UniquePtr<BaseImage> image(BaseImage::New(input_name));
 
   for (ALL_OPTIONS) {
     if      (OPTION("-x")) image->ReflectX();

--- a/Applications/src/register.cc
+++ b/Applications/src/register.cc
@@ -434,11 +434,11 @@ struct ConcurrentImageReader
   {
     HomogeneousTransformation *lin;
     for (size_t n = re.begin(); n != re.end(); ++n) {
-      unique_ptr<BaseImage> &image = (*_Image)[n];
+      UniquePtr<BaseImage> &image = (*_Image)[n];
       if (image.get() == NULL) {
         image.reset(BaseImage::New(_ImageName[n].c_str()));
         if (!IsIdentity(_DoFName[n])) {
-          unique_ptr<Transformation> dof(Transformation::New(_DoFName[n].c_str()));
+          UniquePtr<Transformation> dof(Transformation::New(_DoFName[n].c_str()));
           lin = dynamic_cast<HomogeneousTransformation *>(dof.get());
           if (lin) {
             Matrix mat = lin->GetMatrix();
@@ -456,7 +456,7 @@ struct ConcurrentImageReader
   static void Run(const Array<string>           &fname,
                   const Array<string>           &tname,
                   const Array<bool>             &tinv,
-                  Array<unique_ptr<BaseImage> > &image,
+                  Array<UniquePtr<BaseImage> > &image,
                   Error                         *error)
   {
     ConcurrentImageReader body;
@@ -475,7 +475,7 @@ private:
   Array<string>                  _ImageName;
   Array<string>                  _DoFName;
   Array<bool>                    _DoFInvert;
-  Array<unique_ptr<BaseImage> > *_Image;
+  Array<UniquePtr<BaseImage> > *_Image;
   Error                         *_Error;
 };
 
@@ -507,7 +507,7 @@ public:
           _Error[n] = EmptyPointSet;
         } else {
           if (!IsIdentity(_DoFName[n])) {
-            unique_ptr<Transformation> t(Transformation::New(_DoFName[n].c_str()));
+            UniquePtr<Transformation> t(Transformation::New(_DoFName[n].c_str()));
             for (vtkIdType i = 0; i < points->GetNumberOfPoints(); ++i) {
               points->GetPoint(i, p);
               if (_DoFInvert[n]) t->Inverse  (p[0], p[1], p[2]);
@@ -751,10 +751,10 @@ int main(int argc, char **argv)
   // ---------------------------------------------------------------------------
   // Determine number of input images
   Array<double>                 image_times;
-  Array<unique_ptr<BaseImage> > images;
+  Array<UniquePtr<BaseImage> > images;
 
   if (image_names.size() == 1) {
-    unique_ptr<BaseImage> sequence(BaseImage::New(image_names[0].c_str()));
+    UniquePtr<BaseImage> sequence(BaseImage::New(image_names[0].c_str()));
     const int nframes = sequence->GetT();
     if (nframes < 2) {
       if (verbose > 1) cout << " failed\n" << endl;
@@ -916,7 +916,7 @@ int main(int argc, char **argv)
 
   // ---------------------------------------------------------------------------
   // Read initial transformation
-  unique_ptr<Transformation> dofin;
+  UniquePtr<Transformation> dofin;
   if (dofin_name) {
     if (IsIdentity(dofin_name)) dofin.reset(new RigidTransformation());
     else                        dofin.reset(Transformation::New(dofin_name));
@@ -925,7 +925,7 @@ int main(int argc, char **argv)
 
   // ---------------------------------------------------------------------------
   // Read mask which defines domain on which similarity is evaluated
-  unique_ptr<BinaryImage> mask;
+  UniquePtr<BinaryImage> mask;
   if (mask_name) {
     mask.reset(new BinaryImage(mask_name));
     registration.Domain(mask.get());

--- a/Applications/src/resample-image.cc
+++ b/Applications/src/resample-image.cc
@@ -152,7 +152,7 @@ int main(int argc, char *argv[])
 
   // Read image
   InitializeIOLibrary();
-  unique_ptr<BaseImage> image(BaseImage::New(input_name));
+  UniquePtr<BaseImage> image(BaseImage::New(input_name));
 
   // Parse optional arguments
   InterpolationMode interpolation_mode  = Interpolation_NN;
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
   }
 
   // Create interpolator
-  unique_ptr<InterpolateImageFunction> interpolator;
+  UniquePtr<InterpolateImageFunction> interpolator;
   interpolator.reset(InterpolateImageFunction::New(interpolation_mode, extrapolation_mode, image.get()));
 
   // TODO: The actual type of the templated GenericGaussianInterpolateImageFunction's is not known.

--- a/Applications/src/smooth-image.cc
+++ b/Applications/src/smooth-image.cc
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
 
   // Determine input image data type
   InitializeIOLibrary();
-  unique_ptr<ImageReader> reader(ImageReader::New(input_name));
+  UniquePtr<ImageReader> reader(ImageReader::New(input_name));
   int data_type = reader->DataType();
 
   // Parse and discard options

--- a/Applications/src/transform-image.cc
+++ b/Applications/src/transform-image.cc
@@ -87,9 +87,9 @@ int main(int argc, char **argv)
 
   // Read image
   InitializeIOLibrary();
-  unique_ptr<ImageReader> input_reader(ImageReader::New(input_name));
+  UniquePtr<ImageReader> input_reader(ImageReader::New(input_name));
   int source_type = input_reader->DataType();
-  unique_ptr<BaseImage> source(input_reader->Run());
+  UniquePtr<BaseImage> source(input_reader->Run());
 
   // Parse optional arguments
   const char       *dof_name      = NULL;
@@ -135,7 +135,7 @@ int main(int argc, char **argv)
 
   // Apply affine header transformation
   if (dof_name) {
-    unique_ptr<Transformation> t(Transformation::New(dof_name));
+    UniquePtr<Transformation> t(Transformation::New(dof_name));
     HomogeneousTransformation *lin = dynamic_cast<HomogeneousTransformation *>(t.get());
     if (lin) {
       Matrix mat = lin->GetMatrix();
@@ -147,22 +147,22 @@ int main(int argc, char **argv)
   }
 
   // Read target image
-  unique_ptr<BaseImage> target;
+  UniquePtr<BaseImage> target;
   int target_type = -1;
   if (target_name) {
-    unique_ptr<ImageReader> target_reader(ImageReader::New(target_name));
+    UniquePtr<ImageReader> target_reader(ImageReader::New(target_name));
     target_type = target_reader->DataType();
     target.reset(target_reader->Run());
   }
 
   // Instantiate interpolator
-  unique_ptr<InterpolateImageFunction> interpolator(InterpolateImageFunction::New(interpolation));
+  UniquePtr<InterpolateImageFunction> interpolator(InterpolateImageFunction::New(interpolation));
 
   // Initialize output image
   if (target.get()) {
     // Ensure that output image has same number of channels/frames than input
     if (target->T() != source->T()) {
-      unique_ptr<BaseImage> tmp(BaseImage::New(target_type));
+      UniquePtr<BaseImage> tmp(BaseImage::New(target_type));
       tmp->Initialize(target->Attributes(), source->T());
       tmp->PutTSize(source->GetTSize());
       for (int l = 0; l < tmp->T(); ++l)
@@ -183,7 +183,7 @@ int main(int argc, char **argv)
   if (!IsNaN(source_t)) source->PutTOrigin(source_t);
 
   // Instantiate image transformation
-  unique_ptr<Transformation> transformation;
+  UniquePtr<Transformation> transformation;
   if (dofin_name == NULL || strcmp(dofin_name, "identity") == 0
                          || strcmp(dofin_name, "Identity") == 0
                          || strcmp(dofin_name, "Id")       == 0) {
@@ -218,7 +218,7 @@ int main(int argc, char **argv)
 
   // Change type of target image to source image type
   if (source_type != target_type) {
-    unique_ptr<BaseImage> tmp(BaseImage::New(source_type));
+    UniquePtr<BaseImage> tmp(BaseImage::New(source_type));
     *tmp = *target;
     target.reset(tmp.release());
   }

--- a/Applications/src/transform-points.cc
+++ b/Applications/src/transform-points.cc
@@ -214,7 +214,7 @@ int main(int argc, char **argv)
 
   // Transform first pnumber points
   for (size_t i = 0; i < dofin_name.size(); ++i) {
-    unique_ptr<Transformation> dofin(Transformation::New(dofin_name[i]));
+    UniquePtr<Transformation> dofin(Transformation::New(dofin_name[i]));
     if (dofin_invert[i]) {
       if (verbose) cout << "Apply inverse of " << dofin_name[i] << endl;
       for (int i = 0; i < pnumber; ++i) dofin->Inverse(points(i), ts, tt);

--- a/Modules/Common/include/mirtk/Memory.h
+++ b/Modules/Common/include/mirtk/Memory.h
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2016 Imperial College London
+ * Copyright 2013-2016 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,8 +32,20 @@
 namespace mirtk {
 
 
-using std::unique_ptr;
-using std::shared_ptr;
+template <class T>
+using UniquePtr = std::unique_ptr<T>;
+
+template <class T>
+using SharedPtr = std::shared_ptr<T>;
+
+template <class T>
+using WeakPtr = std::weak_ptr<T>;
+
+template <class T, class... Args>
+SharedPtr<T> NewShared(Args&&... args)
+{
+  return std::make_shared<T>(args...);
+}
 
 using std::memset;
 using std::memcpy;

--- a/Modules/Common/include/mirtk/Parallel.h
+++ b/Modules/Common/include/mirtk/Parallel.h
@@ -23,8 +23,7 @@
 #include "mirtk/CommonExport.h"
 
 #include "mirtk/Stream.h"
-
-#include <memory>
+#include "mirtk/Memory.h"
 
 #ifdef HAVE_TBB
 // TBB includes windows header which defines min/max macros otherwise
@@ -110,8 +109,8 @@ using tbb::split;
 // which can be used to limit the number of threads, a global task scheduler
 // instance is created and the -threads argument passed on to its initialize
 // method by ParseParallelOption. There should be no task scheduler created/
-// terminated in any of the IRTK libraries functions and classes.
-MIRTK_Common_EXPORT extern std::unique_ptr<task_scheduler_init> tbb_scheduler;
+// terminated in any of the MIRTK library functions and classes.
+MIRTK_Common_EXPORT extern UniquePtr<task_scheduler_init> tbb_scheduler;
 
 
 // -----------------------------------------------------------------------------

--- a/Modules/Common/src/Parallel.cc
+++ b/Modules/Common/src/Parallel.cc
@@ -23,9 +23,6 @@
 #include "mirtk/Stream.h"
 #include "mirtk/Options.h"
 
-#include <memory>
-
-
 namespace mirtk {
 
 
@@ -43,7 +40,7 @@ int debug_gpu = 0;
 int tbb_debug = 0;
 
 #ifdef HAVE_TBB
-std::unique_ptr<task_scheduler_init> tbb_scheduler;
+UniquePtr<task_scheduler_init> tbb_scheduler;
 #endif
 
 // =============================================================================

--- a/Modules/Image/include/mirtk/HashImage.hxx
+++ b/Modules/Image/include/mirtk/HashImage.hxx
@@ -1235,7 +1235,7 @@ void HashImage<VoxelType>::Write(const char *fname) const
 {
   string name(fname);
   if (Extension(fname).empty()) name += MIRTK_Image_DEFAULT_EXT;
-  unique_ptr<ImageWriter> writer(ImageWriter::New(name.c_str()));
+  UniquePtr<ImageWriter> writer(ImageWriter::New(name.c_str()));
   GenericImage<VoxelType> img=this->ToGenericImage();
   writer->Input(&img);
   writer->Run();

--- a/Modules/Image/include/mirtk/LieBracketImageFilter.h
+++ b/Modules/Image/include/mirtk/LieBracketImageFilter.h
@@ -199,7 +199,7 @@ void liebracket(GenericImage<VoxelType> *ov,
                 GenericImage<VoxelType> *rv, bool usejac = true)
 {
   typedef LieBracketImageFilter<VoxelType> LieBracketFilter;
-  unique_ptr<LieBracketFilter> filter(LieBracketFilter::New(ov, usejac));
+  UniquePtr<LieBracketFilter> filter(LieBracketFilter::New(ov, usejac));
   filter->Input(0, lv);
   filter->Input(1, rv);
   filter->Output(ov);

--- a/Modules/Image/src/BaseImage.cc
+++ b/Modules/Image/src/BaseImage.cc
@@ -95,7 +95,7 @@ BaseImage::~BaseImage()
 // -----------------------------------------------------------------------------
 BaseImage *BaseImage::New(const char *fname)
 {
-  unique_ptr<ImageReader> reader(ImageReader::New(fname));
+  UniquePtr<ImageReader> reader(ImageReader::New(fname));
   return reader->Run();
 }
 

--- a/Modules/Image/src/DataOp.cc
+++ b/Modules/Image/src/DataOp.cc
@@ -126,7 +126,7 @@ int Read(const char *name, double *&data, int *dtype, ImageAttributes *attr)
       exit(1);
 #endif // MIRTK_Image_WITH_VTK
     case IMAGE: {
-      unique_ptr<BaseImage> image(BaseImage::New(name));
+      UniquePtr<BaseImage> image(BaseImage::New(name));
       if (attr) *attr = image->Attributes();
       if (dtype) *dtype = image->GetDataType();
       n = image->NumberOfVoxels();
@@ -213,7 +213,7 @@ void Write::Process(int n, double *data, bool *)
         cerr << "Cannot write data series to file! Length of data series changed." << endl;
         exit(1);
       }
-      unique_ptr<BaseImage> image(BaseImage::New(_DataType));
+      UniquePtr<BaseImage> image(BaseImage::New(_DataType));
       image->Initialize(_Attributes);
       for (int i = 0; i < n; ++i) image->PutAsDouble(i, data[i]);
       image->Write(_FileName.c_str());

--- a/Modules/Image/src/GenericImage.cc
+++ b/Modules/Image/src/GenericImage.cc
@@ -1745,8 +1745,8 @@ template <class VoxelType>
 void GenericImage<VoxelType>::Read(const char *fname)
 {
   // Read image
-  unique_ptr<ImageReader> reader(ImageReader::New(fname));
-  unique_ptr<BaseImage>   image(reader->Run());
+  UniquePtr<ImageReader> reader(ImageReader::New(fname));
+  UniquePtr<BaseImage>   image(reader->Run());
   // Convert image
   switch (image->GetDataType()) {
     case MIRTK_VOXEL_CHAR:           { *this = *(dynamic_cast<GenericImage<char>           *>(image.get())); } break;
@@ -1787,7 +1787,7 @@ void GenericImage<VoxelType>::Write(const char *fname) const
 {
   string name(fname);
   if (Extension(fname).empty()) name += MIRTK_Image_DEFAULT_EXT;
-  unique_ptr<ImageWriter> writer(ImageWriter::New(name.c_str()));
+  UniquePtr<ImageWriter> writer(ImageWriter::New(name.c_str()));
   writer->Input(this);
   writer->Run();
 }

--- a/Modules/PointSet/include/mirtk/PointLocator.h
+++ b/Modules/PointSet/include/mirtk/PointLocator.h
@@ -809,7 +809,7 @@ inline Array<int> PointLocator
                    vtkPointSet *dataset2, const Array<int> *sample2, const FeatureList *features2,
                    Array<double> *dist2)
 {
-  unique_ptr<PointLocator> locator(PointLocator::New(dataset2, sample2, features2));
+  UniquePtr<PointLocator> locator(PointLocator::New(dataset2, sample2, features2));
   return locator->FindClosestPoint(dataset1, sample1, features1, dist2);
 }
 
@@ -879,7 +879,7 @@ inline Array<Array<int> > PointLocator
                             vtkPointSet *dataset2, const Array<int> *sample2, const FeatureList *features2,
                      Array<Array<double> > *dist2)
 {
-  unique_ptr<PointLocator> locator(PointLocator::New(dataset2, sample2, features2));
+  UniquePtr<PointLocator> locator(PointLocator::New(dataset2, sample2, features2));
   return locator->FindClosestNPoints(k, dataset1, sample1, features1, dist2);
 }
 
@@ -950,7 +950,7 @@ inline Array<Array<int> > PointLocator
                                         vtkPointSet *dataset2, const Array<int> *sample2, const FeatureList *features2,
                          Array<Array<double> > *dist2)
 {
-  unique_ptr<PointLocator> locator(PointLocator::New(dataset2, sample2, features2));
+  UniquePtr<PointLocator> locator(PointLocator::New(dataset2, sample2, features2));
   return locator->FindPointsWithinRadius(radius, dataset1, sample1, features1, dist2);
 }
 

--- a/Modules/Transformation/src/BSplineFreeFormTransformationSV.cc
+++ b/Modules/Transformation/src/BSplineFreeFormTransformationSV.cc
@@ -758,7 +758,7 @@ double BSplineFreeFormTransformationSV
   } else {    
     double x, y, z, vec[3] = {.0, .0, .0};
 
-    unique_ptr<InterpolateImageFunction> f;
+    UniquePtr<InterpolateImageFunction> f;
     f.reset(InterpolateImageFunction::New(Interpolation_Linear, Extrapolation_NN, &disp));
     f->Input(&disp);
     f->Initialize();


### PR DESCRIPTION
`UniquePtr` is an alias for `std::unique_ptr`, `SharedPtr` an alias for `std::shared_ptr`, and `WeakPtr` an alias for `std::weak_ptr`. The `SharedPtr` shall in general be used as smart pointer implementation for MIRTK. Over time, code that returns a raw pointer should be transitioned to return a `SharedPtr` instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/275)
<!-- Reviewable:end -->
