### PR TITLE
enh: Add constructor argument to PolyDataCurvature filter [PointSet]

### DIFF
--- a/Modules/PointSet/include/mirtk/PolyDataCurvature.h
+++ b/Modules/PointSet/include/mirtk/PolyDataCurvature.h
@@ -141,7 +141,7 @@ public:
   // Construction/Destruction
 
   /// Default constructor
-  PolyDataCurvature();
+  PolyDataCurvature(int type = Scalars);
 
   /// Copy constructor
   PolyDataCurvature(const PolyDataCurvature &);

--- a/Modules/PointSet/src/PolyDataCurvature.cc
+++ b/Modules/PointSet/src/PolyDataCurvature.cc
@@ -507,9 +507,9 @@ void PolyDataCurvature::CopyAttributes(const PolyDataCurvature &other)
 }
 
 // -----------------------------------------------------------------------------
-PolyDataCurvature::PolyDataCurvature()
+PolyDataCurvature::PolyDataCurvature(int type)
 :
-  _CurvatureType(Scalars),
+  _CurvatureType(type),
   _VtkCurvatures(false),
   _TensorAveraging(3),
   _Normalize(false),


### PR DESCRIPTION
Just for convenience to be able to select the type of curvature measures to compute already upon construction instead of a separate setter call.