### PR TITLE
fix: Parsing of register -par option arguments [Applications]

### DIFF
--- a/Applications/src/register.cc
+++ b/Applications/src/register.cc
@@ -677,7 +677,11 @@ int main(int argc, char **argv)
     else if (OPTION("-mask"))   mask_name       = ARGUMENT;
     else if (OPTION("-nodebug-level-prefix")) debug_output_level_prefix = false;
     // Parameter
-    else if (OPTION("-par"))    params << ARGUMENT << " = " << ARGUMENT << endl;
+    else if (OPTION("-par")) {
+      const char *name  = ARGUMENT;
+      const char *value = ARGUMENT;
+      params << name << " = " << value << endl;
+    }
     else if (OPTION("-parin" )) parin_name      = ARGUMENT;
     else if (OPTION("-parout")) parout_name     = ARGUMENT;
     // Shortcuts for often used -par "<parameter> = <value>"


### PR DESCRIPTION
Order of `ARGUMENT` evaluation is from left to right instead of right to left as needed when using streaming operators.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/331)
<!-- Reviewable:end -->
