### PR TITLE
enh/fix: Miscellaneous

### DIFF
--- a/Applications/src/calculate-surface-attributes.cc
+++ b/Applications/src/calculate-surface-attributes.cc
@@ -303,12 +303,12 @@ int main(int argc, char *argv[])
       if (mean)       smoother.SmoothArray(mean_name);
       if (gauss)      smoother.SmoothArray(gauss_name);
       if (curvedness) smoother.SmoothArray(curvedness_name);
-      if (e1)         smoother.SmoothArray(e1_name);
-      if (e2)         smoother.SmoothArray(e2_name);
+      if (e1)         smoother.SmoothArray(e1_name, vtkDataSetAttributes::VECTORS);
+      if (e2)         smoother.SmoothArray(e2_name, vtkDataSetAttributes::VECTORS);
       smoother.NumberOfIterations(smooth_iterations);
       smoother.Sigma(-smooth_sigma); // negative: multiple of avg. edge length
       smoother.Weighting(weighting);
-      if (weighting ==  MeshSmoothing::AnisotropicGaussian){
+      if (weighting == MeshSmoothing::AnisotropicGaussian) {
         if (smooth_along_tensor) {
           smoother.GeometryTensorName(tensor_name);
         } else {

--- a/Modules/Image/include/mirtk/DataFunctions.h
+++ b/Modules/Image/include/mirtk/DataFunctions.h
@@ -1210,7 +1210,7 @@ public:
   virtual void Process(int n, double *data, bool *mask = NULL)
   {
     statistic::Extrema extrema;
-    extrema.Evaluate(n, data, mask);
+    extrema.Process(n, data, mask);
     _Slope     = (_Max - _Min) / (extrema.Max() - extrema.Min());
     _Intercept = _Min - (extrema.Min() * _Slope);
     _Data      = data;

--- a/Modules/Image/include/mirtk/InterpolateImageFunction.h
+++ b/Modules/Image/include/mirtk/InterpolateImageFunction.h
@@ -139,7 +139,34 @@ public:
   virtual void Initialize(bool coeff);
 
   // ---------------------------------------------------------------------------
-  // Domain checks
+  // Lattice
+
+  /// Lattice attributes
+  const ImageAttributes &Attributes() const;
+
+  /// Image size along x axis
+  int X() const;
+
+  /// Image size along y axis
+  int Y() const;
+
+  /// Image size along z axis
+  int Z() const;
+
+  /// Image size along t axis
+  int T() const;
+
+  /// Image spacing along x axis
+  double XSize() const;
+
+  /// Image spacing along y axis
+  double YSize() const;
+
+  /// Image spacing along z axis
+  double ZSize() const;
+
+  /// Image spacing along t axis
+  double TSize() const;
 
   /// Convert world coordinates (in mm) to image location (in pixels)
   void WorldToImage(double &, double &) const;
@@ -767,8 +794,62 @@ inline enum ExtrapolationMode InterpolateImageFunction::ExtrapolationMode() cons
 }
 
 // =============================================================================
-// Domain checks
+// Image attributes
 // =============================================================================
+
+// -----------------------------------------------------------------------------
+inline const ImageAttributes &InterpolateImageFunction::Attributes() const
+{
+  return this->_Input->Attributes();
+}
+
+// -----------------------------------------------------------------------------
+inline int InterpolateImageFunction::X() const
+{
+  return this->_Input->X();
+}
+
+// -----------------------------------------------------------------------------
+inline int InterpolateImageFunction::Y() const
+{
+  return this->_Input->Y();
+}
+
+// -----------------------------------------------------------------------------
+inline int InterpolateImageFunction::Z() const
+{
+  return this->_Input->Z();
+}
+
+// -----------------------------------------------------------------------------
+inline int InterpolateImageFunction::T() const
+{
+  return this->_Input->T();
+}
+
+// -----------------------------------------------------------------------------
+inline double InterpolateImageFunction::XSize() const
+{
+  return this->_Input->XSize();
+}
+
+// -----------------------------------------------------------------------------
+inline double InterpolateImageFunction::YSize() const
+{
+  return this->_Input->YSize();
+}
+
+// -----------------------------------------------------------------------------
+inline double InterpolateImageFunction::ZSize() const
+{
+  return this->_Input->ZSize();
+}
+
+// -----------------------------------------------------------------------------
+inline double InterpolateImageFunction::TSize() const
+{
+  return this->_Input->TSize();
+}
 
 // ----------------------------------------------------------------------------
 inline void InterpolateImageFunction::WorldToImage(double &x, double &y) const

--- a/Modules/Numerics/include/mirtk/Vector3.h
+++ b/Modules/Numerics/include/mirtk/Vector3.h
@@ -34,7 +34,7 @@ public:
   Vector3 ();
   Vector3 (double fScalar);
   Vector3 (double fX, double fY, double fZ);
-  Vector3 (double afCoordinate[3]);
+  Vector3 (const double afCoordinate[3]);
   Vector3 (const Vector3& rkVector);
 
   // member access (allows V.x or V[0], V.y or V[1], V.z or V[2])

--- a/Modules/Numerics/src/Vector3.cc
+++ b/Modules/Numerics/src/Vector3.cc
@@ -53,7 +53,7 @@ Vector3::Vector3 (double fX, double fY, double fZ)
 }
 
 //----------------------------------------------------------------------------
-Vector3::Vector3 (double afCoordinate[3])
+Vector3::Vector3 (const double afCoordinate[3])
 {
   x = afCoordinate[0];
   y = afCoordinate[1];

--- a/Modules/PointSet/include/mirtk/MeshSmoothing.h
+++ b/Modules/PointSet/include/mirtk/MeshSmoothing.h
@@ -152,6 +152,9 @@ private:
   /// Names of input point data arrays to be smoothed
   mirtkPublicAttributeMacro(ArrayNames, SmoothArrays);
 
+  /// Array vtkDataSetAttributes::AttributeTypes
+  mirtkAttributeMacro(Array<int>, AttributeTypes);
+
   /// Input point data arrays to be smoothed
   mirtkAttributeMacro(DataArrays, InputArrays);
 
@@ -182,7 +185,13 @@ public:
   virtual ~MeshSmoothing();
 
   /// Add named point data array to list of arrays to be smoothed
-  void SmoothArray(const char *);
+  ///
+  /// \param[in] name Name of data array to smooth.
+  /// \param[in] attr Array attribute type, see vtkDataSetAttributes::AttributeTypes.
+  ///                 When vtkDataSetAttributes::VECTORS, an array with 3 components
+  ///                 is treated as 3D direction vectors and the smoothing is
+  ///                 performed independent of the sign of the direction.
+  void SmoothArray(const char *name, int attr = -1);
 
   // ---------------------------------------------------------------------------
   // Execution
@@ -239,25 +248,27 @@ public:
 // Inline definitions
 ////////////////////////////////////////////////////////////////////////////////
 
+// -----------------------------------------------------------------------------
+template <>
 inline bool FromString(const char *str, MeshSmoothing::WeightFunction &value)
 {
   const string lstr = ToLower(Trim(str));
-
-  if (lstr == "combinatorial") value = MeshSmoothing::Combinatorial;
-  else if (lstr == "inversedistance") value = MeshSmoothing::InverseDistance;
-  else if (lstr == "gaussian") value = MeshSmoothing::Gaussian;
+  if      (lstr == "combinatorial")       value = MeshSmoothing::Combinatorial;
+  else if (lstr == "inversedistance")     value = MeshSmoothing::InverseDistance;
+  else if (lstr == "gaussian")            value = MeshSmoothing::Gaussian;
   else if (lstr == "anisotropicgaussian") value = MeshSmoothing::AnisotropicGaussian;
-  else{
+  else {
     value = MeshSmoothing::Default;
-    return false;
+    return (lstr == "default");
   }
   return true;
 }
 
 // -----------------------------------------------------------------------------
-inline void MeshSmoothing::SmoothArray(const char *name)
+inline void MeshSmoothing::SmoothArray(const char *name, int attr)
 {
   _SmoothArrays.push_back(name);
+  _AttributeTypes.push_back(attr);
 }
 
 


### PR DESCRIPTION
Minor changes. Most important: `MeshSmoothing` filter averages VECTOR's differently. This was before done whenever the number of components was 3. But even with 3 components each one of these could be a separate scalar component rather.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/393)
<!-- Reviewable:end -->
