### PR TITLE
fix: Output precision for point attributes to CSV export

### DIFF
--- a/Modules/IO/include/mirtk/PointSetIO.h
+++ b/Modules/IO/include/mirtk/PointSetIO.h
@@ -378,7 +378,7 @@ vtkSmartPointer<vtkPolyData> ReadGIFTI(const char  *fname,
                                        vtkPolyData *surface = nullptr,
                                        bool         errmsg  = false);
 
-/// Write polygonal dataset to GIFTI ([.surf].gii) file
+/// Write polygonal dataset to GIFTI (.gii) file
 ///
 /// @param[in] fname    File name. Based on the extension either all or only
 ///                     certain data arrays of the polygonal dataset are saved.

--- a/Modules/IO/src/PointSetIO.cc
+++ b/Modules/IO/src/PointSetIO.cc
@@ -1507,15 +1507,19 @@ vtkSmartPointer<vtkPolyData> ReadGIFTI(const char *fname, vtkPolyData *surface, 
   const vtkIdType npoints = points->GetNumberOfPoints();
 
   // Check topology information
-  polys->InitTraversal();
-  vtkIdType npts, *pts;
-  while (polys->GetNextCell(npts, pts) != 0) {
-    if (npts != 3 || pts[0] >= npoints || pts[1] >= npoints || pts[2] >= npoints) {
-      if (errmsg) {
-        cerr << "Error: GIFTI topology array has invalid point index!" << endl;
+  if (polys) {
+    polys->InitTraversal();
+    vtkIdType npts, *pts;
+    while (polys->GetNextCell(npts, pts) != 0) {
+      if (npts != 3 || pts[0] >= npoints || pts[1] >= npoints || pts[2] >= npoints) {
+        if (errmsg) {
+          cerr << "Error: GIFTI topology array has invalid point index!" << endl;
+        }
+        return polydata;
       }
-      return polydata;
     }
+  } else if (surface) {
+    polys = surface->GetPolys();
   }
 
   // Get node indices array

--- a/Modules/IO/src/PointSetIO.cc
+++ b/Modules/IO/src/PointSetIO.cc
@@ -305,9 +305,9 @@ bool WritePointSetTable(const char *fname, vtkPointSet *pointset, bool coords, c
     if (arr->GetName() != nullptr) {
       arrays.push_back(arr);
       switch (arr->GetDataType()) {
-        case VTK_FLOAT:  digits.push_back(numeric_limits<float >::max_digits10);
-        case VTK_DOUBLE: digits.push_back(numeric_limits<double>::max_digits10);
-        default:         digits.push_back(0);
+        case VTK_FLOAT:  { digits.push_back(numeric_limits<float >::max_digits10); } break;
+        case VTK_DOUBLE: { digits.push_back(numeric_limits<double>::max_digits10); } break;
+        default:         { digits.push_back(0); } break;
       }
     }
   }
@@ -331,14 +331,12 @@ bool WritePointSetTable(const char *fname, vtkPointSet *pointset, bool coords, c
     vtkDataArray *arr = arrays[i];
     for (int j = 0; j < arr->GetNumberOfComponents(); ++j) {
       if (++col > 1) ofs << sep;
-      const char *name = arr->GetComponentName(j);
-      if (name != nullptr) {
-        ofs << name;
-      } else {
-        ofs << arr->GetName();
-        if (arr->GetNumberOfComponents() > 1) {
-          ofs << '[' << j << ']';
-        }
+      ofs << arr->GetName();
+      const char *comp = arr->GetComponentName(j);
+      if (comp != nullptr) {
+        ofs << '.' << comp;
+      } else if (arr->GetNumberOfComponents() > 1) {
+        ofs << '.' << (j+1);
       }
     }
   }


### PR DESCRIPTION
- Fix up for PR #355.
- Also contains potential segfault fix of `ReadGIFTI`, e.g., when reading `.shape.gii` files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/358)
<!-- Reviewable:end -->
