### PR TITLE
enh: Add CamelCaseToPrettyParameterName function [Common]

### DIFF
--- a/Modules/Common/include/mirtk/String.h
+++ b/Modules/Common/include/mirtk/String.h
@@ -251,6 +251,15 @@ string TrimAll(const string &str, const string &what = " \t\r\n");
 /// @returns Parts of the string.
 Array<string> Split(string s, const char *d, int n = 0, bool e = false);
 
+/// Convert (upper) camel case string to space separated string
+///
+/// \param[in] s Camel case string.
+///
+/// \return String starting with uppercase letter followed by lowercase letters
+///         only and a space character before each uppercase letter in the
+///         camel case string.
+string CamelCaseToPrettyParameterName(const string &s);
+
 /// Convert units specification to standard lowercase string
 ///
 /// For example, this function returns "vox" for any units specification allowed

--- a/Modules/Common/src/String.cc
+++ b/Modules/Common/src/String.cc
@@ -183,6 +183,23 @@ Array<string> Split(string s, const char *d, int n, bool discard_empty)
 }
 
 // ------------------------------------------------------------------------
+string CamelCaseToPrettyParameterName(const string &s)
+{
+  string param;
+  param.reserve(s.length() + 10);
+  for (auto c = s.begin(); c != s.end(); ++c) {
+    if (param.empty()) {
+      param += toupper(*c);
+    } else {
+      if (isupper(*c)) param += ' ';
+      param += tolower(*c);
+    }
+  }
+  param.shrink_to_fit();
+  return param;
+}
+
+// ------------------------------------------------------------------------
 string StandardUnits(const string &str)
 {
   if (str.empty()) return str;


### PR DESCRIPTION
Helper function to convert (upper) camel case string (e.g., "ArealDistortion") to MIRTK style (see register command configuration file) parameter name (e.g., "Areal distortion").