### PR TITLE
fix: ToString template specialization for ErrorType [Common]

### DIFF
--- a/Modules/Common/include/mirtk/Exception.h
+++ b/Modules/Common/include/mirtk/Exception.h
@@ -38,8 +38,8 @@ enum ErrorType
 };
 
 /// Convert error type to string
-template <typename T>
-string ToString(const ErrorType &value, int w, char c, bool left)
+template <>
+inline string ToString(const ErrorType &value, int w, char c, bool left)
 {
   const char *str;
   switch (value) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/383)
<!-- Reviewable:end -->
