### PR TITLE
fix: Calculation of local MFFD Jacobian matrix [Transformation]

### DIFF
--- a/Modules/Transformation/src/MultiLevelFreeFormTransformation.cc
+++ b/Modules/Transformation/src/MultiLevelFreeFormTransformation.cc
@@ -675,6 +675,7 @@ void MultiLevelFreeFormTransformation
     _GlobalTransformation.Jacobian(jac, x, y, z, t, t0);
   } else {
     jac.Initialize(3, 3);
+    jac.Ident();
   }
 
   // Compute local jacobian


### PR DESCRIPTION
When computing the Jacobian of the local transformation only of a MFFD, the contribution from the global identity transformation was missing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/326)
<!-- Reviewable:end -->
