### PR TITLE
Added an option for compose_dofs

### DIFF
--- a/Applications/src/compose-dofs.cc
+++ b/Applications/src/compose-dofs.cc
@@ -271,7 +271,7 @@ int main(int argc, char **argv)
   }
 
   // Approximate the composed transformation using a single free-form deformation
-  if (approximate && (t.NumberOfLevels() > 1)) {
+  if (approximate && (t.NumberOfLevels() > 0)) {
     cout << "Approximate the composed transformation using a single FFD..." << endl;
 
     // Use the densest control point lattice in the local transformation stack

--- a/Applications/src/compose-dofs.cc
+++ b/Applications/src/compose-dofs.cc
@@ -176,7 +176,7 @@ void PushTransformation(FluidFreeFormTransformation &t1,
 
 // -----------------------------------------------------------------------------
 // Interpolate the composed transformation using a free-form deformation
-void Interpolate_FFD(FluidFreeFormTransformation &t)
+void InterpolateFreeFormDeformation(FluidFreeFormTransformation &t)
 {
   BSplineFreeFormTransformation3D *ffd = dynamic_cast<BSplineFreeFormTransformation3D *>(t.GetLocalTransformation(0));
   if (ffd == NULL) {
@@ -344,7 +344,7 @@ int main(int argc, char **argv)
   // Interpolate the composed transformation using a free-form deformation
   if (interp_ffd) {
     cout << "Interpolate the composed transformation using a free-form deformation..." << endl;
-    Interpolate_FFD(t);
+    InterpolateFreeFormDeformation(t);
   }
 
   // Write composite transformation

--- a/Applications/src/compose-dofs.cc
+++ b/Applications/src/compose-dofs.cc
@@ -272,7 +272,9 @@ int main(int argc, char **argv)
 
   // Approximate the composed transformation using a single free-form deformation
   if (approximate && (t.NumberOfLevels() > 0)) {
-    cout << "Approximate the composed transformation using a single FFD..." << endl;
+    if (verbose) {
+      cout << "Approximate the composed transformation using a single FFD..." << endl;
+    }
 
     // Use the densest control point lattice in the local transformation stack
     ImageAttributes ffd_attr;

--- a/Applications/src/compose-dofs.cc
+++ b/Applications/src/compose-dofs.cc
@@ -271,12 +271,8 @@ int main(int argc, char **argv)
   }
 
   // Approximate the composed transformation using a single free-form deformation
-  if (approximate) {
+  if (approximate && (t.NumberOfLevels() > 1)) {
     cout << "Approximate the composed transformation using a single FFD..." << endl;
-
-    if (t.NumberOfLevels() == 0) {
-      return 0;
-    }
 
     // Use the densest control point lattice in the local transformation stack
     ImageAttributes ffd_attr;


### PR DESCRIPTION
The newly added option "interp_ffd" enables the output transformation to be represented using a single FFD.

I have found that this can dramatically reduce the size of the composed transformation at the cost of very trivial change of accuracy in representation. Representing using a single FFD also has the advantage of being a relatively smooth transformation compared to representing using a stack of FFDs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/325)
<!-- Reviewable:end -->
