### PR TITLE
enh: Remesh surface with boundary edges [PointSet]

### DIFF
--- a/Modules/PointSet/include/mirtk/PointSetUtils.h
+++ b/Modules/PointSet/include/mirtk/PointSetUtils.h
@@ -50,6 +50,8 @@ class Vector;
 
 template <typename> struct Vector3D;
 
+/// List of pairs of edge end point IDs
+typedef List<Pair<int, int>> EdgeList;
 
 // =============================================================================
 // VTK / MIRTK type conversion
@@ -250,8 +252,24 @@ bool IsTetrahedralMesh(vtkDataSet *);
 /// Get IDs of end points of boundary edges
 UnorderedSet<int> BoundaryPoints(vtkDataSet *, const EdgeTable * = nullptr);
 
-/// Get list of boundary edges
-List<Pair<int, int> > BoundaryEdges(vtkDataSet *, const EdgeTable &);
+/// Get list of all boundary edges
+EdgeList BoundaryEdges(vtkDataSet *, const EdgeTable &);
+
+/// Get list of edges with given end point
+///
+/// \param[in] edges List of edges.
+/// \param[in] ptId  Edge end point.
+///
+/// \returns List of edges, where ptId is always the first entry.
+EdgeList GetPointEdges(const EdgeList &edges, int ptId);
+
+/// Get list of edges with given end point and remove them from input list
+///
+/// \param[in] edges List of edges.
+/// \param[in] ptId  Edge end point.
+///
+/// \returns List of edges, where ptId is always the first entry.
+EdgeList PopPointEdges(EdgeList &edges, int ptId);
 
 /// Get connected boundary segments as (closed) line strips
 Array<Array<int> > BoundarySegments(vtkDataSet *, const EdgeTable * = nullptr);

--- a/Modules/PointSet/include/mirtk/SurfaceBoundary.h
+++ b/Modules/PointSet/include/mirtk/SurfaceBoundary.h
@@ -233,6 +233,11 @@ public:
   /// \param[in] i Boundary point index.
   void DeselectPoint(int i);
 
+  // ---------------------------------------------------------------------------
+  // Debug
+
+  /// Write boundary lines to polygonal data set file
+  bool Write(const char *) const;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/Modules/PointSet/include/mirtk/SurfaceRemeshing.h
+++ b/Modules/PointSet/include/mirtk/SurfaceRemeshing.h
@@ -148,6 +148,9 @@ protected:
   /// Invert edge of two triangles when it increases the minimum height
   mirtkPublicAttributeMacro(bool, InvertTrianglesToIncreaseMinHeight);
 
+  /// Whether to allow bisection of boundary edges
+  mirtkPublicAttributeMacro(bool, BisectBoundaryEdges);
+
   /// Number of melted nodes with connectivity 3
   mirtkReadOnlyAttributeMacro(int, NumberOfMeltedNodes);
 
@@ -232,6 +235,12 @@ private:
 
   /// Get neighboring triangle sharing an edge with specified triangle
   vtkIdType GetCellEdgeNeighbor(vtkIdType, vtkIdType, vtkIdType) const;
+
+  /// Check if point is on surface boundary
+  bool IsBoundaryPoint(vtkIdType) const;
+
+  /// Check if edge is on surface boundary
+  bool IsBoundaryEdge(vtkIdType, vtkIdType) const;
 
   /// Get other vertices of cell edge neighbors
   void GetCellPointNeighbors(vtkIdType, vtkIdType, vtkIdList *) const;
@@ -335,6 +344,9 @@ public:
 
   /// Enable/disable inversion of triangles when it increases minimum height
   mirtkOnOffMacro(InvertTrianglesToIncreaseMinHeight);
+
+  /// Enable/disable bisection of boundary edges
+  mirtkOnOffMacro(BisectBoundaryEdges);
 
 };
 

--- a/Modules/PointSet/src/PointSetUtils.cc
+++ b/Modules/PointSet/src/PointSetUtils.cc
@@ -369,9 +369,9 @@ UnorderedSet<int> BoundaryPoints(vtkDataSet *dataset, const EdgeTable *edgeTable
 }
 
 // -----------------------------------------------------------------------------
-List<Pair<int, int> > BoundaryEdges(vtkDataSet *dataset, const EdgeTable &edgeTable)
+EdgeList BoundaryEdges(vtkDataSet *dataset, const EdgeTable &edgeTable)
 {
-  List<Pair<int, int> > boundaryEdges;
+  EdgeList boundaryEdges;
   vtkSmartPointer<vtkIdList> cellIds1 = vtkSmartPointer<vtkIdList>::New();
   vtkSmartPointer<vtkIdList> cellIds2 = vtkSmartPointer<vtkIdList>::New();
   vtkIdType ptId1, ptId2;
@@ -388,6 +388,36 @@ List<Pair<int, int> > BoundaryEdges(vtkDataSet *dataset, const EdgeTable &edgeTa
 }
 
 // -----------------------------------------------------------------------------
+EdgeList GetPointEdges(const EdgeList &edges, int ptId)
+{
+  EdgeList result;
+  for (const auto &edge : edges) {
+    if (edge.first == ptId) {
+      result.push_back(edge);
+    } else if (edge.second == ptId) {
+      result.push_back(MakePair(edge.second, edge.first));
+    }
+  }
+  return result;
+}
+
+// -----------------------------------------------------------------------------
+EdgeList PopPointEdges(EdgeList &edges, int ptId)
+{
+  EdgeList result;
+  for (auto edge = edges.begin(); edge != edges.end(); ++edge) {
+    if (edge->first == ptId) {
+      result.push_back(*edge);
+      edge = edges.erase(edge);
+    } else if (edge->second == ptId) {
+      result.push_back(MakePair(edge->second, edge->first));
+      edge = edges.erase(edge);
+    }
+  }
+  return result;
+}
+
+// -----------------------------------------------------------------------------
 Array<Array<int> > BoundarySegments(vtkDataSet *dataset, const EdgeTable *edgeTable)
 {
   Array<Array<int> > boundaries;
@@ -398,7 +428,7 @@ Array<Array<int> > BoundarySegments(vtkDataSet *dataset, const EdgeTable *edgeTa
   }
   int ptId1, ptId2;
   UnorderedSet<int> boundaryPtIds;
-  List<Pair<int, int> > boundaryEdges = BoundaryEdges(dataset, *edgeTable);
+  EdgeList boundaryEdges = BoundaryEdges(dataset, *edgeTable);
   for (auto edge = boundaryEdges.begin(); edge != boundaryEdges.end(); ++edge) {
     boundaryPtIds.insert(edge->first);
     boundaryPtIds.insert(edge->second);


### PR DESCRIPTION
Modifies `SurfaceRemeshing` filter to preserve boundary edges of a non-closed surface mesh.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/384)
<!-- Reviewable:end -->
