### PR TITLE
Force precomputation of image gradients for all gradient field similarities

### DIFF
--- a/Modules/Registration/src/GradientFieldSimilarity.cc
+++ b/Modules/Registration/src/GradientFieldSimilarity.cc
@@ -375,8 +375,6 @@ GradientFieldSimilarity::GradientFieldSimilarity(const char *name, double weight
   ImageSimilarity(name, weight),
   _IgnoreJacobianGradientWrtDOFs(false)
 {
-  _Target->PrecomputeDerivatives(true);
-  _Source->PrecomputeDerivatives(true);
 }
 
 // -----------------------------------------------------------------------------
@@ -541,6 +539,10 @@ void GradientFieldSimilarity::ReorientGradient(RegisteredImage *image, bool hess
 // -----------------------------------------------------------------------------
 void GradientFieldSimilarity::InitializeInput(const ImageAttributes &domain)
 {
+  // Force precomputation of gradients
+  _Target->PrecomputeDerivatives(true);
+  _Source->PrecomputeDerivatives(true);
+
   // Initialize registered input images
   _Target->Initialize(domain, _Target->Transformation() ? 13 : 4);
   _Source->Initialize(domain, _Source->Transformation() ? 13 : 4);


### PR DESCRIPTION
This changes fixes the fact that for gradient field similarities, it was not sufficient to set the flag for precomputation of gradients in the constructor (precomputation of gradients is crucial for these similarities to work). It has to be done in the GradientFieldSimilarity::InitializeInput method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/332)
<!-- Reviewable:end -->
