### PR TITLE
enh: Miscellaneous minor changes

### DIFF
--- a/Modules/Image/src/DataOp.cc
+++ b/Modules/Image/src/DataOp.cc
@@ -78,7 +78,7 @@ int Read(const char *name, double *&data, int *dtype, ImageAttributes *attr)
         reader->Update();
         vtkDataSet *output = reader->GetOutput();
         if (output) {
-          if (scalar_name) {
+          if (scalar_name && scalar_name[0] != '\0') {
             scalars = output->GetPointData()->GetArray(scalar_name);
           } else {
             scalars = output->GetPointData()->GetScalars();
@@ -92,7 +92,7 @@ int Read(const char *name, double *&data, int *dtype, ImageAttributes *attr)
         reader->Update();
         vtkDataSet *output = vtkDataSet::SafeDownCast(reader->GetOutput());
         if (output) {
-          if (scalar_name) {
+          if (scalar_name && scalar_name[0] != '\0') {
             scalars = output->GetPointData()->GetArray(scalar_name);
           } else {
             scalars = output->GetPointData()->GetScalars();
@@ -111,7 +111,7 @@ int Read(const char *name, double *&data, int *dtype, ImageAttributes *attr)
         cerr << "VTK dataset has empty scalar point data!" << endl;
         exit(1);
       }
-      data = new double[n];
+      data = Allocate<double>(n);
       double *p = data;
       for (vtkIdType i = 0; i < scalars->GetNumberOfTuples(); ++i) {
         for (int j = 0; j < scalars->GetNumberOfComponents(); ++j, ++p) {
@@ -130,7 +130,7 @@ int Read(const char *name, double *&data, int *dtype, ImageAttributes *attr)
       if (attr) *attr = image->Attributes();
       if (dtype) *dtype = image->GetDataType();
       n = image->NumberOfVoxels();
-      data = new double[n];
+      data = Allocate<double>(n);
       for (int i = 0; i < n; ++i) data[i] = image->GetAsDouble(i);
     } break;
     default:

--- a/Modules/Numerics/include/mirtk/Vector3D.h
+++ b/Modules/Numerics/include/mirtk/Vector3D.h
@@ -260,6 +260,9 @@ struct Vector3D
   // ---------------------------------------------------------------------------
   // Other vector functions
 
+  /// Compute squared length of vector
+  double SquaredLength() const;
+
   /// Compute length of vector
   double Length() const;
 
@@ -867,17 +870,24 @@ inline bool Vector3D<T1>::operator >=(const Vector3D<T2> &v) const
 
 // -----------------------------------------------------------------------------
 template <typename T>
-inline void Vector3D<T>::Normalize()
+inline double Vector3D<T>::SquaredLength() const
 {
-  double length = sqrt(static_cast<double>(_x*_x + _y*_y + _z*_z));
-  if (length != .0) (*this) /= length;
+  return static_cast<double>(_x*_x + _y*_y + _z*_z);
 }
 
 // -----------------------------------------------------------------------------
 template <typename T>
 inline double Vector3D<T>::Length() const
 {
-  return sqrt(static_cast<double>(_x*_x + _y*_y + _z*_z));
+  return sqrt(SquaredLength());
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+inline void Vector3D<T>::Normalize()
+{
+  const double length = Length();
+  if (length != .0) (*this) /= length;
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Numerics/src/EnergyThreshold.cc
+++ b/Modules/Numerics/src/EnergyThreshold.cc
@@ -90,7 +90,7 @@ bool EnergyThreshold::Fulfilled(int, double, double value, const double *)
 void EnergyThreshold::Print(ostream &os) const
 {
   const ios::fmtflags fmt = os.flags();
-  os << "target value = " << fixed << setw(7) << _Threshold;
+  os << "target value = ";
   if (_Threshold != .0 && (abs(_Threshold) < 1.e-5 || abs(_Threshold) >= 1.e5)) {
     os << scientific << setprecision(5) << setw(8) << _Threshold; // e-0x
   } else os << fixed << setprecision(5) << setw(8) << _Threshold;

--- a/Modules/PointSet/src/EdgeConnectivity.cc
+++ b/Modules/PointSet/src/EdgeConnectivity.cc
@@ -90,6 +90,8 @@ struct ComputeEdgeConnectivity
 
 // -----------------------------------------------------------------------------
 /// Determine edge-connectivity of nodes
+///
+/// FIXME: Use geodesic distance instead of Euclidean distance.
 struct ComputeEdgeConnectivityWithinRadius
 {
   typedef GenericSparseMatrix<int>::Entries Entries;


### PR DESCRIPTION
Most interesting change is that the name of the point data array to use for `calculate-element-wise` for `-mask`, `-add`, `-sub`, `-mul`, and `-div` can now be specified as second argument or when the initial input point set contains the data array named as first argument, the file name is not required.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/385)
<!-- Reviewable:end -->
