### PR TITLE
fix: Add missing fclose in error case to gxml_read_image GIFTI function [IO]

### DIFF
--- a/Modules/IO/src/gifti/gifti_xml.cc
+++ b/Modules/IO/src/gifti/gifti_xml.cc
@@ -290,6 +290,7 @@ gifti_image * gxml_read_image(const char * fname, int read_data,
     if( !xd->gim ) {
         fprintf(stderr,"** failed to alloc initial gifti_image\n");
         free(buf);
+        fclose(fp);
         return NULL;
     }
 


### PR DESCRIPTION
Closes #290.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/321)
<!-- Reviewable:end -->
