### PR TITLE
enh: Add Throw helper functions

### DIFF
--- a/Modules/Common/include/mirtk/Common.h
+++ b/Modules/Common/include/mirtk/Common.h
@@ -25,6 +25,7 @@
 #include "mirtk/CommonConfig.h"
 
 // Standard containers
+#include "mirtk/Exception.h"
 #include "mirtk/Pair.h"
 #include "mirtk/Array.h"
 #include "mirtk/ArrayHeap.h"

--- a/Modules/Common/include/mirtk/Exception.h
+++ b/Modules/Common/include/mirtk/Exception.h
@@ -1,0 +1,78 @@
+/*
+ * Medical Image Registration ToolKit (MIRTK)
+ *
+ * Copyright 2016 Imperial College London
+ * Copyright 2016 Andreas Schuh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MIRTK_Exception_H
+#define MIRTK_Exception_H
+
+#include "mirtk/String.h"
+#include "mirtk/Stream.h"
+
+
+namespace mirtk {
+
+
+/// Enumeration of error types
+enum ErrorType
+{
+  ERR_Unknown,
+  ERR_LogicError,
+  ERR_InvalidArgument,
+  ERR_RuntimeError,
+  ERR_IOError
+};
+
+/// Convert error type to string
+template <typename T>
+string ToString(const ErrorType &value, int w, char c, bool left)
+{
+  const char *str;
+  switch (value) {
+    case ERR_Unknown:         { str = "UnknownError";    } break;
+    case ERR_LogicError:      { str = "LogicError";      } break;
+    case ERR_InvalidArgument: { str = "InvalidArgument"; } break;
+    case ERR_RuntimeError:    { str = "RuntimeError";    } break;
+    case ERR_IOError:         { str = "IOError";         } break;
+  }
+  return ToString(str, w, c, left);
+}
+
+/// Raise error in function
+///
+/// The current implementation prints the error message to STDERR and terminates
+/// the program with exit code 1. In future releases, when all library code has
+/// been rewritten to use this function, a suitable runtime exception may be
+/// thrown instead.
+///
+/// \param[in] err  Type of error/exception.
+/// \param[in] func Name of function which is throwing the error (i.e., __func__).
+/// \param[in] args Error message. The given arguments are converted to strings
+///                 using the ToString template function. These strings are then
+///                 concatenated to produce the complete error message.
+template <typename... Args>
+void Throw(ErrorType err, const char *func, Args... args)
+{
+  Print(cerr, err, ": ", func, ": ", args...);
+  cerr << endl;
+  exit(1);
+}
+
+
+} // namespace mirtk
+
+#endif // MIRTK_Exception_H

--- a/Modules/Common/include/mirtk/String.h
+++ b/Modules/Common/include/mirtk/String.h
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2016 Imperial College London
+ * Copyright 2013-2016 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -206,7 +206,7 @@ template <class TValue>
 inline void PrintParameter(std::ostream &os, const char *name, const TValue &value)
 {
   const std::streamsize w = os.width(40);
-  os << std::left << name << std::setw(0) << " = " << value << std::endl;
+  os << std::left << name << std::setw(0) << " = " << ToString(value) << std::endl;
   os.width(w);
 }
 
@@ -215,6 +215,23 @@ template <class TValue>
 inline void PrintParameter(std::ostream &os, const std::string &name, const TValue &value)
 {
   PrintParameter(os, name.c_str(), value);
+}
+
+/// Print single argument to output stream
+template <typename T>
+std::ostream &Print(std::ostream &os, T value)
+{
+  os << ToString(value);
+  return os;
+}
+
+/// Print any number of arguments to output stream, i.e.,
+/// concatenating the string representations of the arguments
+template <typename T, typename... Args>
+std::ostream &Print(std::ostream &os, T value, Args... args)
+{
+  os << ToString(value);
+  return Print(os, args...);
 }
 
 /// Convert string to lowercase letters

--- a/Modules/Common/src/CMakeLists.txt
+++ b/Modules/Common/src/CMakeLists.txt
@@ -44,6 +44,7 @@ set(HEADERS
   EnergyMeasure.h
   Event.h
   EventDelegate.h
+  Exception.h
   FastDelegate.h
   Indent.h
   List.h

--- a/Modules/Common/src/Cifstream.cc
+++ b/Modules/Common/src/Cifstream.cc
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2016 Imperial College London
+ * Copyright 2013-2016 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,8 +62,7 @@ void Cifstream::Open(const char *fname)
     _File = fopen(fname, "rb");
   #endif
   if (_File == nullptr) {
-    cerr << "Cifstream::Open: Cannot open file " << fname << endl;
-    exit(1);
+    Throw(ERR_IOError, __func__, "Failed to open file ", fname);
   }
 }
 

--- a/Modules/Common/src/Cofstream.cc
+++ b/Modules/Common/src/Cofstream.cc
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2008-2015 Imperial College London
- * Copyright 2008-2015 Daniel Rueckert, Julia Schnabel
+ * Copyright 2008-2016 Imperial College London
+ * Copyright 2008-2016 Daniel Rueckert, Julia Schnabel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,21 +56,18 @@ void Cofstream::Open(const char *fname)
   Close();
   size_t len = strlen(fname);
   if (len == 0) {
-    cerr << "Cofstream::Open: Filename is empty!" << endl;
-    exit(1);
+    Throw(ERR_InvalidArgument, __func__, "Filename is empty");
   }
   if (len > 3 && (strncmp(fname + len-3, ".gz", 3) == 0 || strncmp(fname + len-3, ".GZ", 3) == 0)) {
     #if MIRTK_Common_WITH_ZLIB
       gzFile fp = gzopen(fname, "wb");
       if (fp == nullptr) {
-        cerr << "Cofstream::Open: Cannot open file " << fname << endl;
-        exit(1);
+        Throw(ERR_IOError, __func__, "Failed to open file ", fname);
       }
       _ZFile = fp;
       _Compressed = true;
     #else // MIRTK_Common_WITH_ZLIB
-      cerr << "Cofstream::Open: Cannot write compressed file when Common module not built WITH_ZLIB" << endl;
-      exit(1);
+      Throw(ERR_IOError, __func__, "Cannot write compressed file when Common module not built WITH_ZLIB");
     #endif // MIRTK_Common_WITH_ZLIB
   } else {
     #ifdef WINDOWS
@@ -80,8 +77,7 @@ void Cofstream::Open(const char *fname)
       _File = fopen(fname, "wb");
     #endif
     if (_File == nullptr) {
-      cerr << "Cofstream::Open: Cannot open file " << fname << endl;
-      exit(1);
+      Throw(ERR_IOError, __func__, "Failed to open file ", fname);
     }
     _Compressed = false;
   }
@@ -134,9 +130,8 @@ bool Cofstream::Write(const char *data, long offset, long length)
       gzFile fp = reinterpret_cast<gzFile>(_ZFile);
       if (offset != -1) {
         if (gztell(fp) > offset) {
-          cerr << "Error: Writing compressed files only supports forward seek (pos="
-               << gztell(fp) << ", offset=" << offset << ")" << endl;
-          exit(1);
+          Throw(ERR_IOError, __func__, "Writing compressed files only supports"
+                " forward seek (pos=", gztell(fp), ", offset=", offset, ")");
         }
         gzseek(fp, offset, SEEK_SET);
       }


### PR DESCRIPTION
These functions should be used instead of direct output to `cerr` + `exit` such that in later releases we may switch to throwing actual C++ exceptions.