### PR TITLE
fix: Endless loop during initialization of sparse matrix from tuples [Numerics]

### DIFF
--- a/Modules/Numerics/include/mirtk/SparseMatrix.h
+++ b/Modules/Numerics/include/mirtk/SparseMatrix.h
@@ -493,7 +493,9 @@ void GenericSparseMatrix<TEntry>::CheckEntries(Entries &entries) const
   // Sum up duplicate entries
   for (typename Entries::iterator i = entries.begin(); i != entries.end(); ++i) {
     typename Entries::iterator j = i + 1;
-    while (j != entries.end() && i->first == j->first) i->second += j->second;
+    while (j != entries.end() && i->first == j->first) {
+      i->second += j->second, ++j;
+    }
     entries.erase(i + 1, i + std::distance(i, j));
   }
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/342)
<!-- Reviewable:end -->
