### PR TITLE
remeshing-inline-functions

### DIFF
--- a/Modules/PointSet/include/mirtk/SurfaceRemeshing.h
+++ b/Modules/PointSet/include/mirtk/SurfaceRemeshing.h
@@ -343,19 +343,19 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 // -----------------------------------------------------------------------------
-int SurfaceRemeshing::NumberOfMeltings() const
+inline int SurfaceRemeshing::NumberOfMeltings() const
 {
   return _NumberOfMeltedNodes + _NumberOfMeltedEdges + _NumberOfMeltedCells;
 }
 
 // -----------------------------------------------------------------------------
-int SurfaceRemeshing::NumberOfSubdivisions() const
+inline int SurfaceRemeshing::NumberOfSubdivisions() const
 {
   return _NumberOfBisections + _NumberOfTrisections + _NumberOfQuadsections;
 }
 
 // -----------------------------------------------------------------------------
-int SurfaceRemeshing::NumberOfChanges() const
+inline int SurfaceRemeshing::NumberOfChanges() const
 {
   return NumberOfMeltings() + NumberOfInversions() + NumberOfSubdivisions();
 }


### PR DESCRIPTION
These functions raise a "multiple definitions" error when MIRTK is included in an external library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/353)
<!-- Reviewable:end -->
