### PR TITLE
enh: Move Cotangent function to Triangle class

### DIFF
--- a/Modules/PointSet/include/mirtk/PointSetUtils.h
+++ b/Modules/PointSet/include/mirtk/PointSetUtils.h
@@ -203,25 +203,6 @@ inline bool ComputeTangents(const double n[3], double e1[3], double e2[3], doubl
   return true;
 }
 
-// -----------------------------------------------------------------------------
-/// Compute cotangent of angle ABC
-///
-/// \param[in] a Position of triangle vertex A.
-/// \param[in] b Position of triangle vertex B.
-/// \param[in] c Position of triangle vertex C.
-///
-/// \returns Cotangent of angle ABC (equals cotangent of angle CBA).
-///
-/// \sa Meyer et al. (2002). Generalized Barycentric Coordinates on Irregular Polygons.
-inline double Cotangent(double posA[3], double posB[3], double posC[3])
-{
-  double vecBA[3], vecBC[3], n[3];
-  vtkMath::Subtract(posA, posB, vecBA);
-  vtkMath::Subtract(posC, posB, vecBC);
-  vtkMath::Cross(vecBA, vecBC, n);
-  return vtkMath::Dot(vecBA, vecBC) / vtkMath::Norm(n);
-}
-
 // =============================================================================
 // Basic point set manipulation
 // =============================================================================

--- a/Modules/PointSet/include/mirtk/Triangle.h
+++ b/Modules/PointSet/include/mirtk/Triangle.h
@@ -263,8 +263,8 @@ inline int coplanar_tri_tri(const double N[3],
 // See article "A Fast Triangle-Triangle Intersection Test",
 // Journal of Graphics Tools, 2(2), 1997
 #define MIRTK_NoDivTriTriIsect_USE_EPSILON_TEST 0
-int NoDivTriTriIsect(const double V0[3], const double V1[3], const double V2[3],
-                     const double U0[3], const double U1[3], const double U2[3])
+inline int NoDivTriTriIsect(const double V0[3], const double V1[3], const double V2[3],
+                            const double U0[3], const double U1[3], const double U2[3])
 {
 #if MIRTK_NoDivTriTriIsect_USE_EPSILON_TEST
   const double EPSILON = 0.000001;
@@ -389,8 +389,10 @@ int NoDivTriTriIsect(const double V0[3], const double V1[3], const double V2[3],
 /// D1,D2,D3 are the vertices of triangle B. Q1,Q2 are the two edges originating from D1.
 ///
 /// @return Zero for disjoint triangles and non-zero for intersection.
-int tri_tri_intersect3D(const double *C1, const double *C2, const double *C3, const double *P1, const double *P2,
-	                    const double *D1, const double *D2, const double *D3, const double *Q1, const double *Q2)
+inline int tri_tri_intersect3D(const double *C1, const double *C2, const double *C3,
+                               const double *P1, const double *P2,
+	                             const double *D1, const double *D2, const double *D3,
+                               const double *Q1, const double *Q2)
 {
 	double t[3],p1[3], p2[3],r[3],r4[3];
 	double beta1, beta2, beta3;

--- a/Modules/PointSet/include/mirtk/Triangle.h
+++ b/Modules/PointSet/include/mirtk/Triangle.h
@@ -22,7 +22,7 @@
 
 #include "mirtk/Memory.h"
 #include "mirtk/Math.h"
-#include "mirtk/VtkMath.h" // vtkMath.h otherwise included by vtkTriangle.h
+#include "mirtk/VtkMath.h"
 
 #include "vtkLine.h"
 #include "vtkPlane.h"
@@ -38,6 +38,15 @@ namespace mirtk {
 class Triangle
 {
 public:
+
+  /// Compute cotangent of angle ABC
+  ///
+  /// \param[in] a Position of triangle vertex A.
+  /// \param[in] b Position of triangle vertex B.
+  /// \param[in] c Position of triangle vertex C.
+  ///
+  /// \returns Cotangent of angle ABC (equals cotangent of angle CBA).
+  static double Cotangent(double a[3], double b[3], double c[3]);
 
   /// Tests whether two triangles intersect each other
   ///
@@ -71,6 +80,21 @@ public:
 
 // Copy 3D point coordinates stored in plain C array
 #define MIRTK_RETURN_POINT(a, b) if (a) memcpy((a), (b), 3 * sizeof(double))
+
+// =============================================================================
+// Angles
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// Meyer et al. (2002). Generalized Barycentric Coordinates on Irregular Polygons.
+inline double Triangle::Cotangent(double a[3], double b[3], double c[3])
+{
+  double ba[3], bc[3], n[3];
+  vtkMath::Subtract(a, b, ba);
+  vtkMath::Subtract(c, b, bc);
+  vtkMath::Cross(ba, bc, n);
+  return vtkMath::Dot(ba, bc) / vtkMath::Norm(n);
+}
 
 // =============================================================================
 // Triangle/triangle intersection test


### PR DESCRIPTION
Also adds missing `inline` declarations to functions defined in `Triangle.h` header file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/308)
<!-- Reviewable:end -->
