### PR TITLE
enh: Rename `calculate` tool to `calculate-element-wise` [Applications]

### DIFF
--- a/Applications/lib/python/mirtk/subprocess.py.in
+++ b/Applications/lib/python/mirtk/subprocess.py.in
@@ -50,7 +50,8 @@ def path(argv, quiet=False):
     """Get full path of MIRTK command executable."""
     if isinstance(argv, str): command = argv
     else:                     command = argv[0]
-    if   command == 'convert-dof2csv':    command = 'convert-dof'
+    if   command == 'calculate':          command = 'calculate-element-wise'
+    elif command == 'convert-dof2csv':    command = 'convert-dof'
     elif command == 'convert-dof2velo':   command = 'convert-dof'
     elif command == 'concatenate-dofs':   command = 'compose-dofs'
     elif command == 'concatenate-images': command = 'combine-images'

--- a/Applications/src/CMakeLists.txt
+++ b/Applications/src/CMakeLists.txt
@@ -51,7 +51,7 @@ if (MIRTK_Image_FOUND)
   endmacro()
 
   add_image_command(average-images)
-  add_image_command(calculate)
+  add_image_command(calculate-element-wise)
   add_image_command(calculate-distance-map)
   add_image_command(calculate-exponential-map)
   add_image_command(calculate-lie-bracket)
@@ -80,7 +80,7 @@ if (MIRTK_Image_FOUND)
   endif ()
 
   if (MIRTK_Image_WITH_VTK)
-    mirtk_target_dependencies(calculate vtkCommonCore)
+    mirtk_target_dependencies(calculate-element-wise vtkCommonCore)
   endif ()
 
   if (MIRTK_Transformation_FOUND AND MIRTK_Registration_FOUND)

--- a/Applications/src/calculate-element-wise.cc
+++ b/Applications/src/calculate-element-wise.cc
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2015-2016 Imperial College London
+ * Copyright 2015-2016 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@
 #include "mirtk/DataFunctions.h"
 
 #if MIRTK_Image_WITH_VTK
-#  include "vtkDataSet.h"
-#  include "vtkSmartPointer.h"
+  #include "vtkDataSet.h"
+  #include "vtkSmartPointer.h"
 #endif
 
 using namespace mirtk;


### PR DESCRIPTION
The `mirtk` script maps `calculate` command to the new name `calculate-element-wise`.