### PR TITLE
fix: Add missing include of vtkConfigure.h in VtkMath.h [Common]

### DIFF
--- a/Modules/Common/include/mirtk/VtkMath.h
+++ b/Modules/Common/include/mirtk/VtkMath.h
@@ -20,6 +20,8 @@
 #ifndef MIRTK_VtkMath_H
 #define MIRTK_VtkMath_H
 
+#include "vtkConfigure.h" // VTK version macros 
+
 
 // See http://www.paraview.org/Bug/view.php?id=14164
 #if VTK_MAJOR_VERSION == 6 && VTK_MINOR_VERSION == 0 && VTK_PATCH_VERSION == 0
@@ -28,7 +30,8 @@
 #  define isfinite ::std::isfinite
 #endif
 
-#include <vtkMath.h>
+#include <vtkMath.h> // DO NOT use double quotes which would cause endless recursive
+                     // include of this file when filesystem is not case sensitive!
 
 #if VTK_MAJOR_VERSION == 6 && VTK_MINOR_VERSION == 0 && VTK_PATCH_VERSION == 0
 #  undef isnan


### PR DESCRIPTION
This should fix the build (on Ubuntu) with VTK 6.0 again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/320)
<!-- Reviewable:end -->
