### PR TITLE
enh: Fast approximate collision test [PointSet]

### DIFF
--- a/Modules/PointSet/include/mirtk/SurfaceCollisions.h
+++ b/Modules/PointSet/include/mirtk/SurfaceCollisions.h
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2016 Imperial College London
+ * Copyright 2013-2016 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -209,7 +209,7 @@ private:
   /// triangles is being determined (cf. CollisionType::BackfaceCollision).
   mirtkPublicAttributeMacro(double, MinBackfaceDistance);
 
-  /// Maximum angle between face normal and center to closest point vector
+  /// Maximum angle between face normal and center to center point vector
   /// required for collision to be detected
   mirtkPublicAttributeMacro(double, MaxAngle);
 
@@ -224,6 +224,9 @@ private:
 
   /// Whether to detect collisions with the back of a face
   mirtkPublicAttributeMacro(bool, BackfaceCollisionTest);
+
+  /// Whether to use fast, approximate collision test
+  mirtkPublicAttributeMacro(bool, FastCollisionTest);
 
   /// Whether to store detailed information about found self-intersections
   mirtkPublicAttributeMacro(bool, StoreIntersectionDetails);
@@ -324,6 +327,9 @@ public:
 
   /// Enable/disable near miss collision test for back-facing triangles
   mirtkOnOffMacro(BackfaceCollisionTest);
+
+  /// Enable/disable fast, approximate collision test
+  mirtkOnOffMacro(FastCollisionTest);
 
   /// Enable/disable storage of details about found intersections
   mirtkOnOffMacro(StoreIntersectionDetails);

--- a/Modules/PointSet/include/mirtk/Triangle.h
+++ b/Modules/PointSet/include/mirtk/Triangle.h
@@ -195,6 +195,11 @@ public:
                                        const double a2[3], const double b2[3], const double c2[3],
                                        double *p1, double *p2);
 
+  /// Compute distance between closest corner points of two triangles
+  static double DistanceBetweenCorners(const double a1[3], const double b1[3], const double c1[3],
+                                       const double a2[3], const double b2[3], const double c2[3],
+                                       double *p1, double *p2);
+
   /// Compute distance between closest points of two triangles
   static double DistanceBetweenTriangles(const double a1[3], const double b1[3], const double c1[3], const double n1[3],
                                          const double a2[3], const double b2[3], const double c2[3], const double n2[3],
@@ -423,6 +428,45 @@ inline double Triangle
   Center(a1, b1, c1, p1);
   Center(a2, b2, c2, p2);
   return sqrt(vtkMath::Distance2BetweenPoints(p1, p2));
+}
+
+// -----------------------------------------------------------------------------
+/// Compute distance between two triangles
+inline double Triangle
+::DistanceBetweenCorners(const double a1[3], const double b1[3], const double c1[3],
+                         const double a2[3], const double b2[3], const double c2[3],
+                         double *p1, double *p2)
+{
+  double d, dmin = vtkMath::Distance2BetweenPoints(a1, a2);
+  const double *x1 = a1, *x2 = a2;
+
+  d = vtkMath::Distance2BetweenPoints(a1, b2);
+  if (d < dmin) dmin = d, x1 = a1, x2 = b2;
+
+  d = vtkMath::Distance2BetweenPoints(a1, c2);
+  if (d < dmin) dmin = d, x1 = a1, x2 = c2;
+
+  d = vtkMath::Distance2BetweenPoints(b1, a2);
+  if (d < dmin) dmin = d, x1 = b1, x2 = a2;
+
+  d = vtkMath::Distance2BetweenPoints(b1, b2);
+  if (d < dmin) dmin = d, x1 = b1, x2 = b2;
+
+  d = vtkMath::Distance2BetweenPoints(b1, c2);
+  if (d < dmin) dmin = d, x1 = b1, x2 = c2;
+
+  d = vtkMath::Distance2BetweenPoints(c1, a2);
+  if (d < dmin) dmin = d, x1 = c1, x2 = a2;
+
+  d = vtkMath::Distance2BetweenPoints(c1, b2);
+  if (d < dmin) dmin = d, x1 = c1, x2 = b2;
+
+  d = vtkMath::Distance2BetweenPoints(c1, c2);
+  if (d < dmin) dmin = d, x1 = c1, x2 = c2;
+
+  if (p1) memcpy(p1, x1, 3 * sizeof(double));
+  if (p2) memcpy(p2, x2, 3 * sizeof(double));
+  return sqrt(dmin);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/PointSet/src/MeshFilter.cc
+++ b/Modules/PointSet/src/MeshFilter.cc
@@ -1,5 +1,5 @@
 /*
- * Medical Image Registration ToolKit (MMIRTK)
+ * Medical Image Registration ToolKit (MIRTK)
  *
  * Copyright 2013-2015 Imperial College London
  * Copyright 2013-2015 Andreas Schuh

--- a/Modules/PointSet/src/SurfaceCollisions.cc
+++ b/Modules/PointSet/src/SurfaceCollisions.cc
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2016 Imperial College London
+ * Copyright 2013-2016 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -150,7 +150,7 @@ public:
     const double R            = _MaxRadius + 1.1 * min_distance;
 
     double         tri1[3][3], tri2[3][3], tri1_2D[3][2], tri2_2D[3][2];
-    double         n1[3], n2[3], p1[3], p2[3], r1, c1[3], v[3], search_radius, dot;
+    double         n1[3], n2[3], p1[3], p2[3], r1, c1[3], d[3], search_radius, dot;
     int            tri12[3], i1, i2, shared_vertex1, shared_vertex2, coplanar, s1, s2;
     vtkIdType      npts, *pts1, *pts2, *cells, cellId1, cellId2;
     unsigned short ncells;
@@ -317,16 +317,26 @@ public:
         // If self-intersection check of non-adjacent triangles disabled or negative,
         // check for near miss collision if minimum distance set
         else if (coll_test) {
-          Triangle::Normal(tri2[0], tri2[1], tri2[2], n2);
-          collision._Distance = Triangle::DistanceBetweenTriangles(
-                                    tri1[0], tri1[1], tri1[2], n1,
-                                    tri2[0], tri2[1], tri2[2], n2,
-                                    collision._Point1, collision._Point2);
+          if (_Filter->FastCollisionTest()) {
+            collision._Distance = Triangle::DistanceBetweenCenters(
+                                      tri1[0], tri1[1], tri1[2],
+                                      tri2[0], tri2[1], tri2[2],
+                                      collision._Point1, collision._Point2);
+          } else {
+            Triangle::Normal(tri2[0], tri2[1], tri2[2], n2);
+            collision._Distance = Triangle::DistanceBetweenTriangles(
+                                      tri1[0], tri1[1], tri1[2], n1,
+                                      tri2[0], tri2[1], tri2[2], n2,
+                                      collision._Point1, collision._Point2);
+          }
           if (collision._Distance < min_distance) {
-            vtkMath::Subtract(collision._Point2, c1, v);
-            vtkMath::Normalize(v);
-            dot = vtkMath::Dot(v, n1);
-            if (fabs(dot) >= _MinAngleCos) {
+            if (collision._Distance > 0.) {
+              vtkMath::Subtract(collision._Point2, collision._Point1, d);
+              dot = vtkMath::Dot(d, n1) / vtkMath::Norm(d);
+            } else {
+              dot = 0.;
+            }
+            if (abs(dot) >= _MinAngleCos) {
               if (dot < .0) {
                 if (_Filter->BackfaceCollisionTest() && collision._Distance < _MinBackfaceDistance) {
                   collision._Type = CollisionType::BackfaceCollision;
@@ -366,7 +376,8 @@ public:
   /// Find collision and self-intersections
   static void Run(SurfaceCollisions  *filter,
                   IntersectionsArray *intersections,
-                  CollisionsArray    *collisions)
+                  CollisionsArray    *collisions,
+                  bool                fast = false)
   {
     vtkDataArray *radius = filter->GetRadiusArray();
     vtkSmartPointer<vtkAbstractPointLocator> locator;
@@ -411,6 +422,7 @@ void SurfaceCollisions::CopyAttributes(const SurfaceCollisions &other)
   _NonAdjacentIntersectionTest = other._NonAdjacentIntersectionTest;
   _FrontfaceCollisionTest      = other._FrontfaceCollisionTest;
   _BackfaceCollisionTest       = other._BackfaceCollisionTest;
+  _FastCollisionTest           = other._FastCollisionTest;
   _StoreIntersectionDetails    = other._StoreIntersectionDetails;
   _StoreCollisionDetails       = other._StoreCollisionDetails;
   _Intersections               = other._Intersections;
@@ -430,6 +442,7 @@ SurfaceCollisions::SurfaceCollisions()
   _NonAdjacentIntersectionTest(false),
   _FrontfaceCollisionTest(false),
   _BackfaceCollisionTest(false),
+  _FastCollisionTest(false),
   _StoreIntersectionDetails(true),
   _StoreCollisionDetails(true)
 {

--- a/Modules/PointSet/src/SurfaceCollisions.cc
+++ b/Modules/PointSet/src/SurfaceCollisions.cc
@@ -1,5 +1,5 @@
 /*
- * Medical Image Registration ToolKit (MMIRTK)
+ * Medical Image Registration ToolKit (MIRTK)
  *
  * Copyright 2013-2015 Imperial College London
  * Copyright 2013-2015 Andreas Schuh

--- a/Modules/PointSet/src/SurfaceFilter.cc
+++ b/Modules/PointSet/src/SurfaceFilter.cc
@@ -1,5 +1,5 @@
 /*
- * Medical Image Registration ToolKit (MMIRTK)
+ * Medical Image Registration ToolKit (MIRTK)
  *
  * Copyright 2016 Imperial College London
  * Copyright 2016 Andreas Schuh


### PR DESCRIPTION
- Add fast collision test based on distance of triangle centers only.
- Use angle between normal and difference vector of closest points / centers to detect false collisions. Previously, the vector from the center to the closest other point was used.
- Contains commit to just replace 'MMIRTK' by 'MIRTK' in source file preamble.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/346)
<!-- Reviewable:end -->
