### PR TITLE
enh: Rename PolyDataFilter to MeshFilter and add SurfaceFilter base class

### DIFF
--- a/Applications/src/calculate-surface-attributes.cc
+++ b/Applications/src/calculate-surface-attributes.cc
@@ -22,8 +22,8 @@
 
 #include "mirtk/PointSetIO.h"
 #include "mirtk/PointSetUtils.h"
-#include "mirtk/PolyDataCurvature.h"
-#include "mirtk/PolyDataSmoothing.h"
+#include "mirtk/SurfaceCurvature.h"
+#include "mirtk/MeshSmoothing.h"
 
 #include "vtkSmartPointer.h"
 #include "vtkPolyData.h"
@@ -97,15 +97,15 @@ int main(int argc, char *argv[])
   const char *input_name  = POSARG(1);
   const char *output_name = POSARG(2);
 
-  const char *kmin_name       = PolyDataCurvature::MINIMUM;
-  const char *kmax_name       = PolyDataCurvature::MAXIMUM;
-  const char *gauss_name      = PolyDataCurvature::GAUSS;
-  const char *mean_name       = PolyDataCurvature::MEAN;
-  const char *curvedness_name = PolyDataCurvature::CURVEDNESS;
-  const char *e1_name         = PolyDataCurvature::MINIMUM_DIRECTION;
-  const char *e2_name         = PolyDataCurvature::MAXIMUM_DIRECTION;
-  const char *tensor_name     = PolyDataCurvature::TENSOR;
-  const char *inverse_name    = PolyDataCurvature::INVERSE_TENSOR;
+  const char *kmin_name       = SurfaceCurvature::MINIMUM;
+  const char *kmax_name       = SurfaceCurvature::MAXIMUM;
+  const char *gauss_name      = SurfaceCurvature::GAUSS;
+  const char *mean_name       = SurfaceCurvature::MEAN;
+  const char *curvedness_name = SurfaceCurvature::CURVEDNESS;
+  const char *e1_name         = SurfaceCurvature::MINIMUM_DIRECTION;
+  const char *e2_name         = SurfaceCurvature::MAXIMUM_DIRECTION;
+  const char *tensor_name     = SurfaceCurvature::TENSOR;
+  const char *inverse_name    = SurfaceCurvature::INVERSE_TENSOR;
 
   bool   point_normals        = false;
   bool   cell_normals         = false;
@@ -130,49 +130,49 @@ int main(int argc, char *argv[])
     else if (OPTION("-consistency"))   consistency = true;
     else if (OPTION("-noconsistency")) consistency = false;
     else if (OPTION("-k1")) {
-      curvatures |= PolyDataCurvature::Minimum;
+      curvatures |= SurfaceCurvature::Minimum;
       if (HAS_ARGUMENT) kmin_name = ARGUMENT;
     }
     else if (OPTION("-k2")) {
-      curvatures |= PolyDataCurvature::Maximum;
+      curvatures |= SurfaceCurvature::Maximum;
       if (HAS_ARGUMENT) kmax_name = ARGUMENT;
     }
     else if (OPTION("-k1k2")) {
-      curvatures |= (PolyDataCurvature::Minimum | PolyDataCurvature::Maximum);
+      curvatures |= (SurfaceCurvature::Minimum | SurfaceCurvature::Maximum);
       if (HAS_ARGUMENT) {
         kmin_name = ARGUMENT;
         kmax_name = ARGUMENT;
       }
     }
     else if (OPTION("-H")) {
-      curvatures |= PolyDataCurvature::Mean;
+      curvatures |= SurfaceCurvature::Mean;
       if (HAS_ARGUMENT) mean_name = ARGUMENT;
     }
     else if (OPTION("-K")) {
-      curvatures |= PolyDataCurvature::Gauss;
+      curvatures |= SurfaceCurvature::Gauss;
       if (HAS_ARGUMENT) gauss_name = ARGUMENT;
     }
     else if (OPTION("-C")) {
-      curvatures |= PolyDataCurvature::Curvedness;
+      curvatures |= SurfaceCurvature::Curvedness;
       if (HAS_ARGUMENT) curvedness_name = ARGUMENT;
     }
     else if (OPTION("-n") || OPTION("-normal")) {
-      curvatures |= PolyDataCurvature::Normal;
+      curvatures |= SurfaceCurvature::Normal;
     }
     else if (OPTION("-e1")) {
-      curvatures |= PolyDataCurvature::MinimumDirection;
+      curvatures |= SurfaceCurvature::MinimumDirection;
       if (HAS_ARGUMENT) e1_name = ARGUMENT;
     }
     else if (OPTION("-e2")) {
-      curvatures |= PolyDataCurvature::MaximumDirection;
+      curvatures |= SurfaceCurvature::MaximumDirection;
       if (HAS_ARGUMENT) e2_name = ARGUMENT;
     }
     else if (OPTION("-tensor")) {
-      curvatures |= PolyDataCurvature::Tensor;
+      curvatures |= SurfaceCurvature::Tensor;
       if (HAS_ARGUMENT) tensor_name = ARGUMENT;
     }
     else if (OPTION("-inverse-tensor")) {
-      curvatures |= PolyDataCurvature::InverseTensor;
+      curvatures |= SurfaceCurvature::InverseTensor;
       if (HAS_ARGUMENT) inverse_name = ARGUMENT;
     }
     else if (OPTION("-tensor-averaging")) {
@@ -203,15 +203,15 @@ int main(int argc, char *argv[])
 
   if (curvatures == 0 && !point_normals && !cell_normals) {
     point_normals = true;
-    curvatures = PolyDataCurvature::Scalars;
+    curvatures = SurfaceCurvature::Scalars;
   }
 
   int curvature_type = curvatures;
   if (smooth_along_tensor) {
-    curvature_type |= PolyDataCurvature::Tensor;
+    curvature_type |= SurfaceCurvature::Tensor;
   } else if (smooth_sigma2 != .0) {
-    curvature_type |= PolyDataCurvature::MinimumDirection;
-    curvature_type |= PolyDataCurvature::MaximumDirection;
+    curvature_type |= SurfaceCurvature::MinimumDirection;
+    curvature_type |= SurfaceCurvature::MaximumDirection;
   }
 
   // Read input surface
@@ -242,11 +242,8 @@ int main(int argc, char *argv[])
   if (curvature_type != 0) {
     if (verbose) cout << "Calculating surface curvature measure(s)...", cout.flush();
 
-    // Build surface links
-    surface->BuildLinks();
-
     // Compute curvature
-    PolyDataCurvature curvature;
+    SurfaceCurvature curvature;
     curvature.Input(surface);
     curvature.CurvatureType(curvature_type);
     curvature.VtkCurvatures(use_vtkCurvatures);
@@ -257,15 +254,15 @@ int main(int argc, char *argv[])
 
     // Get output arrays
     vtkPointData *pd         = surface->GetPointData();
-    vtkDataArray *kmin       = pd->GetArray(PolyDataCurvature::MINIMUM);
-    vtkDataArray *kmax       = pd->GetArray(PolyDataCurvature::MAXIMUM);
-    vtkDataArray *mean       = pd->GetArray(PolyDataCurvature::MEAN);
-    vtkDataArray *gauss      = pd->GetArray(PolyDataCurvature::GAUSS);
-    vtkDataArray *curvedness = pd->GetArray(PolyDataCurvature::CURVEDNESS);
-    vtkDataArray *e1         = pd->GetArray(PolyDataCurvature::MINIMUM_DIRECTION);
-    vtkDataArray *e2         = pd->GetArray(PolyDataCurvature::MAXIMUM_DIRECTION);
-    vtkDataArray *tensor     = pd->GetArray(PolyDataCurvature::TENSOR);
-    vtkDataArray *inverse    = pd->GetArray(PolyDataCurvature::INVERSE_TENSOR);
+    vtkDataArray *kmin       = pd->GetArray(SurfaceCurvature::MINIMUM);
+    vtkDataArray *kmax       = pd->GetArray(SurfaceCurvature::MAXIMUM);
+    vtkDataArray *mean       = pd->GetArray(SurfaceCurvature::MEAN);
+    vtkDataArray *gauss      = pd->GetArray(SurfaceCurvature::GAUSS);
+    vtkDataArray *curvedness = pd->GetArray(SurfaceCurvature::CURVEDNESS);
+    vtkDataArray *e1         = pd->GetArray(SurfaceCurvature::MINIMUM_DIRECTION);
+    vtkDataArray *e2         = pd->GetArray(SurfaceCurvature::MAXIMUM_DIRECTION);
+    vtkDataArray *tensor     = pd->GetArray(SurfaceCurvature::TENSOR);
+    vtkDataArray *inverse    = pd->GetArray(SurfaceCurvature::INVERSE_TENSOR);
 
     // Rename output arrays
     if (kmin)       kmin      ->SetName(kmin_name);
@@ -284,7 +281,7 @@ int main(int argc, char *argv[])
     if (smooth_iterations) {
       if (verbose) cout << "Smoothing scalar curvature measures...", cout.flush();
 
-      PolyDataSmoothing smoother;
+      MeshSmoothing smoother;
       smoother.Input(surface);
       smoother.SmoothPointsOff();
       if (kmin)       smoother.SmoothArray(kmin_name);
@@ -297,7 +294,7 @@ int main(int argc, char *argv[])
       smoother.NumberOfIterations(smooth_iterations);
       smoother.Sigma(-smooth_sigma); // negative: multiple of avg. edge length
       if (smooth_anisotropic) {
-        smoother.Weighting(PolyDataSmoothing::AnisotropicGaussian);
+        smoother.Weighting(MeshSmoothing::AnisotropicGaussian);
         if (smooth_along_tensor) {
           smoother.GeometryTensorName(tensor_name);
         } else {
@@ -306,7 +303,7 @@ int main(int argc, char *argv[])
         }
         smoother.MaximumDirectionSigma(-smooth_sigma2);
       } else {
-        smoother.Weighting(PolyDataSmoothing::Gaussian);
+        smoother.Weighting(MeshSmoothing::Gaussian);
       }
       smoother.Run();
       vtkPointData *pd = smoother.Output()->GetPointData();
@@ -323,13 +320,13 @@ int main(int argc, char *argv[])
   }
 
   // Remove not requested output arrays which were used for anisotropic smoothing
-  if ((curvatures & PolyDataCurvature::Tensor) == 0) {
+  if ((curvatures & SurfaceCurvature::Tensor) == 0) {
     surface->GetPointData()->RemoveArray(tensor_name);
   }
-  if ((curvatures & PolyDataCurvature::MinimumDirection) == 0) {
+  if ((curvatures & SurfaceCurvature::MinimumDirection) == 0) {
     surface->GetPointData()->RemoveArray(e1_name);
   }
-  if ((curvatures & PolyDataCurvature::MaximumDirection) == 0) {
+  if ((curvatures & SurfaceCurvature::MaximumDirection) == 0) {
     surface->GetPointData()->RemoveArray(e2_name);
   }
 

--- a/Applications/src/offset-surface.cc
+++ b/Applications/src/offset-surface.cc
@@ -22,11 +22,10 @@
 
 #include "mirtk/PointSetIO.h"
 #include "mirtk/PointSetUtils.h"
-#include "mirtk/PolyDataSmoothing.h"
+#include "mirtk/MeshSmoothing.h"
 
 #include "mirtk/Vtk.h"
 #include "mirtk/VtkMath.h"
-
 #include "vtkSmartPointer.h"
 #include "vtkPolyData.h"
 #include "vtkPointData.h"
@@ -279,8 +278,7 @@ int main(int argc, char **argv)
     SetVTKConnection(extract, contours);
     extract->Update();
     if (extract->GetOutput()->GetNumberOfPoints() == 0) {
-      cerr << "Error: Failed to extract offset surface" << endl;
-      exit(1);
+      FatalError("Failed to extract offset surface");
     }
 
     extract->GetOutput()->GetPointData()->RemoveArray("ImageScalars");
@@ -288,10 +286,10 @@ int main(int argc, char **argv)
 
     // Smooth offset surface to reduce sampling artifacts
     if (smooth_iter > 0) {
-      PolyDataSmoothing smoother;
+      MeshSmoothing smoother;
       smoother.Input(offset_surface);
       smoother.NumberOfIterations(2 * smooth_iter);
-      smoother.Weighting(PolyDataSmoothing::Combinatorial);
+      smoother.Weighting(MeshSmoothing::Combinatorial);
       smoother.SmoothPointsOn();
       smoother.AdjacentValuesOnlyOn();
       smoother.Lambda(.33);
@@ -422,7 +420,7 @@ int main(int argc, char **argv)
 
   // Write output surface mesh
   if (!WritePolyData(output_name, output, compress, ascii)) {
-    FatalError("Error: Failed to write offset surface to " << output_name);
+    FatalError("Failed to write offset surface to " << output_name);
   }
   return 0;
 }

--- a/Applications/src/smooth-surface.cc
+++ b/Applications/src/smooth-surface.cc
@@ -26,13 +26,12 @@
 #include "mirtk/Options.h"
 
 #include "mirtk/EdgeTable.h"
+#include "mirtk/MeshSmoothing.h"
+#include "mirtk/SurfaceCurvature.h"
 #include "mirtk/PointSetIO.h"
-#include "mirtk/PolyDataSmoothing.h"
-#include "mirtk/PolyDataCurvature.h"
 
 #include "mirtk/Vtk.h"
 #include "mirtk/VtkMath.h"
-
 #include "vtkSmartPointer.h"
 #include "vtkFloatArray.h"
 #include "vtkPointData.h"
@@ -554,10 +553,10 @@ void SmoothInMaximumCurvatureDirection(vtkSmartPointer<vtkPolyData> surface,
 // -----------------------------------------------------------------------------
 enum WeightFunction {
   Default,
-  Combinatorial       = PolyDataSmoothing::Combinatorial,
-  InverseDistance     = PolyDataSmoothing::InverseDistance,
-  Gaussian            = PolyDataSmoothing::Gaussian,
-  AnisotropicGaussian = PolyDataSmoothing::AnisotropicGaussian,
+  Combinatorial       = MeshSmoothing::Combinatorial,
+  InverseDistance     = MeshSmoothing::InverseDistance,
+  Gaussian            = MeshSmoothing::Gaussian,
+  AnisotropicGaussian = MeshSmoothing::AnisotropicGaussian,
   AreaWeighted,
   WindowedSinc,
   GyralWeights
@@ -671,16 +670,16 @@ int main(int argc, char *argv[])
               e1_name = e2_name;
               e2_name = ARGUMENT;
             } else {
-              if (polydata->GetPointData()->HasArray(PolyDataCurvature::MINIMUM_DIRECTION)) {
-                e1_name = PolyDataCurvature::MINIMUM_DIRECTION;
+              if (polydata->GetPointData()->HasArray(SurfaceCurvature::MINIMUM_DIRECTION)) {
+                e1_name = SurfaceCurvature::MINIMUM_DIRECTION;
               }
             }
           } else {
-            if (polydata->GetPointData()->HasArray(PolyDataCurvature::MINIMUM_DIRECTION)) {
-              e1_name = PolyDataCurvature::MINIMUM_DIRECTION;
+            if (polydata->GetPointData()->HasArray(SurfaceCurvature::MINIMUM_DIRECTION)) {
+              e1_name = SurfaceCurvature::MINIMUM_DIRECTION;
             }
-            if (polydata->GetPointData()->HasArray(PolyDataCurvature::MAXIMUM_DIRECTION)) {
-              e2_name = PolyDataCurvature::MAXIMUM_DIRECTION;
+            if (polydata->GetPointData()->HasArray(SurfaceCurvature::MAXIMUM_DIRECTION)) {
+              e2_name = SurfaceCurvature::MAXIMUM_DIRECTION;
             }
           }
         } else {
@@ -688,8 +687,8 @@ int main(int argc, char *argv[])
           tensor_name = ARGUMENT;
         }
       } else {
-        if (polydata->GetPointData()->HasArray(PolyDataCurvature::TENSOR)) {
-          tensor_name = PolyDataCurvature::TENSOR;
+        if (polydata->GetPointData()->HasArray(SurfaceCurvature::TENSOR)) {
+          tensor_name = SurfaceCurvature::TENSOR;
         }
       }
     }
@@ -746,9 +745,6 @@ int main(int argc, char *argv[])
     polydata = filter->GetOutput();
   }
 
-  // Build links
-  polydata->BuildLinks();
-
   // Smooth gyral points
   if (weighting == GyralWeights) {
 
@@ -780,14 +776,14 @@ int main(int argc, char *argv[])
     if (smooth_points && trackingOn) {
       FatalError("-track only implemented for -areaweighted Laplacian smoothing");
     }
-    PolyDataSmoothing smoother;
+    MeshSmoothing smoother;
     smoother.Input(polydata);
     smoother.NumberOfIterations(noOfIterations);
     smoother.Lambda(lambda);
     smoother.Mu(mu);
     smoother.Sigma(-sigma1); // negative: multiple of avg. edge length
     smoother.MaximumDirectionSigma(-sigma2);
-    smoother.Weighting(static_cast<PolyDataSmoothing::WeightFunction>(weighting));
+    smoother.Weighting(static_cast<MeshSmoothing::WeightFunction>(weighting));
     if (tensor_name) smoother.GeometryTensorName(tensor_name);
     if (e1_name    ) smoother.MinimumDirectionName(e1_name);
     if (e1_name    ) smoother.MaximumDirectionName(e2_name);

--- a/Modules/PointSet/include/mirtk/EdgeTable.h
+++ b/Modules/PointSet/include/mirtk/EdgeTable.h
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2016 Imperial College London
+ * Copyright 2013-2016 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@
 #include "mirtk/Memory.h"
 #include "mirtk/Parallel.h"
 
+#include "vtkSmartPointer.h"
 #include "vtkDataSet.h"
 
 
@@ -44,13 +45,19 @@ class EdgeTable : public GenericSparseMatrix<int>
 {
   mirtkObjectMacro(EdgeTable);
 
+  /// Pointer to data set which this edge table was computed from
+  mirtkReadOnlyAttributeMacro(vtkSmartPointer<vtkDataSet>, Mesh);
+
   /// Number of undirected edges
   mirtkReadOnlyAttributeMacro(int, NumberOfEdges);
+
+  /// Copy attributes of this class from another instance
+  void CopyAttributes(const EdgeTable &);
 
 public:
 
   /// Construct edge table for given dataset
-  EdgeTable(vtkDataSet * = NULL);
+  EdgeTable(vtkDataSet * = nullptr);
 
   /// Copy constructor
   EdgeTable(const EdgeTable &);

--- a/Modules/PointSet/include/mirtk/MeshSmoothing.h
+++ b/Modules/PointSet/include/mirtk/MeshSmoothing.h
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2016 Imperial College London
+ * Copyright 2013-2016 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,10 @@
  * limitations under the License.
  */
 
-#ifndef MIRTK_PolyDataSmoothing_H
-#define MIRTK_PolyDataSmoothing_H
+#ifndef MIRTK_MeshSmoothing_H
+#define MIRTK_MeshSmoothing_H
 
-#include "mirtk/PolyDataFilter.h"
+#include "mirtk/MeshFilter.h"
 
 #include "mirtk/Array.h"
 
@@ -33,9 +33,9 @@ namespace mirtk {
 /**
  * Smooth scalars and/or points of triangulated surface mesh
  */
-class PolyDataSmoothing : public PolyDataFilter
+class MeshSmoothing : public MeshFilter
 {
-  mirtkObjectMacro(PolyDataSmoothing);
+  mirtkObjectMacro(MeshSmoothing);
 
   // ---------------------------------------------------------------------------
   // Types
@@ -61,7 +61,7 @@ public:
   // ---------------------------------------------------------------------------
   // Attributes
 
-protected:
+private:
 
   /// Input point mask, only points with mask value != 0 are modified
   mirtkPublicAttributeMacro(vtkSmartPointer<vtkDataArray>, Mask);
@@ -162,7 +162,7 @@ protected:
   mirtkPublicAttributeMacro(int, Verbose);
 
   /// Copy attributes of this class from another instance
-  void CopyAttributes(const PolyDataSmoothing &);
+  void CopyAttributes(const MeshSmoothing &);
 
   // ---------------------------------------------------------------------------
   // Construction/Destruction
@@ -170,16 +170,16 @@ protected:
 public:
 
   /// Constructor
-  PolyDataSmoothing();
+  MeshSmoothing();
 
   /// Copy constructor
-  PolyDataSmoothing(const PolyDataSmoothing &);
+  MeshSmoothing(const MeshSmoothing &);
 
   /// Assignment operator
-  PolyDataSmoothing &operator =(const PolyDataSmoothing &);
+  MeshSmoothing &operator =(const MeshSmoothing &);
 
   /// Destructor
-  virtual ~PolyDataSmoothing();
+  virtual ~MeshSmoothing();
 
   /// Add named point data array to list of arrays to be smoothed
   void SmoothArray(const char *);
@@ -240,7 +240,7 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 // -----------------------------------------------------------------------------
-inline void PolyDataSmoothing::SmoothArray(const char *name)
+inline void MeshSmoothing::SmoothArray(const char *name)
 {
   _SmoothArrays.push_back(name);
 }
@@ -248,4 +248,4 @@ inline void PolyDataSmoothing::SmoothArray(const char *name)
 
 } // namespace mirtk
 
-#endif // MIRTK_PolyDataSmoothing_H
+#endif // MIRTK_MeshSmoothing_H

--- a/Modules/PointSet/include/mirtk/SurfaceCollisions.h
+++ b/Modules/PointSet/include/mirtk/SurfaceCollisions.h
@@ -20,7 +20,7 @@
 #ifndef MIRTK_SurfaceCollisions_H
 #define MIRTK_SurfaceCollisions_H
 
-#include "mirtk/Object.h"
+#include "mirtk/SurfaceFilter.h"
 
 #include "mirtk/Math.h"
 #include "mirtk/Array.h"
@@ -45,7 +45,7 @@ namespace mirtk {
  * i.e., very close to each other. They are used to impose either hard or soft
  * non-self-intersection constraints on a deformable surface.
  */
-class SurfaceCollisions : public Object
+class SurfaceCollisions : public SurfaceFilter
 {
   mirtkObjectMacro(SurfaceCollisions);
 
@@ -181,14 +181,8 @@ public:
   // Attributes
 private:
 
-  /// Triangulated input surface mesh
-  mirtkPublicAttributeMacro(vtkSmartPointer<vtkPolyData>, Input);
-
   /// Optional mask of input triangles to check
   mirtkPublicAttributeMacro(vtkSmartPointer<vtkDataArray>, Mask);
-
-  /// Annotated output surface mesh
-  mirtkReadOnlyAttributeMacro(vtkSmartPointer<vtkPolyData>, Output);
 
   /// Use BoundingSphereCenter and BoundingSphereRadius cell data arrays of input
   mirtkPublicAttributeMacro(bool, UseInputBoundingSpheres);
@@ -245,20 +239,21 @@ private:
   /// \note Only non-empty after Run when _StoreCollisionDetails is \c true.
   mirtkReadOnlyAttributeMacro(CollisionsArray, Collisions);
 
+  /// Copy attributes of this class from another instance
+  void CopyAttributes(const SurfaceCollisions &);
+
   // ---------------------------------------------------------------------------
   // Construction/destruction
-private:
-
-  /// Copy constructor -- not implemented
-  SurfaceCollisions(const SurfaceCollisions &);
-
-  /// Assignment operator -- not implemented
-  SurfaceCollisions &operator =(const SurfaceCollisions &);
-
 public:
 
   /// Constructor
   SurfaceCollisions();
+
+  /// Copy constructor
+  SurfaceCollisions(const SurfaceCollisions &);
+
+  /// Assignment operator
+  SurfaceCollisions &operator =(const SurfaceCollisions &);
 
   /// Destructor
   virtual ~SurfaceCollisions();
@@ -267,13 +262,11 @@ public:
   // Execution
 protected:
 
-  /// Initialize filter execution
-  void Initialize();
+  /// Initialize filter after input and parameters are set
+  virtual void Initialize();
 
-public:
-
-  /// Detect self-collisions of input surface
-  void Run();
+  /// Execute filter
+  virtual void Execute();
 
   // ---------------------------------------------------------------------------
   // Output

--- a/Modules/PointSet/include/mirtk/SurfaceCurvature.h
+++ b/Modules/PointSet/include/mirtk/SurfaceCurvature.h
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2016 Imperial College London
+ * Copyright 2013-2016 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,10 @@
  * limitations under the License.
  */
 
-#ifndef MIRTK_PolyDataCurvature_H
-#define MIRTK_PolyDataCurvature_H
+#ifndef MIRTK_SurfaceCurvature_H
+#define MIRTK_SurfaceCurvature_H
 
-#include "mirtk/PolyDataFilter.h"
-
+#include "mirtk/SurfaceFilter.h"
 #include "mirtk/PointSetExport.h"
 
 #include "vtkDataArray.h"
@@ -58,12 +57,10 @@ namespace mirtk {
  * by vtkCurvatures, to avoid the duplicate computation of these curvature
  * values when using the vtkCurvatures filter. This computation is identical to
  * vtkCurvatures::GetMinimumCurvature and vtkCurvatures::GetMaximumCurvature.
- *
- * @attention vtkPolyData::BuildLinks has to be called before filter execution.
  */
-class PolyDataCurvature : public PolyDataFilter
+class SurfaceCurvature : public SurfaceFilter
 {
-  mirtkObjectMacro(PolyDataCurvature);
+  mirtkObjectMacro(SurfaceCurvature);
 
   // ---------------------------------------------------------------------------
   // Types
@@ -133,7 +130,7 @@ protected:
   mirtkReadOnlyAttributeMacro(double, Radius);
 
   /// Copy attributes of this class from another instance
-  void CopyAttributes(const PolyDataCurvature &);
+  void CopyAttributes(const SurfaceCurvature &);
 
 public:
 
@@ -141,16 +138,16 @@ public:
   // Construction/Destruction
 
   /// Default constructor
-  PolyDataCurvature(int type = Scalars);
+  SurfaceCurvature(int type = Scalars);
 
   /// Copy constructor
-  PolyDataCurvature(const PolyDataCurvature &);
+  SurfaceCurvature(const SurfaceCurvature &);
 
   /// Assignment operator
-  PolyDataCurvature &operator =(const PolyDataCurvature &);
+  SurfaceCurvature &operator =(const SurfaceCurvature &);
 
   /// Destructor
-  virtual ~PolyDataCurvature();
+  virtual ~SurfaceCurvature();
 
   // ---------------------------------------------------------------------------
   // Execution
@@ -268,4 +265,4 @@ public:
 
 } // namespace mirtk
 
-#endif // MIRTK_PolyDataCurvature_H
+#endif // MIRTK_SurfaceCurvature_H

--- a/Modules/PointSet/include/mirtk/SurfaceFilter.h
+++ b/Modules/PointSet/include/mirtk/SurfaceFilter.h
@@ -1,0 +1,72 @@
+/*
+ * Medical Image Registration ToolKit (MIRTK)
+ *
+ * Copyright 2016 Imperial College London
+ * Copyright 2016 Andreas Schuh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MIRTK_SurfaceFilter_H
+#define MIRTK_SurfaceFilter_H
+
+#include "mirtk/MeshFilter.h"
+
+
+namespace mirtk {
+
+
+/**
+ * Base class for filters which process polygonal surface meshes
+ */
+class SurfaceFilter : public MeshFilter
+{
+  mirtkAbstractMacro(SurfaceFilter);
+
+  // ---------------------------------------------------------------------------
+  // Attributes
+
+  /// Copy attributes of this filter from another instance
+  void CopyAttributes(const SurfaceFilter &);
+
+  // ---------------------------------------------------------------------------
+  // Construction/Destruction
+
+protected:
+
+  /// Default constructor
+  SurfaceFilter();
+
+  /// Copy constructor
+  SurfaceFilter(const SurfaceFilter &);
+
+  /// Assignment operator
+  SurfaceFilter &operator =(const SurfaceFilter &);
+
+  /// Destructor
+  virtual ~SurfaceFilter();
+
+  // ---------------------------------------------------------------------------
+  // Execution
+
+protected:
+
+  /// Initialize filter after input and parameters are set
+  virtual void Initialize();
+
+};
+
+
+} // namespace mirtk
+
+#endif // MIRTK_SurfaceFilter_H

--- a/Modules/PointSet/include/mirtk/SurfaceRemeshing.h
+++ b/Modules/PointSet/include/mirtk/SurfaceRemeshing.h
@@ -17,10 +17,10 @@
  * limitations under the License.
  */
 
-#ifndef MIRTK_PolyDataRemeshing_H
-#define MIRTK_PolyDataRemeshing_H
+#ifndef MIRTK_SurfaceRemeshing_H
+#define MIRTK_SurfaceRemeshing_H
 
-#include "mirtk/PolyDataFilter.h"
+#include "mirtk/SurfaceFilter.h"
 
 #include "mirtk/Point.h"
 
@@ -46,9 +46,9 @@ class Transformation;
  * \todo Interpolate cell data during remeshing. The current implementation only
  *       preserves and interpolates point data arrays. Cell attributes are discarded.
  */
-class PolyDataRemeshing : public PolyDataFilter
+class SurfaceRemeshing : public SurfaceFilter
 {
-  mirtkObjectMacro(PolyDataRemeshing);
+  mirtkObjectMacro(SurfaceRemeshing);
 
   // ---------------------------------------------------------------------------
   // Types
@@ -67,9 +67,6 @@ protected:
 
   // ---------------------------------------------------------------------------
   // Attributes
-
-  /// Triangulated input mesh
-  mirtkAttributeMacro(vtkSmartPointer<vtkPolyData>, TriangulatedInput);
 
   /// Optional input transformation used to determine edge length and triangle area
   mirtkPublicAggregateMacro(const class Transformation, Transformation);
@@ -161,7 +158,7 @@ protected:
   mirtkReadOnlyAttributeMacro(int, NumberOfQuadsections);
 
   /// Copy attributes of this class from another instance
-  void CopyAttributes(const PolyDataRemeshing &);
+  void CopyAttributes(const SurfaceRemeshing &);
 
 public:
 
@@ -178,16 +175,16 @@ public:
   // Construction/Destruction
 
   /// Default constructor
-  PolyDataRemeshing();
+  SurfaceRemeshing();
 
   /// Copy constructor
-  PolyDataRemeshing(const PolyDataRemeshing &);
+  SurfaceRemeshing(const SurfaceRemeshing &);
 
   /// Assignment operator
-  PolyDataRemeshing &operator =(const PolyDataRemeshing &);
+  SurfaceRemeshing &operator =(const SurfaceRemeshing &);
 
   /// Destructor
-  virtual ~PolyDataRemeshing();
+  virtual ~SurfaceRemeshing();
 
   // ---------------------------------------------------------------------------
   // Inline auxiliary functions
@@ -334,23 +331,23 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 // -----------------------------------------------------------------------------
-int PolyDataRemeshing::NumberOfMeltings() const
+int SurfaceRemeshing::NumberOfMeltings() const
 {
   return _NumberOfMeltedNodes + _NumberOfMeltedEdges + _NumberOfMeltedCells;
 }
 
 // -----------------------------------------------------------------------------
-int PolyDataRemeshing::NumberOfSubdivisions() const
+int SurfaceRemeshing::NumberOfSubdivisions() const
 {
   return _NumberOfBisections + _NumberOfTrisections + _NumberOfQuadsections;
 }
 
 // -----------------------------------------------------------------------------
-int PolyDataRemeshing::NumberOfChanges() const
+int SurfaceRemeshing::NumberOfChanges() const
 {
   return NumberOfMeltings() + NumberOfInversions() + NumberOfSubdivisions();
 }
 
 } // namespace mirtk
 
-#endif // MIRTK_PolyDataRemeshing_H
+#endif // MIRTK_SurfaceRemeshing_H

--- a/Modules/PointSet/src/CMakeLists.txt
+++ b/Modules/PointSet/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 # ============================================================================
 # Medical Image Registration ToolKit (MIRTK)
 #
-# Copyright 2013-2015 Imperial College London
-# Copyright 2013-2015 Andreas Schuh
+# Copyright 2013-2016 Imperial College London
+# Copyright 2013-2016 Andreas Schuh
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,13 +33,11 @@ set(HEADERS
   FiducialMatch.h
   FuzzyCorrespondence.h
   ImplicitSurfaceUtils.h
+  MeshFilter.h
+  MeshSmoothing.h
   PointCorrespondence.h
   PointLocator.h
   PointSetUtils.h
-  PolyDataCurvature.h
-  PolyDataFilter.h
-  PolyDataRemeshing.h
-  PolyDataSmoothing.h
   Polyhedron.h
   RegisteredPointSet.h
   RegisteredSurface.h
@@ -48,7 +46,10 @@ set(HEADERS
   SpectralDecomposition.h
   SpectralMatch.h
   SurfaceBoundary.h
+  SurfaceFilter.h
   SurfaceCollisions.h
+  SurfaceCurvature.h
+  SurfaceRemeshing.h
   Triangle.h
 )
 
@@ -64,13 +65,11 @@ set(SOURCES
   FuzzyCorrespondenceUtils.cc
   FuzzyCorrespondenceUtils.h
   ImplicitSurfaceUtils.cc
+  MeshFilter.cc
+  MeshSmoothing.cc
   PointCorrespondence.cc
   PointLocator.cc
   PointSetUtils.cc
-  PolyDataCurvature.cc
-  PolyDataFilter.cc
-  PolyDataRemeshing.cc
-  PolyDataSmoothing.cc
   Polyhedron.cc
   RegisteredPointSet.cc
   RegisteredSurface.cc
@@ -79,7 +78,10 @@ set(SOURCES
   SpectralDecomposition.cc
   SpectralMatch.cc
   SurfaceBoundary.cc
+  SurfaceFilter.cc
   SurfaceCollisions.cc
+  SurfaceCurvature.cc
+  SurfaceRemeshing.cc
   Triangle.cc
   triangle_triangle_intersection.h
 )

--- a/Modules/PointSet/src/PointSetUtils.cc
+++ b/Modules/PointSet/src/PointSetUtils.cc
@@ -1000,10 +1000,14 @@ double GetVolume(vtkSmartPointer<vtkPolyData> surface)
 // -----------------------------------------------------------------------------
 bool IsSurfaceMesh(vtkDataSet *dataset)
 {
-  vtkPolyData *poly = vtkPolyData::SafeDownCast(dataset);
-  return poly && poly->GetPolys() && poly->GetPolys()->GetNumberOfCells() > 0 &&
-         (!poly->GetLines() || poly->GetLines()->GetNumberOfCells() == 0) &&
-         (!poly->GetVerts() || poly->GetVerts()->GetNumberOfCells() == 0);
+  vtkPolyData *polydata = vtkPolyData::SafeDownCast(dataset);
+  if (polydata == nullptr) return false;
+  vtkSmartPointer<vtkGenericCell> cell = vtkSmartPointer<vtkGenericCell>::New();
+  for (vtkIdType cellId = 0; cellId < polydata->GetNumberOfCells(); ++cellId) {
+    polydata->GetCell(cellId, cell);
+    if (cell->GetCellDimension() != 2) return false;
+  }
+  return true;
 }
 
 // -----------------------------------------------------------------------------
@@ -1067,7 +1071,7 @@ vtkSmartPointer<vtkPolyData> ConvexHull(vtkSmartPointer<vtkPointSet> pointset, i
 // -----------------------------------------------------------------------------
 bool IsTriangularMesh(vtkDataSet *input)
 {
-  if (vtkPointSet::SafeDownCast(input) == NULL) return false;
+  if (vtkPointSet::SafeDownCast(input) == nullptr) return false;
   for (vtkIdType cellId = 0; cellId < input->GetNumberOfCells(); ++cellId) {
     int type = input->GetCellType(cellId);
     if (type != VTK_EMPTY_CELL && type != VTK_TRIANGLE) return false;
@@ -1078,7 +1082,7 @@ bool IsTriangularMesh(vtkDataSet *input)
 // -----------------------------------------------------------------------------
 bool IsTetrahedralMesh(vtkDataSet *input)
 {
-  if (vtkPointSet::SafeDownCast(input) == NULL) return false;
+  if (vtkPointSet::SafeDownCast(input) == nullptr) return false;
   for (vtkIdType cellId = 0; cellId < input->GetNumberOfCells(); ++cellId) {
     int type = input->GetCellType(cellId);
     if (type != VTK_EMPTY_CELL && type != VTK_TETRA) return false;

--- a/Modules/PointSet/src/SurfaceFilter.cc
+++ b/Modules/PointSet/src/SurfaceFilter.cc
@@ -1,0 +1,83 @@
+/*
+ * Medical Image Registration ToolKit (MMIRTK)
+ *
+ * Copyright 2016 Imperial College London
+ * Copyright 2016 Andreas Schuh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mirtk/SurfaceFilter.h"
+
+#include "mirtk/PointSetUtils.h"
+
+
+namespace mirtk {
+
+
+// =============================================================================
+// Construction/destruction
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+void SurfaceFilter::CopyAttributes(const SurfaceFilter &other)
+{
+}
+
+// -----------------------------------------------------------------------------
+SurfaceFilter::SurfaceFilter()
+{
+}
+
+// -----------------------------------------------------------------------------
+SurfaceFilter::SurfaceFilter(const SurfaceFilter &other)
+:
+  MeshFilter(other)
+{
+  CopyAttributes(other);
+}
+
+// -----------------------------------------------------------------------------
+SurfaceFilter &SurfaceFilter::operator =(const SurfaceFilter &other)
+{
+  if (this != &other) {
+    MeshFilter::operator =(other);
+    CopyAttributes(other);
+  }
+  return *this;
+}
+
+// -----------------------------------------------------------------------------
+SurfaceFilter::~SurfaceFilter()
+{
+}
+
+// =============================================================================
+// Execution
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+void SurfaceFilter::Initialize()
+{
+  // Initialize base class
+  MeshFilter::Initialize();
+
+  // Check input mesh
+  if (!IsSurfaceMesh(_Input)) {
+    cerr << this->NameOfType() << "::Initialize: Input mesh must be a surface mesh with 2D faces" << endl;
+    exit(1);
+  }
+}
+
+
+} // namespace mirtk

--- a/Modules/Registration/src/GenericRegistrationFilter.cc
+++ b/Modules/Registration/src/GenericRegistrationFilter.cc
@@ -57,7 +57,7 @@
 #  include "mirtk/RegisteredPointSet.h"
 #  include "mirtk/PointSetUtils.h"
 #  include "mirtk/PointSetDistance.h"
-#  include "mirtk/PolyDataRemeshing.h"
+#  include "mirtk/SurfaceRemeshing.h"
 #  if MIRTK_Registration_WITH_Deformable
 #    include "mirtk/InternalForce.h"
 #  endif
@@ -517,11 +517,11 @@ public:
       if (IsSurfaceMesh((*_Input)[n]) &&
           (_MinEdgeLength[_Level][n] > .0 ||
            _MaxEdgeLength[_Level][n] < numeric_limits<double>::infinity())) {
-        PolyDataRemeshing remesher;
+        SurfaceRemeshing remesher;
         remesher.Input(vtkPolyData::SafeDownCast((*_Output)[_Level-1][n]));
         remesher.MinEdgeLength(_MinEdgeLength[_Level][n]);
         remesher.MaxEdgeLength(_MaxEdgeLength[_Level][n]);
-        remesher.MeltingOrder(PolyDataRemeshing::AREA);
+        remesher.MeltingOrder(SurfaceRemeshing::AREA);
         remesher.MeltNodesOn();
         remesher.MeltTrianglesOn();
         remesher.Run();
@@ -3951,10 +3951,10 @@ void GenericRegistrationFilter::PreUpdateCallback(bool gradient)
           const double dmax = _MaxEdgeLength[_CurrentLevel][j];
           if (_AdaptiveRemeshing && IsSurfaceMesh(_PointSetInput[j]) && (dmin > .0 || !IsInf(dmax))) {
             MIRTK_START_TIMING();
-            PolyDataRemeshing remesher;
+            SurfaceRemeshing remesher;
             remesher.Input(vtkPolyData::SafeDownCast(_PointSetOutput[i]->InputPointSet()));
             remesher.Transformation(_PointSetOutput[i]->Transformation());
-            remesher.MeltingOrder(PolyDataRemeshing::AREA);
+            remesher.MeltingOrder(SurfaceRemeshing::AREA);
             remesher.MeltNodesOff();
             remesher.MeltTrianglesOn();
             remesher.MinEdgeLength(dmin);


### PR DESCRIPTION
Refactor class hierarchy of surface/volume mesh filters slightly and rename filters. Make `SurfaceCollisions` a subclass of the new `SurfaceFilter` instead of `Object` directly.

Before:
```
Object
  PolyDataFilter
    PolyDataSmoothing
    PolyDataCurvature
    PolyDataRemeshing
  SurfaceCollisions
```

After:
```
Object
  MeshFilter
    MeshSmoothing
    SurfaceFilter
      SurfaceCurvature
      SurfaceRemeshing
      SurfaceCollisions
```

Used `SharedPtr` to optional `EdgeTable` input of mesh filters. When not set to a pre-computed edge table by the user of the filter, the filter instantiates an edge table itself if needed. No need for a separate `_EdgeTableOwner` flag when using smart pointers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/316)
<!-- Reviewable:end -->
