### PR TITLE
enh: Add auxiliary classes to iterate surface mesh boundary segments [PointSet]

### DIFF
--- a/Modules/PointSet/include/mirtk/BoundarySegment.h
+++ b/Modules/PointSet/include/mirtk/BoundarySegment.h
@@ -1,0 +1,383 @@
+/*
+ * Medical Image Registration ToolKit (MIRTK)
+ *
+ * Copyright 2016 Imperial College London
+ * Copyright 2016 Andreas Schuh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MIRTK_BoundarySegment_H
+#define MIRTK_BoundarySegment_H
+
+#include "mirtk/Object.h"
+#include "mirtk/Array.h"
+#include "mirtk/Vector.h"
+#include "mirtk/Point.h"
+#include "mirtk/UnorderedMap.h"
+
+#include "vtkSmartPointer.h"
+#include "vtkPolyData.h"
+
+
+namespace mirtk {
+
+
+/**
+ * Closed boundary segment of surface mesh
+ *
+ * A boundary segment is a closed line strip defined by an ordered list of point
+ * indices with an edge between each consecutive pair of points. The boundary
+ * loop is closed by the edge connecting the last point with the first point.
+ * A surface mesh may have any number of boundary segments, including no boundary
+ * at all in case of a closed genus-0 surface mesh which is topologically
+ * equivalent to a sphere. This class represents a single boundary segment.
+ */
+class BoundarySegment : public Object
+{
+  mirtkObjectMacro(BoundarySegment);
+
+  // ---------------------------------------------------------------------------
+  // Types
+
+  /// Type of surface point ID to boundary segment point index map
+  typedef UnorderedMap<int, int> PointIdToIndexMap;
+
+  // ---------------------------------------------------------------------------
+  // Attributes
+
+  /// Surface mesh which this boundary segment belongs to
+  mirtkReadOnlyAttributeMacro(vtkSmartPointer<vtkPolyData>, Surface);
+
+  /// IDs of boundary segment points
+  mirtkReadOnlyAttributeMacro(Array<int>, PointIds);
+
+  /// Pre-computed map from surface point ID to boundary segment point index
+  mirtkAttributeMacro(PointIdToIndexMap, Index);
+
+  /// Indices of selected points
+  mirtkAttributeMacro(Array<int>, Selection);
+
+  /// Pre-computed boundary segment edge lengths
+  Vector _EdgeLengths;
+
+  /// Length of boundary segment
+  double _Length;
+
+  /// Copy attributes of this class from another instance
+  void CopyAttributes(const BoundarySegment &);
+
+  // ---------------------------------------------------------------------------
+  // Construction/Destruction
+
+public:
+
+  /// Default constructor
+  BoundarySegment();
+
+  /// Constructor
+  ///
+  /// \param[in] surface Surface mesh.
+  /// \param[in] ptIds   Ordered list of IDs of surface points making up this
+  ///                    boundary segment.
+  BoundarySegment(vtkPolyData *surface, const Array<int> &ptIds);
+
+  /// Copy constructor
+  BoundarySegment(const BoundarySegment &);
+
+  /// Assignment operator
+  BoundarySegment &operator =(const BoundarySegment &);
+
+  /// Destructor
+  virtual ~BoundarySegment();
+
+  // ---------------------------------------------------------------------------
+  // Initialization
+
+  /// Pre-compute map of surface point ID to boundary segment point index
+  void InitializeIndex();
+
+  // Pre-compute edge lengths and total length
+  void InitializeLengths();
+
+  /// Compute edge lengths
+  Vector ComputeEdgeLengths() const;
+
+  /// Compute length of boundary segment
+  double ComputeLength() const;
+
+  // ---------------------------------------------------------------------------
+  // Boundary points
+
+  /// Number of boundary segment points
+  int NumberOfPoints() const;
+ 
+  /// Get boundary segment point index in range [0, N)
+  int IndexModuloNumberOfPoints(int i) const;
+
+  /// Get surface point ID of i-th boundary segment point
+  ///
+  /// \param[in] i Index of boundary segment point.
+  ///
+  /// \returns Surface point ID of i-th boundary segment point.
+  int PointId(int i) const;
+
+  /// Get boundary segment point coordinates
+  ///
+  /// \param[in]  i Index of boundary segment point.
+  /// \param[out] p Coordinates of i-th boundary segment point.
+  void GetPoint(int i, double p[3]) const;
+
+  /// Get boundary segment point coordinates
+  ///
+  /// \param[in] i Index of boundary segment point.
+  ///
+  /// \returns Coordinates of i-th boundary segment point.
+  class Point Point(int i) const;
+
+  /// Find surface point in boundary segment
+  ///
+  /// \param[in] ptId Surface point ID.
+  ///
+  /// \returns Boundary segment point index or -1 if segment does not contain this point.
+  int Find(int ptId) const;
+
+  /// Whether this boundary segment contains a given surface point
+  ///
+  /// \param[in] ptId Surface point ID.
+  ///
+  /// \returns Whether surface point ID is part of this boundary segment.
+  bool Contains(int ptId) const;
+
+  // ---------------------------------------------------------------------------
+  // Boundary edges
+
+  /// Get total length of boundary segment
+  double Length() const;
+
+  /// Get lengths of boundary segment edges
+  Vector EdgeLengths() const;
+
+  /// Length of boundary segment edge
+  ///
+  /// \param[in] i  Index of first boundary segment point.
+  /// \param[in] di Index increment +1 or -1, i.e., traversal direction.
+  ///
+  /// \returns Boundary segment edge lengths.
+  double EdgeLength(int i, int di = +1) const;
+
+  // ---------------------------------------------------------------------------
+  // Selected points
+
+  /// Reserve space for n selected points
+  ///
+  /// \param[in] n Number of points to be selected.
+  void ReserveSelection(int n);
+
+  /// Remove the i-th selected point
+  ///
+  /// \param[in] i Selected point index.
+  void RemoveSelection(int i);
+
+  /// Deselect all points
+  void ClearSelection();
+
+  /// Add i-th boundary segment point to selection
+  ///
+  /// \param[in] i Boundary segment point index.
+  void SelectPoint(int i);
+
+  /// Remove i-th boundary segment point from selection
+  ///
+  /// \param[in] i Boundary segment point index.
+  void DeselectPoint(int i);
+
+  /// Number of selected curve points
+  int NumberOfSelectedPoints() const;
+
+  /// Get boundary segment point index of i-th selected boundary point
+  ///
+  /// \param[in] i Index of selected point.
+  ///
+  /// \return Index of corresponding boundary segment point.
+  int SelectedPointIndex(int i) const;
+
+  /// Get surface point ID of i-th selected boundary point
+  ///
+  /// \param[in] i Index of selected point.
+  ///
+  /// \return Index of corresponding surface point.
+  int SelectedPointId(int i) const;
+
+  /// Get selected boundary segment point coordinates
+  ///
+  /// \param[in]  i Index of selected boundary segment point.
+  /// \param[out] p Coordinates of i-th selected boundary segment point.
+  void GetSelectedPoint(int i, double p[3]) const;
+
+  /// Get selected boundary segment point coordinates
+  ///
+  /// \param[in] i Index of selected boundary segment point.
+  ///
+  /// \returns Coordinates of i-th selected boundary segment point.
+  class Point SelectedPoint(int i) const;
+
+  /// Check if boundary segment point is selected
+  ///
+  /// \param[in] i Index of boundary segment point.
+  ///              The index is taken modulo the number of boundary
+  ///              points and negative values count from the end of
+  ///              the list of boundary points.
+  ///
+  /// \return Whether boundary segment point is selected.
+  bool IsSelected(int i) const;
+
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Inline definitions
+////////////////////////////////////////////////////////////////////////////////
+
+// =============================================================================
+// Initialization
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+inline double BoundarySegment::ComputeLength() const
+{
+  if (_EdgeLengths) return _EdgeLengths.Sum();
+  return ComputeEdgeLengths().Sum();
+}
+
+// =============================================================================
+// Boundary points
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+inline int BoundarySegment::NumberOfPoints() const
+{
+  return static_cast<int>(_PointIds.size());
+}
+
+// -----------------------------------------------------------------------------
+inline int BoundarySegment::IndexModuloNumberOfPoints(int i) const
+{
+  const int n = NumberOfPoints();
+  if      (i <  0) i = (i + 1) % n + n - 1;
+  else if (i >= n) i =  i      % n;
+  return i;
+}
+
+// -----------------------------------------------------------------------------
+inline int BoundarySegment::PointId(int i) const
+{
+  i = IndexModuloNumberOfPoints(i);
+  return _PointIds[i];
+}
+
+// -----------------------------------------------------------------------------
+inline void BoundarySegment::GetPoint(int i, double p[3]) const
+{
+  i = IndexModuloNumberOfPoints(i);
+  _Surface->GetPoint(static_cast<vtkIdType>(PointId(i)), p);
+}
+
+// -----------------------------------------------------------------------------
+inline Point BoundarySegment::Point(int i) const
+{
+  double p[3];
+  GetPoint(i, p);
+  return p;
+}
+
+// -----------------------------------------------------------------------------
+inline bool BoundarySegment::Contains(int ptId) const
+{
+  return Find(ptId) != -1;
+}
+
+// =============================================================================
+// Boundary edges
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+inline double BoundarySegment::Length() const
+{
+  if (_Length > 0.) return _Length;
+  return ComputeLength();
+}
+
+// -----------------------------------------------------------------------------
+inline Vector BoundarySegment::EdgeLengths() const
+{
+  if (_EdgeLengths) return _EdgeLengths;
+  return ComputeEdgeLengths();
+}
+
+// -----------------------------------------------------------------------------
+inline double BoundarySegment::EdgeLength(int i, int di) const
+{
+  if (_EdgeLengths) {
+    return _EdgeLengths(IndexModuloNumberOfPoints(di < 0 ? i-1 : i));
+  } else {
+    return Point(i).Distance(Point(i + di));
+  }
+}
+
+// =============================================================================
+// Selected points
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+inline int BoundarySegment::NumberOfSelectedPoints() const
+{
+  return static_cast<int>(_Selection.size());
+}
+
+// -----------------------------------------------------------------------------
+inline int BoundarySegment::SelectedPointIndex(int i) const
+{
+  return _Selection[i];
+}
+
+// -----------------------------------------------------------------------------
+inline int BoundarySegment::SelectedPointId(int i) const
+{
+  return _PointIds[_Selection[i]];
+}
+
+// -----------------------------------------------------------------------------
+inline void BoundarySegment::GetSelectedPoint(int i, double p[3]) const
+{
+  GetPoint(_Selection[i], p);
+}
+
+// -----------------------------------------------------------------------------
+inline Point BoundarySegment::SelectedPoint(int i) const
+{
+  return Point(_Selection[i]);
+}
+
+// -----------------------------------------------------------------------------
+inline bool BoundarySegment::IsSelected(int i) const
+{
+  for (auto it = _Selection.begin(); it != _Selection.end(); ++it) {
+    if (*it == i) return true;
+  }
+  return false;
+}
+
+
+} // namespace mirtk
+
+#endif // MIRTK_BoundarySegment_H

--- a/Modules/PointSet/include/mirtk/PointSetUtils.h
+++ b/Modules/PointSet/include/mirtk/PointSetUtils.h
@@ -20,10 +20,14 @@
 #ifndef MIRTK_PointSetUtils_H
 #define MIRTK_PointSetUtils_H
 
+#include "mirtk/UnorderedSet.h"
+#include "mirtk/Array.h"
+#include "mirtk/List.h"
+#include "mirtk/Pair.h"
+
 #include "mirtk/Math.h"
 #include "mirtk/Vtk.h"
 #include "mirtk/VtkMath.h"
-#include "mirtk/UnorderedSet.h"
 
 class vtkDataSet;
 class vtkDataSetAttributes;
@@ -33,7 +37,6 @@ class vtkImageData;
 class vtkImageStencilData;
 class vtkDataArray;
 class vtkCell;
-class vtkCellArray;
 
 
 namespace mirtk {
@@ -265,8 +268,11 @@ bool IsTetrahedralMesh(vtkDataSet *);
 /// Get IDs of end points of boundary edges
 UnorderedSet<int> BoundaryPoints(vtkDataSet *, const EdgeTable * = nullptr);
 
+/// Get list of boundary edges
+List<Pair<int, int> > BoundaryEdges(vtkDataSet *, const EdgeTable &);
+
 /// Get connected boundary segments as (closed) line strips
-vtkSmartPointer<vtkCellArray> BoundarySegments(vtkDataSet *, const EdgeTable * = nullptr);
+Array<Array<int> > BoundarySegments(vtkDataSet *, const EdgeTable * = nullptr);
 
 /// Number of points
 int NumberOfPoints(vtkDataSet *);

--- a/Modules/PointSet/include/mirtk/SurfaceBoundary.h
+++ b/Modules/PointSet/include/mirtk/SurfaceBoundary.h
@@ -1,0 +1,344 @@
+/*
+ * Medical Image Registration ToolKit (MIRTK)
+ *
+ * Copyright 2016 Imperial College London
+ * Copyright 2016 Andreas Schuh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MIRTK_SurfaceBoundary_H
+#define MIRTK_SurfaceBoundary_H
+
+#include "mirtk/Object.h"
+
+#include "mirtk/Memory.h"
+#include "mirtk/Array.h"
+#include "mirtk/UnorderedMap.h"
+#include "mirtk/Point.h"
+
+#include "mirtk/EdgeTable.h"
+#include "mirtk/BoundarySegment.h"
+
+#include "vtkSmartPointer.h"
+#include "vtkPolyData.h"
+
+
+namespace mirtk {
+
+
+/**
+ * Boundary points and boundary segments of surface mesh
+ */
+class SurfaceBoundary : public Object
+{
+  mirtkObjectMacro(SurfaceBoundary);
+
+  // ---------------------------------------------------------------------------
+  // Types
+
+  /// Type of shared edge table pointer
+  typedef SharedPtr<class EdgeTable> EdgeTablePointer;
+
+  /// Type of surface point ID to boundary point index map
+  typedef UnorderedMap<int, int> PointIdToIndexMap;
+
+  // ---------------------------------------------------------------------------
+  // Attributes
+
+  /// Surface mesh
+  mirtkPublicAttributeMacro(vtkSmartPointer<vtkPolyData>, Surface);
+
+  /// Pre-computed edge table (optional)
+  mirtkPublicAttributeMacro(EdgeTablePointer, EdgeTable);
+
+  /// IDs of boundary points
+  mirtkReadOnlyAttributeMacro(Array<int>, PointIds);
+
+  /// Map from surface point ID to boundary point index
+  mirtkAttributeMacro(PointIdToIndexMap, Index);
+
+  /// Closed boundary segments
+  mirtkReadOnlyAttributeMacro(Array<BoundarySegment>, Segments);
+
+  /// Copy attributes of this class from another instance
+  void CopyAttributes(const SurfaceBoundary &);
+
+  // ---------------------------------------------------------------------------
+  // Construction/Destruction
+
+public:
+
+  /// Constructor
+  SurfaceBoundary(vtkPolyData *, EdgeTablePointer = nullptr);
+
+  /// Copy constructor
+  SurfaceBoundary(const SurfaceBoundary &);
+
+  /// Assignment operator
+  SurfaceBoundary &operator =(const SurfaceBoundary &);
+
+  /// Destructor
+  virtual ~SurfaceBoundary();
+
+  // ---------------------------------------------------------------------------
+  // Initialization
+
+  /// Pre-compute maps of surface point ID to boundary (segment) point index
+  void InitializeIndex();
+
+  /// Pre-compute boundary edge lengths and length of each segment
+  void InitializeLengths();
+
+  // ---------------------------------------------------------------------------
+  // Boundary points
+
+  /// Number of surface boundary points
+  int NumberOfPoints() const;
+
+  /// Surface point index of boundary point
+  ///
+  /// \param[in] i SurfaceBoundary point index.
+  ///
+  /// \returns Surface point index of i-th boundary point.
+  int PointId(int i) const;
+
+  /// Get coordinates of boundary point
+  ///
+  /// \param[in]  i Index of boundary point.
+  /// \param[out] p Boundary point coordinates.
+  void GetPoint(int i, double p[3]) const;
+
+  /// Get coordinates of boundary point
+  ///
+  /// \param[in] i Index of boundary point.
+  ///
+  /// \return Boundary point coordinates.
+  class Point Point(int i) const;
+
+  /// Find surface point ID in list of boundary points
+  ///
+  /// \param[in] ptId Surface point ID.
+  ///
+  /// \returns Index of surface boundary point or -1 if point is not on the boundary.
+  int Find(int ptId) const;
+ 
+  /// Check if surface point is on the boundary
+  ///
+  /// \param[in] ptId Surface point ID.
+  ///
+  /// \returns Whether a given surface point is on the boundary.
+  bool Contains(int ptId) const;
+
+  // ---------------------------------------------------------------------------
+  // Boundary segments
+
+  /// Number of boundary segments
+  int NumberOfSegments() const;
+
+  /// Get index of boundary segment that a surface point belongs to
+  ///
+  /// \param[in]  ptId Index of surface point.
+  /// \param[out] i    Corresponding boundary segment point index.
+  ///
+  /// \returns Index of first encountered boundary segment.
+  /// \retval -1 if point is not a boundary point.
+  int FindSegment(int ptId, int *i = nullptr) const;
+
+  /// Get index of longest boundary segment
+  int FindLongestSegment() const;
+
+  /// Get index of boundary segment which contains the most boundary points
+  int FindLargestSegment() const;
+
+  /// Get n-th boundary segment
+  ///
+  /// \param[in] n Index of boundary segment.
+  ///
+  /// \returns Reference to n-th boundary segment.
+  const BoundarySegment &Segment(int n) const;
+
+  /// Get longest boundary segment
+  const BoundarySegment &LongestSegment() const;
+
+  /// Get boundary segment which contains the most boundary points
+  const BoundarySegment &LargestSegment() const;
+
+  /// Number of boundary segment points
+  int NumberOfPoints(int n) const;
+
+  /// Surface point IDs of points making up a boundary point segment
+  ///
+  /// \param[in] n Index of boundary segment.
+  ///
+  /// \returns Indices of surface points making up the n-th boundary segment.
+  const Array<int> &PointIds(int n) const;
+
+  /// Surface point ID of boundary segment point
+  ///
+  /// \param[in] n Index of boundary segment.
+  /// \param[in] i Index of boundary segment point.
+  ///
+  /// \returns Surface point ID of i-th point of n-th boundary segment.
+  int PointId(int n, int i) const;
+
+  /// Get indices of boundary points making up a boundary segment
+  ///
+  /// \param[in]  n Index of boundary segment.
+  /// \param[out] i Indices of boundary points making up the n-th boundary segment.
+  void PointIndices(int n, Array<int> &i) const;
+
+  /// Get indices of boundary points making up a boundary segment
+  ///
+  /// \param[in] n Index of boundary segment.
+  ///
+  /// \returns Indices of boundary points making up the n-th boundary segment.
+  Array<int> PointIndices(int n) const;
+
+  /// Boundary point index of boundary segment point
+  ///
+  /// \param[in] n Index of boundary segment.
+  /// \param[in] i Index of boundary segment point.
+  ///
+  /// \returns Boundary point index of i-th point of n-th boundary segment.
+  int PointIndex(int n, int i) const;
+
+  // ---------------------------------------------------------------------------
+  // Selected points
+
+  /// Select i-th boundary point
+  ///
+  /// \param[in] i Boundary point index.
+  void SelectPoint(int i);
+
+  /// Deselect i-th boundary point
+  ///
+  /// \param[in] i Boundary point index.
+  void DeselectPoint(int i);
+
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Inline definitions
+////////////////////////////////////////////////////////////////////////////////
+
+// =============================================================================
+// Boundary points
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+inline int SurfaceBoundary::NumberOfPoints() const
+{
+  return static_cast<int>(_PointIds.size());
+}
+
+// -----------------------------------------------------------------------------
+inline int SurfaceBoundary::PointId(int i) const
+{
+  return _PointIds[i];
+}
+
+// -----------------------------------------------------------------------------
+inline void SurfaceBoundary::GetPoint(int i, double p[3]) const
+{
+  const int ptId = PointId(i);
+  _Surface->GetPoint(static_cast<vtkIdType>(ptId), p);
+}
+
+// -----------------------------------------------------------------------------
+inline Point SurfaceBoundary::Point(int i) const
+{
+  double p[3];
+  GetPoint(i, p);
+  return p;
+}
+
+// -----------------------------------------------------------------------------
+inline bool SurfaceBoundary::Contains(int ptId) const
+{
+  return Find(ptId) != -1;
+}
+
+// =============================================================================
+// Boundary segments
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+inline int SurfaceBoundary::NumberOfSegments() const
+{
+  return static_cast<int>(_Segments.size());
+}
+
+// -----------------------------------------------------------------------------
+inline const BoundarySegment &SurfaceBoundary::Segment(int n) const
+{
+  return _Segments[n];
+}
+
+// -----------------------------------------------------------------------------
+inline const BoundarySegment &SurfaceBoundary::LongestSegment() const
+{
+  return Segment(FindLongestSegment());
+}
+
+// -----------------------------------------------------------------------------
+inline const BoundarySegment &SurfaceBoundary::LargestSegment() const
+{
+  return Segment(FindLargestSegment());
+}
+
+// -----------------------------------------------------------------------------
+inline int SurfaceBoundary::NumberOfPoints(int n) const
+{
+  return Segment(n).NumberOfPoints();
+}
+
+// -----------------------------------------------------------------------------
+inline const Array<int> &SurfaceBoundary::PointIds(int n) const
+{
+  return Segment(n).PointIds();
+}
+
+// -----------------------------------------------------------------------------
+inline int SurfaceBoundary::PointId(int n, int i) const
+{
+  return Segment(n).PointId(i);
+}
+
+// -----------------------------------------------------------------------------
+inline void SurfaceBoundary::PointIndices(int n, Array<int> &i) const
+{
+  i = PointIds(n);
+  for (auto it = i.begin(); it != i.end(); ++it) {
+    *it = Find(*it);
+  }
+}
+
+// -----------------------------------------------------------------------------
+inline Array<int> SurfaceBoundary::PointIndices(int n) const
+{
+  Array<int> i;
+  PointIndices(n, i);
+  return i;
+}
+
+// -----------------------------------------------------------------------------
+inline int SurfaceBoundary::PointIndex(int n, int i) const
+{
+  return Find(Segment(n).PointId(i));
+}
+
+
+} // namespace mirtk
+
+#endif // MIRTK_SurfaceBoundary_H

--- a/Modules/PointSet/src/BoundarySegment.cc
+++ b/Modules/PointSet/src/BoundarySegment.cc
@@ -1,0 +1,190 @@
+/*
+ * Medical Image Registration ToolKit (MIRTK)
+ *
+ * Copyright 2016 Imperial College London
+ * Copyright 2016 Andreas Schuh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mirtk/BoundarySegment.h"
+
+#include "mirtk/Assert.h"
+#include "mirtk/Algorithm.h"
+
+
+namespace mirtk {
+
+
+// =============================================================================
+// Construction/destruction
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+void BoundarySegment::CopyAttributes(const BoundarySegment &other)
+{
+  _Surface     = other._Surface;
+  _PointIds    = other._PointIds;
+  _Index       = other._Index;
+  _Selection   = other._Selection;
+  _EdgeLengths = other._EdgeLengths;
+  _Length      = other._Length;
+}
+
+// -----------------------------------------------------------------------------
+BoundarySegment::BoundarySegment()
+:
+  _Length(0.)
+{
+}
+
+// -----------------------------------------------------------------------------
+BoundarySegment::BoundarySegment(vtkPolyData *surface, const Array<int> &ptIds)
+:
+  _Surface(surface),
+  _PointIds(ptIds),
+  _Length(0.)
+{
+}
+
+// -----------------------------------------------------------------------------
+BoundarySegment::BoundarySegment(const BoundarySegment &other)
+:
+  Object(other)
+{
+  CopyAttributes(other);
+}
+
+// -----------------------------------------------------------------------------
+BoundarySegment &BoundarySegment::operator =(const BoundarySegment &other)
+{
+  if (this != &other) {
+    Object::operator =(other);
+    CopyAttributes(other);
+  }
+  return *this;
+}
+
+// -----------------------------------------------------------------------------
+BoundarySegment::~BoundarySegment()
+{
+}
+
+// =============================================================================
+// Initialization
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+void BoundarySegment::InitializeIndex()
+{
+  if (_Index.empty()) {
+    int i = 0;
+    _Index.reserve(_PointIds.size());
+    for (auto it = _PointIds.begin(); it != _PointIds.end(); ++it, ++i) {
+      _Index[*it] = i;
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+void BoundarySegment::InitializeLengths()
+{
+  if (!_EdgeLengths) {
+    _EdgeLengths = ComputeEdgeLengths();
+    _Length      = _EdgeLengths.Sum();
+  } else if (_Length == 0.) {
+    _Length = _EdgeLengths.Sum();
+  }
+}
+
+// -----------------------------------------------------------------------------
+Vector BoundarySegment::ComputeEdgeLengths() const
+{
+  const int npoints = NumberOfPoints();
+  if (npoints == 0) return Vector();
+
+  const class Point p0 = Point(0);
+
+  class Point p1, p2;
+  Vector      l(npoints);
+
+  p1 = p0;
+  for (int i = 1; i < npoints; ++i) {
+    p2 = Point(i);
+    l(i-1) = p1.Distance(p2);
+    p1 = p2;
+  }
+  l(npoints-1) = p1.Distance(p0);
+
+  return l;
+}
+
+// =============================================================================
+// Boundary points
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+int BoundarySegment::Find(int ptId) const
+{
+  if (_Index.empty()) {
+    auto it = find(_PointIds.begin(), _PointIds.end(), ptId);
+    if (it == _PointIds.end()) return -1;
+    return distance(_PointIds.begin(), it);
+  } else {
+    auto it = _Index.find(ptId);
+    if (it == _Index.end()) return -1;
+    return it->second;
+  }
+}
+
+// =============================================================================
+// Selected points
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+void BoundarySegment::ReserveSelection(int n)
+{
+  _Selection.reserve(n);
+}
+
+// -----------------------------------------------------------------------------
+void BoundarySegment::RemoveSelection(int i)
+{
+  mirtkAssert(i >= 0 && i < static_cast<int>(_Selection.size()), "valid selection index");
+  _Selection.erase(_Selection.begin() + i);
+}
+
+// -----------------------------------------------------------------------------
+void BoundarySegment::ClearSelection()
+{
+  _Selection.clear();
+}
+
+// -----------------------------------------------------------------------------
+void BoundarySegment::SelectPoint(int i)
+{
+  mirtkAssert(i >= 0 && i < NumberOfPoints(), "valid boundary segment point index");
+  if (find(_Selection.begin(), _Selection.end(), i) == _Selection.end()) {
+    _Selection.push_back(i);
+  }
+}
+
+// -----------------------------------------------------------------------------
+void BoundarySegment::DeselectPoint(int i)
+{
+  auto it = find(_Selection.begin(), _Selection.end(), i);
+  if (it != _Selection.end()) _Selection.erase(it);
+}
+
+
+} // namespace mirtk

--- a/Modules/PointSet/src/CMakeLists.txt
+++ b/Modules/PointSet/src/CMakeLists.txt
@@ -24,6 +24,7 @@
 
 set(HEADERS
   ${BINARY_INCLUDE_DIR}/mirtk/PointSetExport.h
+  BoundarySegment.h
   ClosestCell.h
   ClosestPoint.h
   ClosestPointLabel.h
@@ -46,11 +47,13 @@ set(HEADERS
   RobustPointMatch.h
   SpectralDecomposition.h
   SpectralMatch.h
+  SurfaceBoundary.h
   SurfaceCollisions.h
   Triangle.h
 )
 
 set(SOURCES
+  BoundarySegment.cc
   ClosestCell.cc
   ClosestPoint.cc
   ClosestPointLabel.cc
@@ -75,6 +78,7 @@ set(SOURCES
   RobustPointMatch.cc
   SpectralDecomposition.cc
   SpectralMatch.cc
+  SurfaceBoundary.cc
   SurfaceCollisions.cc
 )
 

--- a/Modules/PointSet/src/SurfaceBoundary.cc
+++ b/Modules/PointSet/src/SurfaceBoundary.cc
@@ -1,0 +1,250 @@
+/*
+ * Medical Image Registration ToolKit (MIRTK)
+ *
+ * Copyright 2016 Imperial College London
+ * Copyright 2016 Andreas Schuh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mirtk/SurfaceBoundary.h"
+
+#include "mirtk/List.h"
+#include "mirtk/Pair.h"
+#include "mirtk/UnorderedSet.h"
+#include "mirtk/Algorithm.h"
+
+#include "mirtk/PointSetUtils.h"
+
+
+namespace mirtk {
+
+
+// =============================================================================
+// Construction/destruction
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+void SurfaceBoundary::CopyAttributes(const SurfaceBoundary &other)
+{
+  _Surface   = other._Surface;
+  _EdgeTable = other._EdgeTable;
+  _PointIds  = other._PointIds;
+  _Index     = other._Index;
+  _Segments  = other._Segments;
+}
+
+// -----------------------------------------------------------------------------
+SurfaceBoundary::SurfaceBoundary(vtkPolyData *surface, EdgeTablePointer edgeTable)
+:
+  _Surface(surface),
+  _EdgeTable(edgeTable)
+{
+  // Get list of boundary edges
+  if (!edgeTable) edgeTable = NewShared<class EdgeTable>(_Surface);
+  List<Pair<int, int> > boundaryEdges = BoundaryEdges(_Surface, *edgeTable);
+
+  // Get set of boundary point IDs
+  UnorderedSet<int> boundaryPtIds;
+  for (auto edge = boundaryEdges.begin(); edge != boundaryEdges.end(); ++edge) {
+    boundaryPtIds.insert(edge->first);
+    boundaryPtIds.insert(edge->second);
+  }
+
+  // Store ordered set in container with random access
+  _PointIds.clear();
+  _PointIds.reserve(boundaryPtIds.size());
+  copy(boundaryPtIds.begin(), boundaryPtIds.end(), back_inserter(_PointIds));
+  sort(_PointIds.begin(), _PointIds.end());
+
+  // Extract boundary segments
+  _Segments.clear();
+  int ptId1, ptId2;
+  Array<int> ptIds;
+  ptIds.reserve(boundaryPtIds.size());
+  while (!boundaryPtIds.empty()) {
+    ptId1 = *boundaryPtIds.begin();
+    ptIds.clear();
+    do {
+      ptIds.push_back(ptId1);
+      boundaryPtIds.erase(ptId1);
+      ptId2 = -1;
+      for (auto edge = boundaryEdges.begin(); edge != boundaryEdges.end(); ++edge) {
+        if (edge->first == ptId1) {
+          if (boundaryPtIds.find(edge->second) != boundaryPtIds.end()) {
+            ptId2 = edge->second;
+            boundaryEdges.erase(edge);
+            break;
+          }
+        } else if (edge->second == ptId1) {
+          if (boundaryPtIds.find(edge->first) != boundaryPtIds.end()) {
+            ptId2 = edge->first;
+            boundaryEdges.erase(edge);
+            break;
+          }
+        }
+      }
+      ptId1 = ptId2;
+    } while (ptId1 != -1);
+    _Segments.reserve(_Segments.size() + 1);
+    _Segments.push_back(BoundarySegment(_Surface, ptIds));
+  }
+}
+
+// -----------------------------------------------------------------------------
+SurfaceBoundary::SurfaceBoundary(const SurfaceBoundary &other)
+:
+  Object(other)
+{
+  CopyAttributes(other);
+}
+
+// -----------------------------------------------------------------------------
+SurfaceBoundary &SurfaceBoundary::operator =(const SurfaceBoundary &other)
+{
+  if (this != &other) {
+    Object::operator =(other);
+    CopyAttributes(other);
+  }
+  return *this;
+}
+
+// -----------------------------------------------------------------------------
+SurfaceBoundary::~SurfaceBoundary()
+{
+}
+
+// =============================================================================
+// Initialization
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+void SurfaceBoundary::InitializeIndex()
+{
+  if (_Index.empty()) {
+    int i = 0;
+    _Index.reserve(_PointIds.size());
+    for (auto ptId = _PointIds.begin(); ptId != _PointIds.end(); ++ptId, ++i) {
+      _Index[*ptId] = i;
+    }
+  }
+  for (auto segment = _Segments.begin(); segment != _Segments.end(); ++segment) {
+    segment->InitializeIndex();
+  }
+}
+
+// -----------------------------------------------------------------------------
+void SurfaceBoundary::InitializeLengths()
+{
+  for (auto segment = _Segments.begin(); segment != _Segments.end(); ++segment) {
+    segment->InitializeLengths();
+  }
+}
+
+// =============================================================================
+// Boundary points
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+int SurfaceBoundary::Find(int ptId) const
+{
+  if (_Index.empty()) {
+    auto it = find(_PointIds.begin(), _PointIds.end(), ptId);
+    if (it == _PointIds.end()) return -1;
+    return distance(_PointIds.begin(), it);
+  } else {
+    auto it = _Index.find(ptId);
+    if (it == _Index.end()) return -1;
+    return it->second;
+  }
+}
+
+// =============================================================================
+// Boundary segments
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+int SurfaceBoundary::FindSegment(int ptId, int *i) const
+{
+  int idx = -1, n = 0;
+  for (const auto &segment : _Segments) {
+    idx = segment.Find(ptId);
+    if (idx != -1) {
+      if (i != nullptr) *i = idx;
+      return n;
+    }
+    ++n;
+  }
+  if (i != nullptr) *i = -1;
+  return -1;
+}
+
+// -----------------------------------------------------------------------------
+int SurfaceBoundary::FindLongestSegment() const
+{
+  if (_Segments.size() == 1) return 0;
+  int    N = 0, n = 0;
+  double L = 0., l;
+  for (const auto &segment : _Segments) {
+    l = segment.Length();
+    if (l > L) {
+      L = l;
+      N = n;
+    }
+    ++n;
+  }
+  return N;
+}
+
+// -----------------------------------------------------------------------------
+int SurfaceBoundary::FindLargestSegment() const
+{
+  int N = 0, n = 0;
+  int L = 0, l;
+  for (const auto &segment : _Segments) {
+    l = segment.NumberOfPoints();
+    if (l > L) {
+      L = l;
+      N = n;
+    }
+    ++n;
+  }
+  return N;
+}
+
+// =============================================================================
+// Selected points
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+void SurfaceBoundary::SelectPoint(int i)
+{
+  const int ptId = PointId(i);
+  for (auto && segment : _Segments) {
+    auto pos = segment.Find(ptId);
+    if (pos >= 0) segment.SelectPoint(pos);
+  }
+}
+
+// -----------------------------------------------------------------------------
+void SurfaceBoundary::DeselectPoint(int i)
+{
+  const int ptId = PointId(i);
+  for (auto && segment : _Segments) {
+    auto pos = segment.Find(ptId);
+    if (pos >= 0) segment.DeselectPoint(pos);
+  }
+}
+
+
+} // namespace mirtk


### PR DESCRIPTION
Auxiliary classes utilized in refactored and extended Mapping module, but are of common use.