### PR TITLE
fix: Positional argument parsing in offset-surface [Applications]

### DIFF
--- a/Applications/src/offset-surface.cc
+++ b/Applications/src/offset-surface.cc
@@ -114,7 +114,7 @@ int main(int argc, char **argv)
     if (!FromString(POSARG(3), offset)) {
       FatalError("Invalid <offset> argument, must be floating point number!");
     }
-  } else {
+  } else if (NUM_POSARGS > 3) {
     FatalError("Too many positional arguments!");
   }
 


### PR DESCRIPTION
When not exactly three positional arguments where given, a usage error was shown even though the third positional argument is optional. It is recommended to use the `-offset` option instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/359)
<!-- Reviewable:end -->
