### PR TITLE
enh: Add header which imports used STL's numeric functions into mirtk namespace [Common]

### DIFF
--- a/Modules/Common/include/mirtk/Numeric.h
+++ b/Modules/Common/include/mirtk/Numeric.h
@@ -1,0 +1,42 @@
+/*
+ * Medical Image Registration ToolKit (MIRTK)
+ *
+ * Copyright 2016 Imperial College London
+ * Copyright 2016 Andreas Schuh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MIRTK_Numeric_H
+#define MIRTK_Numeric_H
+
+#include "mirtk/Array.h"
+
+#include <numeric>
+
+
+namespace mirtk {
+
+
+using std::accumulate;
+
+template <class T>
+T Accumulate(const Array<T> &values)
+{
+  return accumulate(values.begin(), values.end(), T(0));
+}
+
+
+} // namespace mirtk
+
+#endif // MIRTK_Numeric_H

--- a/Modules/Common/src/CMakeLists.txt
+++ b/Modules/Common/src/CMakeLists.txt
@@ -49,6 +49,7 @@ set(HEADERS
   List.h
   Math.h
   Memory.h
+  Numeric.h
   Object.h
   ObjectFactory.h
   Observable.h


### PR DESCRIPTION
MIRTK header file `Numeric.h` which includes STL's `numeric` header and imports used functions into the `mirtk` namespace, plus additional basic MIRTK helper functions.