### PR TITLE
fix: Build links right before curvature filter is run [Applications]

### DIFF
--- a/Applications/src/calculate-surface-attributes.cc
+++ b/Applications/src/calculate-surface-attributes.cc
@@ -221,7 +221,6 @@ int main(int argc, char *argv[])
   vtkSmartPointer<vtkPolyData> surface;
   if (curvature_type != 0) surface = Triangulate(input);
   else                     surface = input;
-  surface->BuildLinks();
 
   // Calculate normals
   if (point_normals || cell_normals) {
@@ -242,6 +241,9 @@ int main(int argc, char *argv[])
   // Calculate curvatures
   if (curvature_type != 0) {
     if (verbose) cout << "Calculating surface curvature measure(s)...", cout.flush();
+
+    // Build surface links
+    surface->BuildLinks();
 
     // Compute curvature
     PolyDataCurvature curvature;


### PR DESCRIPTION
Minor bug in `calculate-pointset-attributes`. The `vtkPolyData` links/cells may not be available anymore after the `vtkPolyDataNormals` filter has run. Thus, build links right before the curvature filter is run instead. The `vtkPolyDataNormals` filter itself builds the links of the input.