### PR TITLE
enh: Rename NewVTKDataArray to NewVtkDataArray [Common]

### DIFF
--- a/Modules/Common/include/mirtk/Vtk.h
+++ b/Modules/Common/include/mirtk/Vtk.h
@@ -81,6 +81,9 @@ namespace mirtk {
 ///                 or double is returned.
 ///
 /// \returns New VTK data array instance.
+vtkSmartPointer<vtkDataArray> NewVtkDataArray(int type = VTK_VOID);
+
+/// \deprecated Use NewVtkDataArray instead
 vtkSmartPointer<vtkDataArray> NewVTKDataArray(int type = VTK_VOID);
 
 // -----------------------------------------------------------------------------

--- a/Modules/Common/src/Vtk.cc
+++ b/Modules/Common/src/Vtk.cc
@@ -37,7 +37,7 @@ namespace mirtk {
 
 
 // -----------------------------------------------------------------------------
-vtkSmartPointer<vtkDataArray> NewVTKDataArray(int vtkType)
+vtkSmartPointer<vtkDataArray> NewVtkDataArray(int vtkType)
 {
   switch (vtkType) {
     case VTK_VOID: {
@@ -60,6 +60,12 @@ vtkSmartPointer<vtkDataArray> NewVTKDataArray(int vtkType)
       cerr << "Invalid VTK data type: " << vtkType << endl;
       exit(1);
   }
+}
+
+// -----------------------------------------------------------------------------
+vtkSmartPointer<vtkDataArray> NewVTKDataArray(int vtkType)
+{
+  return NewVtkDataArray(vtkType);
 }
 
 


### PR DESCRIPTION
Just a minor function name change to be consistent with other functions such as `VtkDataTypeString` and `VtkAttributeTypeString`.

Keep deprecated function for grace period of transition to [future branch](https://github.com/schuhschuh/MIRTK/tree/future), where all uses of `NewVTKDataArray` were already replaced by `NewVtkDataArray`. This change allows selective merging of changes with the new function name in mind into the current master branch without breaking the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/365)
<!-- Reviewable:end -->
