### PR TITLE
enh: Add mirtk.run function to Python module [Applications]

### DIFF
--- a/Applications/lib/python/mirtk/__init__.py.in
+++ b/Applications/lib/python/mirtk/__init__.py.in
@@ -49,4 +49,4 @@ del _putenvs
 # Import main functions
 # ==============================================================================
 
-from mirtk.subprocess import path, call, check_call, check_output
+from mirtk.subprocess import path, run, call, check_call, check_output

--- a/Applications/lib/python/mirtk/subprocess.py.in
+++ b/Applications/lib/python/mirtk/subprocess.py.in
@@ -27,7 +27,10 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 import sys
+import shlex
 import subprocess
+
+from collections import OrderedDict
 
 # ============================================================================
 # configuration
@@ -48,8 +51,8 @@ else:                              libexec_ext = ['']
 # ----------------------------------------------------------------------------
 def path(argv, quiet=False):
     """Get full path of MIRTK command executable."""
-    if isinstance(argv, str): command = argv
-    else:                     command = argv[0]
+    if isinstance(argv, list): command = argv[0]
+    else:                      command = argv
     if   command == 'calculate':          command = 'calculate-element-wise'
     elif command == 'convert-dof2csv':    command = 'convert-dof'
     elif command == 'convert-dof2velo':   command = 'convert-dof'
@@ -78,6 +81,9 @@ def path(argv, quiet=False):
 # ----------------------------------------------------------------------------
 def _call(argv, verbose=0, execfunc=subprocess.call):
     """Execute MIRTK command."""
+    if not isinstance(argv, list):
+        argv = shlex.split(argv)
+    argv = [str(arg) for arg in argv]
     if argv[0] == 'convert-dof2csv':
         new_argv = ['convert-dof']
         out_fmt  = 'star_ccm_table'
@@ -86,7 +92,7 @@ def _call(argv, verbose=0, execfunc=subprocess.call):
             else: new_argv.append(arg)
         new_argv.extend(['-output-format', out_fmt])
         argv = new_argv
-    argv[0] = path(argv)
+    argv[0] = path(argv[0])
     if not argv[0]: return 1
     if verbose > 0:
         args = []
@@ -104,9 +110,27 @@ def call(argv, verbose=0):
 # ----------------------------------------------------------------------------
 def check_call(argv, verbose=0):
     """Execute MIRTK command and throw exception on error."""
-    return _call(argv, verbose=verbose, execfunc=subprocess.check_call)
+    _call(argv, verbose=verbose, execfunc=subprocess.check_call)
 
 # ----------------------------------------------------------------------------
 def check_output(argv, verbose=0):
     """Execute MIRTK command and return its output."""
     return _call(argv, verbose=verbose, execfunc=subprocess.check_output)
+
+# ----------------------------------------------------------------------------
+def run(cmd, args=[], opts={}):
+    """Execute MIRTK command and throw exception on error."""
+    argv = [cmd]
+    argv.extend(args)
+    if isinstance(opts, list):
+        opts = OrderedDict(opt if isinstance(opt, (tuple, list)) else (opt, None) for opt in opts)
+    for opt, arg in opts.items():
+        if not opt.startswith('-'):
+            opt = '-' + opt
+        argv.append(opt)
+        if not arg is None:
+            if isinstance(arg, list):
+                argv.extend(arg)
+            else:
+                argv.append(arg)
+    check_call(argv)


### PR DESCRIPTION
Convenience function that allows the use of Python dictionaries or ordered lists of tuples for command options instead. It also allows non-string arguments in the `argv` list of all call functions. Moreover, a single string is split into a list of arguments using `shlex.split`.

Example:
```python
import mirtk
mirtk.run('calculate-distance-map', args=[input_name, output_name],
          opts={'distance': 'euclidean', '3D': None, 'isotropic': None})
mirtk.run('calculate-distance-map', args=[input_name, output_name],
          opts=[('distance', 'euclidean'), '3D', 'isotropic'])
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/366)
<!-- Reviewable:end -->
