### PR TITLE
Miscellaneous changes

### DIFF
--- a/Applications/src/average-dofs.cc
+++ b/Applications/src/average-dofs.cc
@@ -255,17 +255,17 @@ int main(int argc, char **argv)
     else if (OPTION("-cubic"))         bsplineffd  = true;
     else if (OPTION("-dofs"))          avgdofs     = true;
     else if (OPTION("-inverse-dofs"))  avgdofs     = true, invert = invavg = true;
-    else if (OPTION("-epsilon"))       epsilon     = atof(ARGUMENT);
-    else if (OPTION("-gaussian")) { mean = atof(ARGUMENT); sigma = atof(ARGUMENT); }
+    else if (OPTION("-epsilon"))       PARSE_ARGUMENT(epsilon);
+    else if (OPTION("-gaussian")) { PARSE_ARGUMENT(mean), PARSE_ARGUMENT(sigma); }
     else if (OPTION("-rigid"))    { translation = rotation = true;  scaling = shearing = deformation = false; }
     else if (OPTION("-norigid"))  { translation = rotation = false; }
     else if (OPTION("-affine"))   { translation = rotation = scaling = shearing = true;  deformation = false; }
     else if (OPTION("-noaffine")) { translation = rotation = scaling = shearing = false; }
     else if (OPTION("-all"))      { translation = rotation = scaling = shearing = deformation = true; }
     else if (OPTION("-add-identity"))             { identity_value = NaN; }
-    else if (OPTION("-add-identity-with-weight")) { identity_value = atof(ARGUMENT); }
+    else if (OPTION("-add-identity-with-weight")) { PARSE_ARGUMENT(identity_value); }
     else if (OPTION("-add-identity-for-dofname")) { identity_name  = ARGUMENT; }
-    else if (OPTION("-max-frechet-iterations")) frechet_iter = atoi(ARGUMENT);
+    else if (OPTION("-max-frechet-iterations")) PARSE_ARGUMENT(frechet_iter);
     else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
   }
 

--- a/Applications/src/convert-pointset.cc
+++ b/Applications/src/convert-pointset.cc
@@ -205,11 +205,11 @@ int main(int argc, char *argv[])
   // Optional arguments
   bool pointdata  = true;
   bool celldata   = true;
-  bool ascii      = false;
-  bool compress   = true;
   bool merge      = false;
   bool with_holes = false;
   double merge_tol = 1e-6;
+
+  FileOption fopt = FO_Default;
 
   for (ALL_OPTIONS) {
     if      (OPTION("-nopointdata")) pointdata = false;
@@ -218,18 +218,17 @@ int main(int argc, char *argv[])
       merge = true;
       if (HAS_ARGUMENT) PARSE_ARGUMENT(merge_tol);
     }
-    else if (OPTION("-holes"))       with_holes = true;
-    else if (OPTION("-ascii"))       ascii = true;
-    else if (OPTION("-binary"))      ascii = false;
-    else if (OPTION("-compress"))    compress = true;
-    else if (OPTION("-nocompress"))  compress = false;
+    else if (OPTION("-holes")) with_holes = true;
+    else HANDLE_POINTSETIO_OPTION(fopt);
     else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   // Read input point sets
   Array<vtkSmartPointer<vtkPointSet> > pointsets(input_names.size());
   for (size_t i = 0; i < input_names.size(); ++i) {
-    pointsets[i] = ReadPointSet(input_names[i], NULL, true);
+    FileOption opt;
+    pointsets[i] = ReadPointSet(input_names[i], opt);
+    if (fopt == FO_Default) fopt = opt;
   }
 
   // Combine point sets into single point set
@@ -307,7 +306,7 @@ int main(int argc, char *argv[])
   }
 
   // Write output point set
-  if (!WritePointSet(output_name, output, compress, ascii)) {
+  if (!WritePointSet(output_name, output, fopt)) {
     FatalError("Failed to write output point set to " << output_name);
     exit(1);
   }

--- a/Applications/src/convert-pointset.cc
+++ b/Applications/src/convert-pointset.cc
@@ -251,18 +251,6 @@ int main(int argc, char *argv[])
       }
       append->Update();
       output = append->GetOutput();
-      if (merge) {
-        vtkNew<vtkCleanPolyData> merger;
-        merger->ConvertLinesToPointsOff();
-        merger->ConvertPolysToLinesOff();
-        merger->ConvertStripsToPolysOn();
-        merger->PointMergingOn();
-        merger->ToleranceIsAbsoluteOn();
-        merger->SetAbsoluteTolerance(merge_tol);
-        SetVTKInput(merger, output);
-        merger->Update();
-        output = merger->GetOutput();
-      }
     } else {
       vtkNew<vtkAppendFilter> append;
       for (size_t i = 0; i < pointsets.size(); ++i) {
@@ -272,6 +260,20 @@ int main(int argc, char *argv[])
       append->Update();
       output = append->GetOutput();
     }
+  }
+
+  // Merge points
+  if (merge && vtkPolyData::SafeDownCast(output) != nullptr) {
+    vtkNew<vtkCleanPolyData> merger;
+    merger->ConvertLinesToPointsOff();
+    merger->ConvertPolysToLinesOff();
+    merger->ConvertStripsToPolysOn();
+    merger->PointMergingOn();
+    merger->ToleranceIsAbsoluteOn();
+    merger->SetAbsoluteTolerance(merge_tol);
+    SetVTKInput(merger, output);
+    merger->Update();
+    output = merger->GetOutput();
   }
 
   // Reset point/cell data

--- a/Applications/src/copy-pointset-attributes-from-mat.cc
+++ b/Applications/src/copy-pointset-attributes-from-mat.cc
@@ -193,8 +193,7 @@ int main(int argc, char *argv[])
   // Optional arguments
   Array<string> var_name;
   Array<int>    var_type;
-  bool          compress = true;
-  bool          ascii    = false;
+  FileOption    fopt     = FO_Default;
   OutputType    out_type = InputType;
 
   for (ALL_OPTIONS) {
@@ -212,10 +211,7 @@ int main(int argc, char *argv[])
     else if (OPTION("-long"))   out_type = OutputLong;
     else if (OPTION("-float"))  out_type = OutputFloat;
     else if (OPTION("-double")) out_type = OutputDouble;
-    else if (OPTION("-ascii")  || OPTION("-nobinary")) ascii = true;
-    else if (OPTION("-binary") || OPTION("-noascii") ) ascii = false;
-    else if (OPTION("-compress"))   compress = true;
-    else if (OPTION("-nocompress")) compress = false;
+    else HANDLE_POINTSETIO_OPTION(fopt);
     else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
   }
 
@@ -224,7 +220,9 @@ int main(int argc, char *argv[])
 
   // Read input dataset
   if (verbose > 1) cout << "Reading dataset from " << input_name << "...";
-  vtkSmartPointer<vtkPolyData> dataset = ReadPolyData(input_name);
+  FileOption dataset_fopt;
+  vtkSmartPointer<vtkPolyData> dataset = ReadPolyData(input_name, dataset_fopt);
+  if (fopt == FO_Default) fopt = dataset_fopt;
   if (verbose > 1) cout << " done" << endl;
 
   // Open MAT file
@@ -311,7 +309,7 @@ int main(int argc, char *argv[])
   }
 
   // Write modified dataset
-  WritePolyData(output_name, dataset, compress, ascii);
+  WritePolyData(output_name, dataset, fopt);
   if (verbose > 1) cout << "Wrote modified dataset to " << output_name << endl;
 
   // Close MAT file

--- a/Applications/src/copy-pointset-attributes.cc
+++ b/Applications/src/copy-pointset-attributes.cc
@@ -144,7 +144,7 @@ struct ArrayInfo
 vtkSmartPointer<vtkDataArray> Copy(vtkDataArray *array, vtkIdType n)
 {
   vtkSmartPointer<vtkDataArray> copy;
-  copy = vtkSmartPointer<vtkDataArray>::NewInstance(array);
+  copy.TakeReference(array->NewInstance());
   copy->SetName(array->GetName());
   copy->SetNumberOfComponents(array->GetNumberOfComponents());
   copy->SetNumberOfTuples(n);

--- a/Applications/src/cut-brain.cc
+++ b/Applications/src/cut-brain.cc
@@ -79,16 +79,15 @@ enum Hemisphere
 double SymmetricCuttingPlane(const ByteImage &mask, double n[3])
 {
   BytePixel h;
-  Point center[2];
-  int numvox[2] = {0};
-  double p[3];
+  Point center[2], p;
+  int   numvox[2] = {0};
   for (int k = 0; k < mask.Z(); ++k)
   for (int j = 0; j < mask.Y(); ++j)
   for (int i = 0; i < mask.X(); ++i) {
     h = mask(i, j, k) - 1;
     if (h < 0 || h > 1) continue;
-    p[0] = i, p[1] = j, p[2] = k;
-    mask.ImageToWorld(p[0], p[1], p[2]);
+    p._x = i, p._y = j, p._z = k;
+    mask.ImageToWorld(p);
     center[h] += p;
     numvox[h] += 1;
   }
@@ -98,12 +97,10 @@ double SymmetricCuttingPlane(const ByteImage &mask, double n[3])
   }
   center[0] /= numvox[0];
   center[1] /= numvox[1];
-  p[0] = (center[0]._x + center[1]._x) / 2.0;
-  p[1] = (center[0]._y + center[1]._y) / 2.0;
-  p[2] = (center[0]._z + center[1]._z) / 2.0;
-  n[0] =  center[0]._x - center[1]._x;
-  n[1] =  center[0]._y - center[1]._y;
-  n[2] =  center[0]._z - center[1]._z;
+  p = (center[0] + center[1]) / 2.0;
+  n[0] = center[0]._x - center[1]._x;
+  n[1] = center[0]._y - center[1]._y;
+  n[2] = center[0]._z - center[1]._z;
   double m = sqrt(n[0]*n[0] + n[1]*n[1] + n[2]*n[2]);
   n[0] /= m, n[1] /= m, n[2] /= m;
   return - (p[0]*n[0] + p[1]*n[1] + p[2]*n[2]);

--- a/Applications/src/decimate-surface.cc
+++ b/Applications/src/decimate-surface.cc
@@ -104,9 +104,8 @@ int main(int argc, char **argv)
   quadric->AttributeErrorMetricOn(); // Otherwise point data is not copied
 
   // Change decimater settings to user specified values
-  bool                  ascii    = false;
-  bool                  compress = true;
-  vtkPolyDataAlgorithm *filter   = quadric;
+  FileOption            fopt   = FO_Default;
+  vtkPolyDataAlgorithm *filter = quadric;
 
   for (ALL_OPTIONS) {
     if (OPTION("-reduceby") || OPTION("-targetreduction")) {
@@ -143,15 +142,12 @@ int main(int argc, char **argv)
     else if (OPTION("-pro")) {
       filter = decimater;
     }
-    else if (OPTION("-compress"))   compress = true;
-    else if (OPTION("-nocompress")) compress = false;
-    else if (OPTION("-binary"))     ascii    = false;
-    else if (OPTION("-ascii"))      ascii    = true;
+    else HANDLE_POINTSETIO_OPTION(fopt);
     else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   // Read input mesh
-  vtkSmartPointer<vtkPolyData> input = ReadPolyData(POSARG(1));
+  vtkSmartPointer<vtkPolyData> input = ReadPolyData(POSARG(1), fopt);
 
   // Execute pipeline
   vtkSmartPointer<vtkTriangleFilter> triangulator;
@@ -164,7 +160,7 @@ int main(int argc, char **argv)
   vtkSmartPointer<vtkPolyData> output = filter->GetOutput();
 
   // Write output mesh
-  WritePolyData(POSARG(2), output, compress, ascii);
+  WritePolyData(POSARG(2), output, fopt);
 
   // Some verbose reporting
   if (verbose) {

--- a/Applications/src/evaluate-distance.cc
+++ b/Applications/src/evaluate-distance.cc
@@ -33,7 +33,6 @@
 #include "vtkPolyDataNormals.h"
 #include "vtkModifiedBSPTree.h"
 #include "vtkKdTreePointLocator.h"
-#include "vtkDataReader.h" // VTK_ASCII, VTK_BINARY defines
 
 using namespace mirtk;
 
@@ -214,6 +213,7 @@ int main(int argc, char *argv[])
   const char  *separator      = "\t";
   DistanceType dist_type      = Default;
   bool         eval_hausdorff = false;
+  FileOption   fopt           = FO_Default;
 
   for (ALL_OPTIONS) {
     if      (OPTION("-array") || OPTION("-name")) array_name = ARGUMENT;
@@ -226,14 +226,16 @@ int main(int argc, char *argv[])
       separator = ARGUMENT;
       if (strcmp(separator, "\\t") == 0) separator = "\t";
     }
+    else HANDLE_POINTSETIO_OPTION(fopt);
     else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   // read input point sets
-  int output_type = VTK_BINARY;
+  FileOption source_fopt;
   vtkSmartPointer<vtkPointSet> target, source;
   target = ReadPointSet(target_name);
-  source = ReadPointSet(source_name, &output_type);
+  source = ReadPointSet(source_name, source_fopt);
+  if (fopt == FO_Default) fopt = source_fopt;
 
   if (dist_type == Default) {
     if (target->GetNumberOfCells() > 0) dist_type = ClosestCell;
@@ -319,8 +321,7 @@ int main(int argc, char *argv[])
 
   // write output
   if (output_name) {
-    const bool compress = true;
-    if (!WritePointSet(output_name, target, compress, output_type == VTK_ASCII)) {
+    if (!WritePointSet(output_name, target, fopt)) {
       FatalError("Failed to write output point set to " << output_name);
     }
   }

--- a/Applications/src/evaluate-distortion.cc
+++ b/Applications/src/evaluate-distortion.cc
@@ -324,7 +324,7 @@ int main(int argc, char *argv[])
           if (!areal_distortion) {
             areal_distortion = ArealDistortion(orig, mesh);
           }
-          abs_areal_distortion = areal_distortion->NewInstance();
+          abs_areal_distortion.TakeReference(areal_distortion->NewInstance());
           abs_areal_distortion->SetName("AbsArealDistortion");
           abs_areal_distortion->SetNumberOfComponents(1);
           abs_areal_distortion->SetNumberOfTuples(ncells);

--- a/Applications/src/extract-connected-points.cc
+++ b/Applications/src/extract-connected-points.cc
@@ -74,22 +74,19 @@ int main(int argc, char *argv[])
   const char *input_name  = POSARG(1);
   const char *output_name = POSARG(2);
 
-  int  m        = 0;
-  int  n        = 1;
-  bool compress = true;
-  bool ascii    = false;
+  int m = 0;
+  int n = 1;
+
+  FileOption fopt = FO_Default;
 
   for (ALL_OPTIONS) {
     if      (OPTION("-m")) PARSE_ARGUMENT(m);
     else if (OPTION("-n")) PARSE_ARGUMENT(n);
-    else if (OPTION("-binary"))     ascii    = false;
-    else if (OPTION("-ascii"))      ascii    = true;
-    else if (OPTION("-compress"))   compress = true;
-    else if (OPTION("-nocompress")) compress = false;
+    else HANDLE_POINTSETIO_OPTION(fopt);
     else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
   }
 
-  vtkSmartPointer<vtkPolyData> input = ReadPolyData(input_name);
+  vtkSmartPointer<vtkPolyData> input = ReadPolyData(input_name, fopt);
 
   if (verbose) cout << "Analyzing connected components...", cout.flush();
   vtkNew<vtkPolyDataConnectivityFilter> lcc;
@@ -127,7 +124,7 @@ int main(int argc, char *argv[])
   cleaner->Update();
   if (verbose) cout << " done" << endl;
 
-  if (!WritePointSet(output_name, cleaner->GetOutput(), compress, ascii)) {
+  if (!WritePointSet(output_name, cleaner->GetOutput(), fopt)) {
     FatalError("Failed to write components to file " << output_name);
   }
 

--- a/Applications/src/extract-surface.cc
+++ b/Applications/src/extract-surface.cc
@@ -72,10 +72,9 @@ int main(int argc, char **argv)
 
   const char *input_name  = POSARG(1);
   const char *output_name = POSARG(2);
+  FileOption output_fopt  = FO_Default;
 
   double isovalue  = .0;
-  bool   compress  = true;
-  bool   ascii     = false;
   bool   isotropic = false;
   bool   close     = false;
   bool   gradients = false;
@@ -107,10 +106,7 @@ int main(int argc, char **argv)
       normals = false;
     }
     else if (OPTION("-blur")) PARSE_ARGUMENT(blurring);
-    else if (OPTION("-compress"))   compress = true;
-    else if (OPTION("-nocompress")) compress = false;
-    else if (OPTION("-ascii"))      ascii    = true;
-    else if (OPTION("-binary"))     ascii    = false;
+    else HANDLE_POINTSETIO_OPTION(output_fopt);
     else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
@@ -123,7 +119,7 @@ int main(int argc, char **argv)
   vtkSmartPointer<vtkPolyData> isosurface;
   isosurface = Isosurface(image, isovalue, blurring, isotropic, close, normals, gradients);
 
-  if (!WritePolyData(output_name, isosurface, compress, ascii)) {
+  if (!WritePolyData(output_name, isosurface, output_fopt)) {
     FatalError("Failed to write surface to " << output_name);
   }
 

--- a/Applications/src/info.cc
+++ b/Applications/src/info.cc
@@ -417,7 +417,8 @@ int main(int argc, char *argv[])
       // FIXME: Silence errors of VTK readers instead
       fext != ".nii"  && fext != ".hdr" && fext != ".img" && fext != ".png" &&
       fext != ".gipl" && fext != ".pgm") {
-    pointset = ReadPointSet(POSARG(1), NULL, false);
+    const bool exit_on_failure = false;
+    pointset = ReadPointSet(POSARG(1), exit_on_failure);
     if (pointset) {
       polydata = ConvertToPolyData(pointset);
       polydata->BuildLinks();

--- a/Applications/src/info.cc
+++ b/Applications/src/info.cc
@@ -764,20 +764,30 @@ int main(int argc, char *argv[])
 
     // Attributes
     if (list_pointdata_arrays) {
-      if (pointset->GetPointData()->GetNumberOfArrays() > 0) {
-        cout << "\nPoint data arrays:\n";
-        for (int i = 0; i < pointset->GetPointData()->GetNumberOfArrays(); ++i) {
-          vtkDataArray *scalars = pointset->GetPointData()->GetArray(i);
-          printf(" %2d %-24s (dim: %2d)\n", i, scalars->GetName(), scalars->GetNumberOfComponents());
+      vtkPointData *pd = pointset->GetPointData();
+      if (pd->GetNumberOfArrays() > 0) {
+        cout << "\nPoint data attributes:\n";
+        for (int i = 0; i < pd->GetNumberOfArrays(); ++i) {
+          vtkDataArray *array = pd->GetArray(i);
+          printf(" %2d %-24s (dim: %2d, type: %-7s kind: %s)\n", i,
+              array->GetName(),
+              array->GetNumberOfComponents(),
+              (VtkDataTypeString(array->GetDataType()) + ",").c_str(),
+              VtkAttributeTypeString(pd->IsArrayAnAttribute(i)).c_str());
         }
       }
     }
     if (list_celldata_arrays) {
-      if (pointset->GetCellData()->GetNumberOfArrays() > 0) {
-        cout << "\nCell data arrays:\n";
-        for (int i = 0; i < pointset->GetCellData()->GetNumberOfArrays(); ++i) {
-          vtkDataArray *scalars = pointset->GetCellData()->GetArray(i);
-          printf(" %2d %-24s (dim: %2d)\n", i, scalars->GetName(), scalars->GetNumberOfComponents());
+      vtkCellData *cd = pointset->GetCellData();
+      if (cd->GetNumberOfArrays() > 0) {
+        cout << "\nCell data attributes:\n";
+        for (int i = 0; i < cd->GetNumberOfArrays(); ++i) {
+          vtkDataArray *array = cd->GetArray(i);
+          printf(" %2d %-24s (dim: %2d, type: %-7s kind: %s)\n", i,
+              array->GetName(),
+              array->GetNumberOfComponents(),
+              (VtkDataTypeString(array->GetDataType()) + ",").c_str(),
+              VtkAttributeTypeString(cd->IsArrayAnAttribute(i)).c_str());
         }
       }
     }

--- a/Applications/src/offset-surface.cc
+++ b/Applications/src/offset-surface.cc
@@ -105,8 +105,8 @@ int main(int argc, char **argv)
   double target_reduction = .0;
   bool   relative         = false;
   bool   implicit         = false;
-  bool   compress         = true;
-  bool   ascii            = false;
+
+  FileOption fopt = FO_Default;
 
   // resolution of implicit surface model
   int    nx =  0, ny =  0, nz =  0;
@@ -150,15 +150,12 @@ int main(int argc, char **argv)
         }
       }
     }
-    else if (OPTION("-compress"))   compress = true;
-    else if (OPTION("-nocompress")) compress = false;
-    else if (OPTION("-binary"))     ascii = false;
-    else if (OPTION("-ascii"))      ascii = true;
+    else HANDLE_POINTSETIO_OPTION(fopt);
     else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   // Read input point set
-  vtkSmartPointer<vtkPointSet> pointset = ReadPointSet(input_name);
+  vtkSmartPointer<vtkPointSet> pointset = ReadPointSet(input_name, fopt);
   vtkSmartPointer<vtkPolyData> output   = DataSetSurface(pointset);
   vtkSmartPointer<vtkPolyData> surface  = output;
   vtkSmartPointer<vtkPolyData> offset_surface;
@@ -419,7 +416,7 @@ int main(int argc, char **argv)
   }
 
   // Write output surface mesh
-  if (!WritePolyData(output_name, output, compress, ascii)) {
+  if (!WritePolyData(output_name, output, fopt)) {
     FatalError("Failed to write offset surface to " << output_name);
   }
   return 0;

--- a/Applications/src/smooth-surface.cc
+++ b/Applications/src/smooth-surface.cc
@@ -96,10 +96,10 @@ void PrintHelp(const char *name)
   cout << endl;
   cout << "  -anisotropic ([<sigma>] [<tensor_array>] | <sigma1> <sigma2> [(<e2_array> | <e1_array> <e2_array>)])" << endl;
   cout << "      Anisotropic Gaussian smoothing kernel given input tensor field point data array" << endl;
-  cout << "      named <tensor_array>. The default tensor field used no arguments or only <sigma> specified" << endl;
-  cout << "      is the curvature tensor output of polydatacurvature. Alternatively, specify <sigma1> and <sigma2>" << endl;
-  cout << "      together with the direction of maximum curvature in <e2_array> or both, the direction of minimum" << endl;
-  cout << "      and maximum curvature direction in point data arrays named <e1_array> and <e2_array>." << endl;
+  cout << "      named <tensor_array>. The default tensor field used with no arguments or only <sigma> specified" << endl;
+  cout << "      is the curvature tensor output of the calculate-surface-attributes -tensor command. Alternatively," << endl;
+  cout << "      specify <sigma1> and <sigma2> together with the direction of maximum curvature in <e2_array> or both," << endl;
+  cout << "      the direction of minimum and maximum curvature direction in point data arrays named <e1_array> and <e2_array>." << endl;
   cout << endl;
   cout << "  -track [<name>]          Track the signed distances traversed by points (positive is outwards)." << endl;
   cout << "                           The optional arguments specifies the name of output output point data array." << endl;

--- a/Modules/Common/include/mirtk/Algorithm.h
+++ b/Modules/Common/include/mirtk/Algorithm.h
@@ -79,7 +79,7 @@ public:
   template <class IndexType>
   bool operator ()(IndexType i, IndexType j) const
   {
-    return _Values[i] < _Values[j];
+    return _Values[i] > _Values[j];
   }
 };
 

--- a/Modules/Common/include/mirtk/Vtk.h
+++ b/Modules/Common/include/mirtk/Vtk.h
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2016 Imperial College London
+ * Copyright 2013-2016 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,13 @@ namespace mirtk {
 
 // -----------------------------------------------------------------------------
 /// Instantiate new VTK data array of given type
-vtkSmartPointer<vtkDataArray> NewVTKDataArray(int vtkType);
+///
+/// \param[in] type VTK data type ID, e.g., VTK_FLOAT. When VTK_VOID, a floating
+///                 point data array with default precision, i.e., either single
+///                 or double is returned.
+///
+/// \returns New VTK data array instance.
+vtkSmartPointer<vtkDataArray> NewVTKDataArray(int type = VTK_VOID);
 
 // -----------------------------------------------------------------------------
 /// Convert string to vtkDataSetAttributes::AttributeType
@@ -103,17 +109,48 @@ inline string ToString(const vtkDataSetAttributes::AttributeTypes &type,
 {
   const char *str;
   switch (type) {
-    case vtkDataSetAttributes::SCALARS:     str = "SCALARS";     break;
-    case vtkDataSetAttributes::VECTORS:     str = "VECTORS";     break;
-    case vtkDataSetAttributes::NORMALS:     str = "NORMALS";     break;
-    case vtkDataSetAttributes::TCOORDS:     str = "TCOORDS";     break;
-    case vtkDataSetAttributes::TENSORS:     str = "TENSORS";     break;
-    case vtkDataSetAttributes::GLOBALIDS:   str = "GLOBALIDS";   break;
-    case vtkDataSetAttributes::PEDIGREEIDS: str = "PEDIGREEIDS"; break;
-    case vtkDataSetAttributes::EDGEFLAG:    str = "EDGEFLAG";    break;
-    default:                                str = "UNKNOWN";     break;
+    case vtkDataSetAttributes::SCALARS:     str = "scalars";     break;
+    case vtkDataSetAttributes::VECTORS:     str = "vectors";     break;
+    case vtkDataSetAttributes::NORMALS:     str = "normals";     break;
+    case vtkDataSetAttributes::TCOORDS:     str = "tcoords";     break;
+    case vtkDataSetAttributes::TENSORS:     str = "tensors";     break;
+    case vtkDataSetAttributes::GLOBALIDS:   str = "globalids";   break;
+    case vtkDataSetAttributes::PEDIGREEIDS: str = "pedigreeids"; break;
+    case vtkDataSetAttributes::EDGEFLAG:    str = "edgeflag";    break;
+    default:                                str = "unknown";     break;
   }
   return ToString(str, w, c, left);
+}
+
+// -----------------------------------------------------------------------------
+/// Convert vtkDataSetAttributes::AttributeType to string
+inline string VtkAttributeTypeString(int type)
+{
+  if (type < 0) return "other";
+  return ToString(static_cast<vtkDataSetAttributes::AttributeTypes>(type));
+}
+
+// -----------------------------------------------------------------------------
+/// Convert vtkDataSetAttributes::AttributeType to string
+inline string VtkDataTypeString(int type)
+{
+  switch (type)
+  {
+    case VTK_VOID:               return "void";
+    case VTK_CHAR:               return "char";
+    case VTK_SHORT:              return "short";
+    case VTK_INT:                return "int";
+    case VTK_LONG:               return "long";
+    case VTK_LONG_LONG:          return "int64";
+    case VTK_UNSIGNED_CHAR:      return "uchar";
+    case VTK_UNSIGNED_SHORT:     return "ushort";
+    case VTK_UNSIGNED_INT:       return "uint";
+    case VTK_UNSIGNED_LONG:      return "ulong";
+    case VTK_UNSIGNED_LONG_LONG: return "uint64";
+    case VTK_FLOAT:              return "float";
+    case VTK_DOUBLE:             return "double";
+    default:                     return "unknown";
+  }
 }
 
 

--- a/Modules/Common/src/Vtk.cc
+++ b/Modules/Common/src/Vtk.cc
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2016 Imperial College London
+ * Copyright 2013-2016 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include "mirtk/Config.h" // MIRTK_USE_FLOAT_BY_DEFAULT
 
 #include "mirtk/Vtk.h"
 #include "mirtk/Stream.h"
@@ -38,6 +40,13 @@ namespace mirtk {
 vtkSmartPointer<vtkDataArray> NewVTKDataArray(int vtkType)
 {
   switch (vtkType) {
+    case VTK_VOID: {
+      #if MIRTK_USE_FLOAT_BY_DEFAULT
+        return vtkSmartPointer<vtkFloatArray>::New();
+      #else
+        return vtkSmartPointer<vtkDoubleArray>::New();
+      #endif
+    } break;
     case VTK_CHAR:           return vtkSmartPointer<vtkCharArray>::New();
     case VTK_UNSIGNED_CHAR:  return vtkSmartPointer<vtkUnsignedCharArray>::New();
     case VTK_SHORT:          return vtkSmartPointer<vtkShortArray>::New();

--- a/Modules/IO/include/mirtk/PointSetIO.h
+++ b/Modules/IO/include/mirtk/PointSetIO.h
@@ -53,43 +53,77 @@ const char *DefaultExtension(vtkDataSet *);
 // Generic I/O functions
 // =============================================================================
 
+/// Auxiliary macro to parse common point set output file type options
+#define HANDLE_POINTSETIO_OPTION(fopt)                                         \
+         if (OPTION("-ascii") || OPTION("-nobinary")) fopt = FO_ASCII;         \
+    else if (OPTION("-noascii") || OPTION("-binary")) fopt = FO_Binary;        \
+    else if (OPTION("-compress"))                     fopt = FO_Binary;        \
+    else if (OPTION("-nocompress"))                   fopt = FO_NoCompress
+
+/// Enumeration of file type options
+enum FileOption
+{
+  FO_Default,   ///< Default options
+  FO_ASCII,     ///< Uncompressed ASCII
+  FO_Binary,    ///< (Compressed) binary
+  FO_NoCompress ///< Unompressed binary
+};
+
 /// Read point set from file
 ///
-/// @param[in]  fname           File name.
-/// @param[out] ftype           File type (VTK_ASCII or VTK_BINARY) of legacy VTK input file.
-/// @param[in]  exit_on_failure Call exit when point set could not be read.
+/// @param[in] fname           File name.
+/// @param[in] exit_on_failure Call exit when point set could not be read.
 ///
 /// @return Point set. Dataset is empty if file could not be read and @p exit_on_failure is @c false.
-vtkSmartPointer<vtkPointSet> ReadPointSet(const char *fname, int *ftype = nullptr, bool exit_on_failure = true);
+vtkSmartPointer<vtkPointSet> ReadPointSet(const char *fname, bool exit_on_failure = true);
+
+/// Read point set from file
+///
+/// @param[in]  fname  File name.
+/// @param[out] fopt   Input file type option to be passed to WritePointSet
+///                    in order to save point set again in an equivalent
+///                    file format when the same file format extension is used.
+/// @param[in] exit_on_failure Call exit when point set could not be read.
+///
+/// @return Point set. Dataset is empty if file could not be read and @p exit_on_failure is @c false.
+vtkSmartPointer<vtkPointSet> ReadPointSet(const char *fname, FileOption &fopt, bool exit_on_failure = true);
 
 /// Read polygonal dataset from file
 ///
-/// @param[in]  fname           File name.
-/// @param[out] ftype           File type (VTK_ASCII or VTK_BINARY) of legacy VTK input file.
-/// @param[in]  exit_on_failure Call exit when point set could not be read.
+/// @param[in] fname           File name.
+/// @param[in] exit_on_failure Call exit when point set could not be read.
 ///
 /// @return Polygonal dataset. Dataset is empty if file could not be read and @p exit_on_failure is @c false.
-vtkSmartPointer<vtkPolyData> ReadPolyData(const char *fname, int *ftype = nullptr, bool exit_on_failure = true);
+vtkSmartPointer<vtkPolyData> ReadPolyData(const char *fname, bool exit_on_failure = true);
+
+/// Read polygonal dataset from file
+///
+/// @param[in]  fname  File name.
+/// @param[out] fopt   Input file type option to be passed to WritePointSet
+///                    in order to save point set again in an equivalent
+///                    file format when the same file format extension is used.
+/// @param[in] exit_on_failure Call exit when point set could not be read.
+///
+/// @return Polygonal dataset. Dataset is empty if file could not be read and @p exit_on_failure is @c false.
+vtkSmartPointer<vtkPolyData> ReadPolyData(const char *fname, FileOption &fopt, bool exit_on_failure = true);
 
 /// Write point set to file
 ///
 /// @param fname    File name. The extension determines the output format.
 /// @param pointset Point set to write.
-/// @param compress Whether to use compression when writing to VTK XML format (.vtp).
-/// @param ascii    Whether to use ASCII format when writing to legacy VTK format (.vtk).
+/// @param fopt     Whether to use ASCII, binary, or compressed binary file format.
 ///
 /// @return Whether point set was written successfully to the specified file.
-bool WritePointSet(const char *fname, vtkPointSet *pointset, bool compress = true, bool ascii = false);
+bool WritePointSet(const char *fname, vtkPointSet *pointset, FileOption fopt = FO_Default);
 
 /// Write polygonal dataset to file
 ///
 /// @param fname    File name. The extension determines the output format.
 /// @param polydata Polydata to write.
-/// @param compress Whether to use compression when writing to VTK XML format (.vtp).
-/// @param ascii    Whether to use ASCII format when writing to legacy VTK format (.vtk).
+/// @param fopt     Whether to use ASCII, binary, or compressed binary file format.
 ///
 /// @return Whether point set was written successfully to the specified file.
-bool WritePolyData(const char *fname, vtkPolyData *polydata, bool compress = true, bool ascii = false);
+bool WritePolyData(const char *fname, vtkPolyData *polydata, FileOption fopt = FO_Default);
 
 // =============================================================================
 // TetGen I/O functions
@@ -340,14 +374,12 @@ vtkSmartPointer<vtkPolyData> ReadGIFTI(const char  *fname,
 ///                     - .topo.gii:   Topology.
 ///                     - otherwise:   Point coordinates, topology, and point data.
 /// @param[in] polydata Polygonal dataset.
-/// @param[in] compress Whether to compress binary data.
-/// @param[in] ascii    Whether to write data in ASCII format.
+/// @param[in] fopt     GIFTI file encoding.
 ///
 /// @return Whether dataset was written successfully to the specified file.
 ///
 /// @sa https://www.nitrc.org/projects/gifti/
-bool WriteGIFTI(const char *fname, vtkPolyData *polydata,
-                bool compress = true, bool ascii = false);
+bool WriteGIFTI(const char *fname, vtkPolyData *polydata, FileOption fopt = FO_Default);
 
 #endif // MIRTK_IO_WITH_GIFTI
 

--- a/Modules/Image/include/mirtk/ConnectedComponents.h
+++ b/Modules/Image/include/mirtk/ConnectedComponents.h
@@ -93,6 +93,11 @@ public:
   /// Run() will add the component again to the output.
   virtual void DeleteComponent(VoxelType);
 
+  /// Size of the specified component
+  ///
+  /// \param[in] label Component label (1-based).
+  int ComponentSize(VoxelType label) const;
+
 protected:
 
   /// Initialize the filter execution
@@ -135,6 +140,17 @@ inline bool FromString(const char *str, ConnectedComponentsOrdering &value)
     value = CC_SmallestFirst;
   } else return false;
   return true;
+}
+
+// =============================================================================
+// Inline definitions
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+template <class TVoxel>
+inline int ConnectedComponents<TVoxel>::ComponentSize(VoxelType label) const
+{
+  return _ComponentSize[label-1];
 }
 
 

--- a/Modules/Image/include/mirtk/DataOp.h
+++ b/Modules/Image/include/mirtk/DataOp.h
@@ -70,7 +70,7 @@ public:
 
 #if MIRTK_Image_WITH_VTK
   /// Process given vtkDataArray
-  virtual void Process(vtkDataArray *data, bool *mask = NULL)
+  virtual void Process(vtkDataArray *data, bool *mask = nullptr)
   {
     const int n = static_cast<int>(data->GetNumberOfTuples() * data->GetNumberOfComponents());
     if (data->GetDataType() == VTK_DOUBLE) {
@@ -113,10 +113,10 @@ DataFileType FileType(const char *name);
 // -----------------------------------------------------------------------------
 /// Read data sequence from any supported input file type
 #if MIRTK_Image_WITH_VTK
-int Read(const char *name, double *&data, int *dtype = NULL, ImageAttributes *attr = NULL,
-         vtkSmartPointer<vtkDataSet> *dataset= NULL, const char *scalar_name = NULL);
+int Read(const char *name, double *&data, int *dtype = nullptr, ImageAttributes *attr = nullptr,
+         vtkSmartPointer<vtkDataSet> *dataset= nullptr, const char *scalar_name = nullptr);
 #else
-int Read(const char *name, double *&data, int *dtype = NULL, ImageAttributes *attr = NULL);
+int Read(const char *name, double *&data, int *dtype = nullptr, ImageAttributes *attr = nullptr);
 #endif // MIRTK_Image_WITH_VTK
 
 // -----------------------------------------------------------------------------
@@ -131,8 +131,11 @@ class Write : public Op
   /// VTK input dataset whose scalar data was modified
   mirtkPublicAttributeMacro(vtkSmartPointer<vtkDataSet>, DataSet);
 
-  /// Name of input/output point data array
+  /// Name of input point data array
   mirtkPublicAttributeMacro(string, ArrayName);
+
+  /// Name of output point data array
+  mirtkPublicAttributeMacro(string, OutputName);
 
 #endif // MIRTK_Image_WITH_VTK
 
@@ -149,15 +152,17 @@ public:
 
   Write(const char *fname, int dtype = MIRTK_VOXEL_DOUBLE,
         ImageAttributes attr = ImageAttributes(),
-        vtkDataSet *dataset      = NULL,
-        const char *scalars_name = NULL)
+        vtkDataSet *dataset     = nullptr,
+        const char *array_name  = nullptr,
+        const char *output_name = nullptr)
   :
     _FileName(fname),
     _DataSet(dataset),
     _Attributes(attr),
     _DataType(dtype)
   {
-    if (scalars_name) _ArrayName = scalars_name;
+    if (array_name)  _ArrayName  = array_name;
+    if (output_name) _OutputName = output_name;
   }
 
 #else // MIRTK_Image_WITH_VTK
@@ -173,7 +178,7 @@ public:
 #endif // MIRTK_Image_WITH_VTK
 
   /// Process given data
-  virtual void Process(int n, double *data, bool * = NULL);
+  virtual void Process(int n, double *data, bool * = nullptr);
 
 };
 

--- a/Modules/Image/src/ConnectedComponents.cc
+++ b/Modules/Image/src/ConnectedComponents.cc
@@ -82,7 +82,7 @@ int LabelComponent(const NeighborhoodOffsets  &offsets,
       components(idx) = component_label, ++num;
       if (segmentation.IsBoundary(idx)) {
         const TLabel *neighbor_label, *label = segmentation.Data(idx);
-        const TLabel *neighbor_comp,  *comp  = components.Data(idx);
+        const TLabel *neighbor_comp,  *comp  = components  .Data(idx);
         for (int n = 0; n < offsets.Size(); ++n) {
           neighbor_label = label + offsets(n);
           neighbor_idx   = static_cast<int>(neighbor_label - start_label);
@@ -94,8 +94,8 @@ int LabelComponent(const NeighborhoodOffsets  &offsets,
           }
         }
       } else {
-        const TLabel *neighbor_label, *label  = segmentation.Data(idx);
-        const TLabel *neighbor_comp,  *comp = components.Data(idx);
+        const TLabel *neighbor_label, *label = segmentation.Data(idx);
+        const TLabel *neighbor_comp,  *comp  = components  .Data(idx);
         for (int n = 0; n < offsets.Size(); ++n) {
           neighbor_label = label + offsets(n);
           neighbor_comp  = comp  + offsets(n);

--- a/Modules/Numerics/include/mirtk/Point.h
+++ b/Modules/Numerics/include/mirtk/Point.h
@@ -28,8 +28,8 @@ namespace mirtk {
 
 
 // Forward declaration of Vector in particular, as its header
-// includes mrtkVector3D.h which in turn includes this file again.
-// Therefore, only include mrtkVector.h after Point is declared.
+// includes mirtk/Vector3D.h which in turn includes this file again.
+// Therefore, only include mirtk/Vector.h after Point is declared.
 class Vector;
 class Matrix;
 
@@ -69,7 +69,7 @@ public:
   Point(const Point &);
 
   /// Constructor with Vector
-  Point(const Vector&);
+  Point(const Vector &);
 
   /// Default destructor
   virtual ~Point();

--- a/Modules/Numerics/include/mirtk/Vector3D.h
+++ b/Modules/Numerics/include/mirtk/Vector3D.h
@@ -22,6 +22,7 @@
 
 #include "mirtk/Math.h"
 #include "mirtk/Point.h"
+#include "mirtk/Vector3.h"
 
 
 namespace mirtk {
@@ -70,8 +71,14 @@ struct Vector3D
   /// Construct from vector components
   Vector3D(T, T, T);
 
+  /// Construct from C array
+  explicit Vector3D(const T [3]);
+
+  /// Construct from non-template 3D vector type
+  explicit Vector3D(const Vector3 &);
+
   /// Construct from 3D point
-  Vector3D(const Point &);
+  explicit Vector3D(const Point &);
 
   /// Assignment operator
   Vector3D &operator =(const Vector3D &);
@@ -310,6 +317,24 @@ inline Vector3D<T>::Vector3D(T x, T y, T z)
   _x = x;
   _y = y;
   _z = z;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+inline Vector3D<T>::Vector3D(const T v[3])
+{
+  _x = v[0];
+  _y = v[1];
+  _z = v[2];
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+inline Vector3D<T>::Vector3D(const Vector3 &v)
+{
+  _x = static_cast<T>(v[0]);
+  _y = static_cast<T>(v[1]);
+  _z = static_cast<T>(v[2]);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/PointSet/include/mirtk/BoundarySegment.h
+++ b/Modules/PointSet/include/mirtk/BoundarySegment.h
@@ -152,6 +152,14 @@ public:
   /// \returns Boundary segment point index or -1 if segment does not contain this point.
   int Find(int ptId) const;
 
+  /// Find closest boundary point
+  ///
+  /// \param[in] x     Point coordinates.
+  /// \param[in] dist2 Squared distance of closest boundary point.
+  ///
+  /// \returns Index of closest boundary segment point.
+  int FindClosestPoint(const class Point &x, double *dist2 = nullptr) const;
+
   /// Whether this boundary segment contains a given surface point
   ///
   /// \param[in] ptId Surface point ID.

--- a/Modules/PointSet/include/mirtk/ImplicitSurfaceUtils.h
+++ b/Modules/PointSet/include/mirtk/ImplicitSurfaceUtils.h
@@ -780,16 +780,16 @@ inline void EvaluateTangential(DistanceMeasurement &d,
   PointSamples dirs(ndirs * nbetas);
   switch (ndirs) {
     case 1: {
-      dirs(0) = e1;
+      dirs(0) = Point(e1);
     } break;
     case 2: {
-      dirs(0) = e1;
-      dirs(1) = e2;
+      dirs(0) = Point(e1);
+      dirs(1) = Point(e2);
     } break;
     case 4: {
       const double sqrt2 = sqrt(2.0);
-      dirs(0) = e1;
-      dirs(1) = e2;
+      dirs(0) = Point(e1);
+      dirs(1) = Point(e2);
       dirs(2) = (Point(e1) + Point(e2)) / sqrt2;
       dirs(3) = (Point(e1) - Point(e2)) / sqrt2;
     } break;

--- a/Modules/PointSet/include/mirtk/PointCorrespondence.h
+++ b/Modules/PointSet/include/mirtk/PointCorrespondence.h
@@ -534,7 +534,7 @@ inline vtkSmartPointer<vtkPointSet> PointCorrespondence
 {
   vtkSmartPointer<vtkPointSet> output;
   if (sample && sample->size() > 0) {
-    output = vtkSmartPointer<vtkPointSet>::NewInstance(dataset);
+    output.TakeReference(dataset->NewInstance());
     output->SetPoints(GetPoints(dataset, sample));
   } else {
     output = dataset;

--- a/Modules/PointSet/include/mirtk/SurfaceBoundary.h
+++ b/Modules/PointSet/include/mirtk/SurfaceBoundary.h
@@ -166,6 +166,13 @@ public:
   /// \param[in] n Index of boundary segment.
   ///
   /// \returns Reference to n-th boundary segment.
+  BoundarySegment &Segment(int n);
+
+  /// Get n-th boundary segment
+  ///
+  /// \param[in] n Index of boundary segment.
+  ///
+  /// \returns Reference to n-th boundary segment.
   const BoundarySegment &Segment(int n) const;
 
   /// Get longest boundary segment
@@ -277,6 +284,12 @@ inline bool SurfaceBoundary::Contains(int ptId) const
 inline int SurfaceBoundary::NumberOfSegments() const
 {
   return static_cast<int>(_Segments.size());
+}
+
+// -----------------------------------------------------------------------------
+inline BoundarySegment &SurfaceBoundary::Segment(int n)
+{
+  return _Segments[n];
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/PointSet/include/mirtk/SurfaceCurvature.h
+++ b/Modules/PointSet/include/mirtk/SurfaceCurvature.h
@@ -70,16 +70,17 @@ public:
   /// Enumeration of output curvature measures, can be combined using bitwise OR
   enum Type
   {
-    Minimum          =   1, ///< Minimum principle curvature, k_min
-    Maximum          =   2, ///< Maximum principle curvature, k_max
-    Mean             =   4, ///< Mean curvature, (k_min + k_max)/2
-    Gauss            =   8, ///< Gauss curvature, k_min * k_max
-    Curvedness       =  16, ///< Curvedness, i.e., sqrt((k_min^2 + k_max^2) / 2)
-    Normal           =  32, ///< Point normal computed from curvature tensor
-    MinimumDirection =  64, ///< Direction of minimum curvature
-    MaximumDirection = 128, ///< Direction of maximum curvature
-    Tensor           = 256, ///< 6 entries of symmetric 3x3 curvature tensor
-    InverseTensor    = 512, ///< 6 entries of inverse of symmetric 3x3 curvature tensor
+    Minimum          =    1, ///< Minimum principal curvature, k_min
+    Maximum          =    2, ///< Maximum principal curvature, k_max
+    Principal        =    4, ///< Both principal curvatures in single array
+    Mean             =    8, ///< Mean curvature, (k_min + k_max)/2
+    Gauss            =   16, ///< Gauss curvature, k_min * k_max
+    Curvedness       =   32, ///< Curvedness, i.e., sqrt((k_min^2 + k_max^2) / 2)
+    Normal           =   64, ///< Point normal computed from curvature tensor
+    MinimumDirection =  128, ///< Direction of minimum curvature
+    MaximumDirection =  256, ///< Direction of maximum curvature
+    Tensor           =  512, ///< 6 entries of symmetric 3x3 curvature tensor
+    InverseTensor    = 1024, ///< 6 entries of inverse of symmetric 3x3 curvature tensor
     Scalars          = Minimum | Maximum | Mean | Gauss | Curvedness,
     Directions       = Normal | MinimumDirection | MaximumDirection
   };
@@ -95,6 +96,7 @@ public:
 
   MIRTK_PointSet_EXPORT static const char *MINIMUM;           ///< Name of minimum curvature array
   MIRTK_PointSet_EXPORT static const char *MAXIMUM;           ///< Name of maximum curvature array
+  MIRTK_PointSet_EXPORT static const char *PRINCIPAL;         ///< Name of principal curvatures array
   MIRTK_PointSet_EXPORT static const char *MEAN;              ///< Name of mean curvature array
   MIRTK_PointSet_EXPORT static const char *GAUSS;             ///< Name of Gauss curvature array
   MIRTK_PointSet_EXPORT static const char *CURVEDNESS;        ///< Name of curvedness array
@@ -177,6 +179,21 @@ public:
   /// \note Smoothing is not performed unless Run is executed.
   vtkDataArray *GetMaximumCurvature();
 
+  /// Get/compute principal curvatures
+  ///
+  /// If Run was executed and the principle curvatures were included in
+  /// the requested output curvature types, this function just returns
+  /// the respective point data array. Otherwise, Initialize must be called
+  /// first and this function will compute the mean, Gauss, and principle
+  /// curvatures using the vtkCurvatures filter.
+  ///
+  /// When the minimum and maximum curvatures were computed before and stored
+  /// in separate output point data arrays, this function only allocates a new
+  /// output point data array to store both principal curvatures.
+  ///
+  /// \note Smoothing is not performed unless Run is executed.
+  vtkDataArray *GetPrincipalCurvatures();
+
   /// Get/compute mean curvature
   ///
   /// If Run was executed and the mean curvature was included in the
@@ -227,6 +244,9 @@ protected:
 
   /// Compute Gauss curvature
   void ComputeGaussCurvature();
+
+  /// Compute principal curvatures from mean and Gauss curvature
+  void ComputePrincipalCurvatures();
 
   /// Compute minimum and/or maximum curvature from mean and Gauss curvature
   void ComputeMinMaxCurvature(bool, bool);

--- a/Modules/PointSet/include/mirtk/SurfaceRemeshing.h
+++ b/Modules/PointSet/include/mirtk/SurfaceRemeshing.h
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2016 Imperial College London
+ * Copyright 2013-2016 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 #include "mirtk/SurfaceFilter.h"
 
 #include "mirtk/Point.h"
+#include "mirtk/OrderedSet.h"
 
 #include "vtkPriorityQueue.h"
 
@@ -68,11 +69,22 @@ protected:
   // ---------------------------------------------------------------------------
   // Attributes
 
+  /// Name of internal minimum edge length point data array
+  static const char * const MIN_EDGE_LENGTH;
+
+  /// Name of internal maximum edge length point data array
+  static const char * const MAX_EDGE_LENGTH;
+
+  /// Shallow copy of input surface with additional internal point data
+  mirtkAttributeMacro(vtkSmartPointer<vtkPolyData>, Surface);
+
   /// Optional input transformation used to determine edge length and triangle area
   mirtkPublicAggregateMacro(const class Transformation, Transformation);
 
-  /// Output point labels
-  mirtkAttributeMacro(vtkSmartPointer<vtkDataArray>, OutputPointLabels);
+  /// Indices of point data arrays with categorical data that requires
+  /// nearest neighbor interpolation instead of linear interpolation
+  mirtkAttributeMacro(OrderedSet<int>, CategoricalPointDataIndices);
+  Array<double> _CategoricalPointDataCache;
 
   /// Minimum angle between edge end point normals to consider the edge as
   /// an important feature edge which is excluded from any melting operation.

--- a/Modules/PointSet/include/mirtk/Triangle.h
+++ b/Modules/PointSet/include/mirtk/Triangle.h
@@ -21,6 +21,8 @@
 #define MIRTK_Triangle_H
 
 #include "mirtk/Math.h"
+#include "mirtk/Vector3.h"
+#include "mirtk/Matrix3x3.h"
 #include "mirtk/VtkMath.h"
 
 
@@ -34,13 +36,31 @@ class Triangle
 {
 public:
 
+  /// Compute center point of triangle
+  ///
+  /// \param[in]  a      Position of triangle vertex A.
+  /// \param[in]  b      Position of triangle vertex B.
+  /// \param[in]  c      Position of triangle vertex C.
+  /// \param[out] center Positoin of triangle center.
+  static void Center(const double a[3], const double b[3], const double c[3], double center[3]);
+
   /// Compute normal direction of triangle
   ///
   /// \param[in]  a Position of triangle vertex A.
   /// \param[in]  b Position of triangle vertex B.
   /// \param[in]  c Position of triangle vertex C.
-  /// \param[out] n Non-normalized triangle normal vector. Length equals twice the triangle area.
+  /// \param[out] n Non-normalized triangle normal vector.
+  ///               The length of the resulting vector equals twice the triangle area.
   static void NormalDirection(const double a[3], const double b[3], const double c[3], double n[3]);
+
+  /// Partial derivatives of normal direction w.r.t. position of vertex A
+  ///
+  /// \param[in] a Position of triangle vertex A.
+  /// \param[in] b Position of triangle vertex B.
+  /// \param[in] c Position of triangle vertex C.
+  ///
+  /// \returns Partial derivatives of normal direction components w.r.t. coordinates of vertex A.
+  static Matrix3x3 NormalDirectionJacobian(const double a[3], const double b[3], const double c[3]);
 
   /// Compute normal of triangle
   ///
@@ -49,6 +69,41 @@ public:
   /// \param[in]  c Position of triangle vertex C.
   /// \param[out] n Triangle normal vector.
   static void Normal(const double a[3], const double b[3], const double c[3], double n[3]);
+
+  /// Partial derivatives of normal w.r.t. coordinates of vertex A
+  ///
+  /// \param[in]  a Position of triangle vertex A.
+  /// \param[in]  b Position of triangle vertex B.
+  /// \param[in]  c Position of triangle vertex C.
+  ///
+  /// \returns Partial derivatives of normal components w.r.t. coordinates of vertex A.
+  static Matrix3x3 NormalJacobian(const double a[3], const double b[3], const double c[3]);
+
+  /// Partial derivatives of normal w.r.t. coordinates of vertex A
+  ///
+  /// \param[in]  a Position of triangle vertex A.
+  /// \param[in]  b Position of triangle vertex B.
+  /// \param[in]  c Position of triangle vertex C.
+  /// \param[in] dn Partial derivatives of normal direction vector.
+  ///
+  /// \returns Partial derivatives of normal components w.r.t. coordinates of vertex A.
+  static Matrix3x3 NormalJacobian(const double a[3], const double b[3], const double c[3], const Matrix3x3 &dn);
+
+  /// Partial derivatives of normal w.r.t. coordinates of vertex A
+  ///
+  /// \param[in]  n Triangle normal vector, i.e., normalized direction vector.
+  /// \param[in] dn Partial derivatives of normal direction vector.
+  ///
+  /// \returns Partial derivatives of normal components w.r.t. coordinates of vertex A.
+  static Matrix3x3 NormalJacobian(const double n[3], const Matrix3x3 &dn);
+
+  /// Partial derivatives of normal w.r.t. coordinates of vertex A
+  ///
+  /// \param[in]  n Triangle normal vector, i.e., normalized direction vector.
+  /// \param[in] dn Partial derivatives of normal direction vector.
+  ///
+  /// \returns Partial derivatives of normal components w.r.t. coordinates of vertex A.
+  static Matrix3x3 NormalJacobian(const Vector3 &n, const Matrix3x3 &dn);
 
   /// Compute twice the area of triangle
   ///
@@ -59,6 +114,15 @@ public:
   /// \returns Twice the area of the triangle.
   static double DoubleArea(const double a[3], const double b[3], const double c[3]);
 
+  /// Partial derivatives of twice the triangle area w.r.t. coordinates of vertex A
+  ///
+  /// \param[in] a Position of triangle vertex A.
+  /// \param[in] b Position of triangle vertex B.
+  /// \param[in] c Position of triangle vertex C.
+  ///
+  /// \returns Partial derivatives of twice the triangle area w.r.t. coordinates of vertex A.
+  static Vector3 DoubleAreaGradient(const double a[3], const double b[3], const double c[3]);
+
   /// Compute area of triangle
   ///
   /// \param[in] a Position of triangle vertex A.
@@ -67,6 +131,15 @@ public:
   ///
   /// \returns Area of triangle.
   static double Area(const double a[3], const double b[3], const double c[3]);
+
+  /// Partial derivative of triangle area w.r.t. coordinates of vertex A
+  ///
+  /// \param[in] a Position of triangle vertex A.
+  /// \param[in] b Position of triangle vertex B.
+  /// \param[in] c Position of triangle vertex C.
+  ///
+  /// \returns Partial derivatives of triangle area w.r.t. coordinates of vertex A.
+  static Vector3 AreaGradient(const double a[3], const double b[3], const double c[3]);
 
   /// Compute area of triangle in 2D
   ///
@@ -117,6 +190,11 @@ public:
   static bool TriangleTriangleIntersection(const double a1[3], const double b1[3], const double c1[3],
                                            const double a2[3], const double b2[3], const double c2[3]);
 
+  /// Compute distance between triangle center points
+  static double DistanceBetweenCenters(const double a1[3], const double b1[3], const double c1[3],
+                                       const double a2[3], const double b2[3], const double c2[3],
+                                       double *p1, double *p2);
+
   /// Compute distance between closest points of two triangles
   static double DistanceBetweenTriangles(const double a1[3], const double b1[3], const double c1[3], const double n1[3],
                                          const double a2[3], const double b2[3], const double c2[3], const double n2[3],
@@ -133,6 +211,18 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 // Inline definitions
 ////////////////////////////////////////////////////////////////////////////////
+
+// =============================================================================
+// Center
+// =============================================================================
+
+//----------------------------------------------------------------------------
+inline void Triangle::Center(const double a[3], const double b[3], const double c[3], double center[3])
+{
+  center[0] = (a[0] + b[0] + c[0]) / 3.0;
+  center[1] = (a[1] + b[1] + c[1]) / 3.0;
+  center[2] = (a[2] + b[2] + c[2]) / 3.0;
+}
 
 // =============================================================================
 // Normals
@@ -215,8 +305,125 @@ inline double Triangle::Cotangent(double a[3], double b[3], double c[3])
 }
 
 // =============================================================================
+// Derivatives
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+inline Matrix3x3 Triangle
+::NormalDirectionJacobian(const double a[3], const double b[3], const double c[3])
+{
+  // - Derivative of ab x ac w.r.t. ab:
+  //   [     0.,     b[2] - a[2], a[1] - b[1];
+  //    a[2] - b[2],      0.,     b[0] - a[0];
+  //    b[1] - a[1], a[0] - b[0],      0.    ]
+  // - Derivative of ab x ac w.r.t. ac:
+  //   [         0., a[2] - c[2], c[1] - a[1];
+  //    c[2] - a[2],          0., a[0] - c[0];
+  //    a[1] - c[1], c[0] - a[0],          0.]
+  // - Dervative of ab w.r.t. a: -I
+  // - Dervative of ac w.r.t. a: -I
+  //
+  // Apply chain rule to obtain total derivative of ab x ac w.r.t. a.
+  // This results in the following three subtractions and negations.
+  const double m01 = c[2] - b[2];
+  const double m02 = b[1] - c[1];
+  const double m12 = c[0] - b[0];
+  return Matrix3x3(0.,  m01, m02, -m01, 0., m12, -m02, -m12, 0.);
+}
+
+// -----------------------------------------------------------------------------
+inline Matrix3x3 Triangle
+::NormalJacobian(const Vector3 &n, const Matrix3x3 &dn)
+{
+  const double l2 = n.SquaredLength();
+  if (l2 == 0.) return Matrix3x3(0.);
+
+  const double l  = sqrt(l2);
+  const double l3 = l2 * l;
+  const double d  = 1. / l;
+
+  const double m00 = n[0] * n[0] / l3;
+  const double m01 = n[0] * n[1] / l3;
+  const double m02 = n[0] * n[2] / l3;
+  const double m11 = n[1] * n[1] / l3;
+  const double m12 = n[1] * n[2] / l3;
+  const double m22 = n[2] * n[2] / l3;
+
+  return Matrix3x3(m00 + d, m01, m02,
+                   m01, m11 + d, m12,
+                   m02, m12, m22 + d) * dn;
+}
+
+// -----------------------------------------------------------------------------
+inline Matrix3x3 Triangle
+::NormalJacobian(const double n[3], const Matrix3x3 &dn)
+{
+  const double l2 = vtkMath::Dot(n, n);
+  if (l2 == 0.) return Matrix3x3(0.);
+
+  const double l  = sqrt(l2);
+  const double l3 = l2 * l;
+  const double d  = 1. / l;
+
+  const double m00 = n[0] * n[0] / l3;
+  const double m01 = n[0] * n[1] / l3;
+  const double m02 = n[0] * n[2] / l3;
+  const double m11 = n[1] * n[1] / l3;
+  const double m12 = n[1] * n[2] / l3;
+  const double m22 = n[2] * n[2] / l3;
+
+  return Matrix3x3(m00 + d, m01, m02,
+                   m01, m11 + d, m12,
+                   m02, m12, m22 + d) * dn;
+}
+
+// -----------------------------------------------------------------------------
+inline Matrix3x3 Triangle
+::NormalJacobian(const double a[3], const double b[3], const double c[3], const Matrix3x3 &dn)
+{
+  double n[3];
+  Normal(a, b, c, n);
+  return NormalJacobian(n, dn);
+}
+
+// -----------------------------------------------------------------------------
+inline Matrix3x3 Triangle
+::NormalJacobian(const double a[3], const double b[3], const double c[3])
+{
+  return NormalJacobian(a, b, c, NormalDirectionJacobian(a, b, c));
+}
+
+// -----------------------------------------------------------------------------
+inline Vector3 Triangle
+::DoubleAreaGradient(const double a[3], const double b[3], const double c[3])
+{
+  double n[3];
+  Normal(a, b, c, n);
+  return - Vector3(n) * NormalDirectionJacobian(a, b, c);
+}
+
+// -----------------------------------------------------------------------------
+inline Vector3 Triangle
+::AreaGradient(const double a[3], const double b[3], const double c[3])
+{
+  return .5 * DoubleAreaGradient(a, b, c);
+}
+
+// =============================================================================
 // Distance between two triangles
 // =============================================================================
+
+// -----------------------------------------------------------------------------
+/// Compute distance between two triangles
+inline double Triangle
+::DistanceBetweenCenters(const double a1[3], const double b1[3], const double c1[3],
+                         const double a2[3], const double b2[3], const double c2[3],
+                         double *p1, double *p2)
+{
+  Center(a1, b1, c1, p1);
+  Center(a2, b2, c2, p2);
+  return sqrt(vtkMath::Distance2BetweenPoints(p1, p2));
+}
 
 // -----------------------------------------------------------------------------
 /// Compute distance between two triangles

--- a/Modules/PointSet/src/BoundarySegment.cc
+++ b/Modules/PointSet/src/BoundarySegment.cc
@@ -147,6 +147,25 @@ int BoundarySegment::Find(int ptId) const
   }
 }
 
+// -----------------------------------------------------------------------------
+int BoundarySegment::FindClosestPoint(const class Point &x, double *dist2) const
+{
+  int    min_index = -1;
+  double min_dist2 = inf;
+  double d;
+
+  for (int i = 0; i < NumberOfPoints(); ++i) {
+    d = Point(i).SquaredDistance(x);
+    if (d < min_dist2) {
+      min_dist2 = d;
+      min_index = i;
+    }
+  }
+
+  if (dist2 != nullptr) *dist2 = min_dist2;
+  return min_index;
+}
+
 // =============================================================================
 // Selected points
 // =============================================================================

--- a/Modules/PointSet/src/ClosestPointLabel.cc
+++ b/Modules/PointSet/src/ClosestPointLabel.cc
@@ -206,7 +206,7 @@ struct ConvertCellLabelsToPointLabels
 vtkSmartPointer<vtkDataArray> CellLabelsToPointLabels(vtkPointSet *dataset, vtkDataArray *cellLabels)
 {
   vtkSmartPointer<vtkDataArray> pointLabels;
-  pointLabels = vtkSmartPointer<vtkDataArray>::NewInstance(cellLabels);
+  pointLabels.TakeReference(cellLabels->NewInstance());
   pointLabels->SetName("Labels");
   pointLabels->SetNumberOfComponents(1);
   pointLabels->SetNumberOfTuples(dataset->GetNumberOfPoints());

--- a/Modules/PointSet/src/MeshFilter.cc
+++ b/Modules/PointSet/src/MeshFilter.cc
@@ -51,7 +51,7 @@ void MeshFilter::CopyAttributes(const MeshFilter &other)
   _DoublePrecision = other._DoublePrecision;
 
   if (other._Output) {
-    _Output = other._Output->NewInstance();
+    _Output.TakeReference(other._Output->NewInstance());
     _Output->ShallowCopy(other._Output);
   } else {
     _Output = nullptr;
@@ -118,7 +118,7 @@ void MeshFilter::Initialize()
   _Input->BuildLinks();
 
   // By default, set output to be shallow copy of input
-  _Output = _Input->NewInstance();
+  _Output.TakeReference(_Input->NewInstance());
   _Output->ShallowCopy(_Input);
 }
 

--- a/Modules/PointSet/src/MeshSmoothing.cc
+++ b/Modules/PointSet/src/MeshSmoothing.cc
@@ -1026,7 +1026,7 @@ void MeshSmoothing::Initialize()
   // Allocate output arrays
   _OutputArrays.resize(_InputArrays.size());
   for (size_t i = 0; i < _InputArrays.size(); ++i) {
-    _OutputArrays[i] = vtkSmartPointer<vtkDataArray>::NewInstance(_InputArrays[i]);
+    _OutputArrays[i].TakeReference(_InputArrays[i]->NewInstance());
     _OutputArrays[i]->SetName(_InputArrays[i]->GetName());
     _OutputArrays[i]->SetNumberOfComponents(_InputArrays[i]->GetNumberOfComponents());
     _OutputArrays[i]->SetNumberOfTuples(_InputArrays[i]->GetNumberOfTuples());
@@ -1077,11 +1077,11 @@ void MeshSmoothing::Execute()
     // Make copy of previously smoothed outputs
     if (iter > 1) {
       if (_SmoothPoints) {
-        if (iter == 2) ip = vtkSmartPointer<vtkPoints>::NewInstance(ip);
+        if (iter == 2) ip.TakeReference(ip->NewInstance());
         ip->DeepCopy(_Output->GetPoints());
       }
       for (size_t i = 0; i < ia.size(); ++i) {
-        if (iter == 2) ia[i] = vtkSmartPointer<vtkDataArray>::NewInstance(ia[i]);
+        if (iter == 2) ia[i].TakeReference(ia[i]->NewInstance());
         ia[i]->DeepCopy(_OutputArrays[i]);
       }
     }

--- a/Modules/PointSet/src/PointCorrespondence.cc
+++ b/Modules/PointSet/src/PointCorrespondence.cc
@@ -290,7 +290,7 @@ vtkSmartPointer<vtkPointSet> SpectralPoints(vtkPointSet *input)
   delete[] p;
 
   vtkSmartPointer<vtkPointSet> output;
-  output = vtkSmartPointer<vtkPointSet>::NewInstance(input);
+  output.TakeReference(input->NewInstance());
   output->DeepCopy (input);
   output->SetPoints(points);
   return output;
@@ -939,7 +939,7 @@ void PointCorrespondence::WriteSpectralPoints(const char *fname, vtkPointSet *d)
   delete[] p;
 
   vtkSmartPointer<vtkPointSet> output;
-  output = vtkSmartPointer<vtkPointSet>::NewInstance(d);
+  output.TakeReference(d->NewInstance());
   output->ShallowCopy(d);
   output->SetPoints(points);
   WritePointSet(fname, output);

--- a/Modules/PointSet/src/PointSetUtils.cc
+++ b/Modules/PointSet/src/PointSetUtils.cc
@@ -236,7 +236,7 @@ int DeepCopyArrayUsingCaseInsensitiveName(vtkDataSetAttributes *dst, vtkDataSetA
       dst_array->DeepCopy(src_array);
     } else {
       vtkSmartPointer<vtkDataArray> copy;
-      copy = vtkSmartPointer<vtkDataArray>::NewInstance(src_array);
+      copy.TakeReference(src_array->NewInstance());
       copy->DeepCopy(src_array);
       loc = dst->AddArray(copy);
     }
@@ -1021,7 +1021,7 @@ vtkSmartPointer<vtkPolyData> Triangulate(vtkSmartPointer<vtkPolyData> mesh)
 {
   vtkSmartPointer<vtkPolyData> output;
   if (IsTriangularMesh(mesh)) {
-    output = vtkSmartPointer<vtkPolyData>::NewInstance(mesh);
+    output.TakeReference(mesh->NewInstance());
     output->ShallowCopy(mesh);
   } else {
     vtkSmartPointer<vtkTriangleFilter> filter;
@@ -1101,7 +1101,7 @@ vtkSmartPointer<vtkPointSet> Tetrahedralize(vtkSmartPointer<vtkPointSet> input)
 {
   vtkSmartPointer<vtkPointSet> mesh;
   if (IsTetrahedralMesh(input)) {
-    mesh = vtkSmartPointer<vtkPointSet>::NewInstance(input);
+    mesh.TakeReference(input->NewInstance());
     mesh->ShallowCopy(input);
   } else {
     // TODO: Use TetGen library to tetrahedralize interior of input PLC
@@ -1140,7 +1140,7 @@ vtkSmartPointer<vtkPointSet> WorldToImage(vtkSmartPointer<vtkPointSet> pointset,
     points->SetPoint(ptId, p);
   }
   vtkSmartPointer<vtkPointSet> output;
-  output = vtkSmartPointer<vtkPointSet>::NewInstance(pointset);
+  output.TakeReference(pointset->NewInstance());
   output->ShallowCopy(pointset);
   output->SetPoints(points);
   return output;

--- a/Modules/PointSet/src/PointSetUtils.cc
+++ b/Modules/PointSet/src/PointSetUtils.cc
@@ -292,13 +292,19 @@ double ComputeVolume(vtkCell *cell)
 // -----------------------------------------------------------------------------
 vtkSmartPointer<vtkPolyData> DataSetSurface(vtkSmartPointer<vtkDataSet> dataset, bool passPtIds, bool passCellIds)
 {
-  vtkSmartPointer<vtkDataSetSurfaceFilter> surface;
-  surface = vtkSmartPointer<vtkDataSetSurfaceFilter>::New();
-  SetVTKInput(surface, dataset);
-  surface->SetPassThroughPointIds(passPtIds);
-  surface->SetPassThroughCellIds(passCellIds);
-  surface->Update();
-  return surface->GetOutput();
+  if (IsSurfaceMesh(dataset)) {
+    vtkSmartPointer<vtkPolyData> surface = vtkSmartPointer<vtkPolyData>::New();
+    surface->ShallowCopy(dataset);
+    return surface;
+  } else {
+    vtkSmartPointer<vtkDataSetSurfaceFilter> surface;
+    surface = vtkSmartPointer<vtkDataSetSurfaceFilter>::New();
+    SetVTKInput(surface, dataset);
+    surface->SetPassThroughPointIds(passPtIds);
+    surface->SetPassThroughCellIds(passCellIds);
+    surface->Update();
+    return surface->GetOutput();
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/PointSet/src/RegisteredPointSet.cc
+++ b/Modules/PointSet/src/RegisteredPointSet.cc
@@ -306,13 +306,13 @@ void RegisteredPointSet::CopyAttributes(const RegisteredPointSet &other)
     }
   }
   if (other._OutputPointSet) {
-    _OutputPointSet = vtkSmartPointer<vtkPointSet>::NewInstance(other);
+    _OutputPointSet.TakeReference(other._OutputPointSet->NewInstance());
     _OutputPointSet->DeepCopy(other._OutputPointSet);
   } else {
     _OutputPointSet = NULL;
   }
   if (other._OutputSurface) {
-    _OutputSurface = vtkSmartPointer<vtkPolyData>::NewInstance(other._OutputSurface);
+    _OutputSurface.TakeReference(other._OutputSurface->NewInstance());
     _OutputSurface->DeepCopy(other._OutputSurface);
   } else {
     _OutputSurface = NULL;
@@ -376,7 +376,7 @@ void RegisteredPointSet
   // upon the first Update of a transformed point set. If no transformation is
   // set or if the point set is never updated, no copy of input points is made.
   // This is overridden by the deep_copy_points argument.
-  _OutputPointSet = vtkSmartPointer<vtkPointSet>::NewInstance(_InputPointSet);
+  _OutputPointSet.TakeReference(_InputPointSet->NewInstance());
   _OutputPointSet->ShallowCopy(_InputPointSet);
   if (deep_copy_points) {
     vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
@@ -386,7 +386,7 @@ void RegisteredPointSet
 
   _OutputSurface = vtkPolyData::SafeDownCast(_OutputPointSet);
   if (!_OutputSurface) {
-    _OutputSurface = vtkSmartPointer<vtkPolyData>::NewInstance(_InputSurface);
+    _OutputSurface.TakeReference(_InputSurface->NewInstance());
     _OutputSurface->ShallowCopy(_InputSurface);
     // ShallowCopy also copies the previously built cells and links
     if (deep_copy_points) {
@@ -845,7 +845,7 @@ void RegisteredPointSet::Update(bool force)
         output_array = outputPD->GetArray(it->_OutputIndex);
       } else {
         if (it->_Slope == 1.0 && it->_Intercept == .0) {
-          output_array = vtkSmartPointer<vtkDataArray>::NewInstance(input_array);
+          output_array.TakeReference(input_array->NewInstance());
         } else {
           output_array = vtkSmartPointer<vtkFloatArray>::New();
         }

--- a/Modules/PointSet/src/RobustPointMatch.cc
+++ b/Modules/PointSet/src/RobustPointMatch.cc
@@ -283,7 +283,7 @@ public:
     double p[3];
     for (int i = re.begin(); i != re.end(); ++i) {
       _DataSet->GetPoint(PointCorrespondence::GetPointIndex(_DataSet, _Sample, i), p);
-      _Sum += p;
+      _Sum += Point(p);
     }
   }
 

--- a/Modules/Registration/src/PointCorrespondenceDistance.cc
+++ b/Modules/Registration/src/PointCorrespondenceDistance.cc
@@ -754,9 +754,9 @@ void PointCorrespondenceDistance
   vtkSmartPointer<vtkCellArray> verts;
   vtkPolyData                  *polydata;
 
-  output = vtkSmartPointer<vtkPointSet>::NewInstance(target->PointSet());
   points = vtkSmartPointer<vtkPoints>::New();
   points->SetNumberOfPoints(n);
+  output.TakeReference(target->PointSet()->NewInstance());
   output->SetPoints(points);
   polydata = vtkPolyData::SafeDownCast(output);
   if (polydata) {
@@ -772,7 +772,7 @@ void PointCorrespondenceDistance
     vtkPointData *pd = target->PointSet()->GetPointData();
     for (int i = 0; i < pd->GetNumberOfArrays(); ++i) {
       vtkDataArray *data = pd->GetArray(i);
-      copy = vtkSmartPointer<vtkDataArray>::NewInstance(data);
+      copy.TakeReference(data->NewInstance());
       copy->SetName(data->GetName());
       copy->SetNumberOfComponents(data->GetNumberOfComponents());
       copy->SetNumberOfTuples(n);


### PR DESCRIPTION
- Replace boolean `ascii` and `compress` arguments of point set I/O functions by new `FileOption` argument.
- Fix segfault sometimes encountered in surface remeshing filter.
- Fix memory leak in `MeshFilter::Initialize` caused by incorrect new VTK instance creation.
- Use NN interpolation for all point data arrays with name matching `[lL]abel' during remeshing.
- Use latest Deformable and Mapping modules with some further changes.
- ... (i.e., see commit messages below)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/339)
<!-- Reviewable:end -->
