### PR TITLE
fix: Build of Docker image

### DIFF
--- a/Docker/Ubuntu/Dockerfile
+++ b/Docker/Ubuntu/Dockerfile
@@ -30,8 +30,16 @@ ARG THREADS
 ARG VTK_VERSION=6.3.0
 
 # Install prerequisites for MIRTK build
+#
+# The bzindovic/suitesparse-bugfix-1319687 PPA is required for building
+# shared libraries which link with the static SuiteSparse libraries due
+# to a bug in the official Ubuntu package:
+# https://bugs.launchpad.net/ubuntu/+source/suitesparse/+bug/1333214
 RUN NUM_CPUS=${THREADS:-`cat /proc/cpuinfo | grep processor | wc -l`} \
     && echo "Maximum number of build threads = $NUM_CPUS" \
+    && apt-get update && apt-get install -y --no-install-recommends \
+      software-properties-common \
+    && add-apt-repository -y ppa:bzindovic/suitesparse-bugfix-1319687 \
     && apt-get update && apt-get install -y --no-install-recommends \
       gcc \
       g++ \
@@ -40,6 +48,9 @@ RUN NUM_CPUS=${THREADS:-`cat /proc/cpuinfo | grep processor | wc -l`} \
       python \
       freeglut3-dev \
       libarpack2-dev \
+      libboost-math-dev \
+      libboost-random-dev \
+      libeigen3-dev \
       libflann-dev \
       libgtest-dev \
       libnifti-dev \

--- a/Docker/Ubuntu/Dockerfile
+++ b/Docker/Ubuntu/Dockerfile
@@ -29,6 +29,8 @@ ARG THREADS
 # and unused VTK modules is used instead!
 ARG VTK_VERSION=7.0.0
 
+ARG EIGEN_VERSION=3.2.8
+
 # Install prerequisites for MIRTK build
 #
 # The bzindovic/suitesparse-bugfix-1319687 PPA is required for building
@@ -41,6 +43,7 @@ RUN NUM_CPUS=${THREADS:-`cat /proc/cpuinfo | grep processor | wc -l`} \
       software-properties-common \
     && add-apt-repository -y ppa:bzindovic/suitesparse-bugfix-1319687 \
     && apt-get update && apt-get install -y --no-install-recommends \
+      wget \
       gcc \
       g++ \
       make \
@@ -50,7 +53,6 @@ RUN NUM_CPUS=${THREADS:-`cat /proc/cpuinfo | grep processor | wc -l`} \
       libarpack2-dev \
       libboost-math-dev \
       libboost-random-dev \
-      libeigen3-dev \
       libflann-dev \
       libgtest-dev \
       libnifti-dev \
@@ -67,10 +69,23 @@ RUN NUM_CPUS=${THREADS:-`cat /proc/cpuinfo | grep processor | wc -l`} \
     && rm -rf /usr/src/gtest/build \
     && \
     if [ -z ${VTK_VERSION} ]; then \
+      apt-get install -y libeigen3-dev; \
+    else \
+      EIGEN_SOURCE_DIR=/usr/src/eigen-${EIGEN_VERSION} \
+      && mkdir ${EIGEN_SOURCE_DIR} /usr/include/eigen3 \
+      && cd ${EIGEN_SOURCE_DIR} \
+      && wget -O archive.tar.bz2 http://bitbucket.org/eigen/eigen/get/${EIGEN_VERSION}.tar.bz2 \
+      && tar vxjf archive.tar.bz2 --strip 1 \
+      && mv signature_of_eigen3_matrix_library Eigen /usr/include/eigen3/ \
+      && mv cmake/FindEigen3.cmake /usr/share/cmake-2.8/Modules/ \
+      && cd /usr/src \
+      && rm -rf ${EIGEN_SOURCE_DIR}; \
+    fi \
+    && \
+    if [ -z ${VTK_VERSION} ]; then \
       apt-get install -y libvtk6-dev; \
     else \
       VTK_RELEASE=`echo ${VTK_VERSION} | sed s/\.[0-9]*$//` \
-      && apt-get install -y wget \
       && cd /usr/src \
       && wget http://www.vtk.org/files/release/${VTK_RELEASE}/VTK-${VTK_VERSION}.tar.gz \
       && tar -xvzf VTK-${VTK_VERSION}.tar.gz \

--- a/Docker/Ubuntu/Dockerfile
+++ b/Docker/Ubuntu/Dockerfile
@@ -27,7 +27,7 @@ ARG THREADS
 # Note, however, that this results in a Docker image that is about twice
 # the size of the image when a custom VTK build without Qt, wrappers,
 # and unused VTK modules is used instead!
-ARG VTK_VERSION=6.3.0
+ARG VTK_VERSION=7.0.0
 
 # Install prerequisites for MIRTK build
 #


### PR DESCRIPTION
The new `biomedia/ubuntu` Docker image on Docker Hub now includes an installation of Boost and Eigen 3.2.8. These system installations are now a requirement. Also, VTK was upgraded to VTK 7.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/324)
<!-- Reviewable:end -->
