### PR TITLE
fix: Remove unused include of vtkCellIterator which is further not available in VTK 6.0 [PointSet]

### DIFF
--- a/Modules/PointSet/src/PointSetUtils.cc
+++ b/Modules/PointSet/src/PointSetUtils.cc
@@ -48,7 +48,6 @@
 #include "vtkCellData.h"
 #include "vtkDataSetAttributes.h"
 #include "vtkCell.h"
-#include "vtkCellIterator.h"
 #include "vtkTriangle.h"
 #include "vtkTetra.h"
 #include "vtkGenericCell.h"


### PR DESCRIPTION
Fixup #273.