### PR TITLE
enh: S-shaped membership function, Point/Vector3 assignment [Common,PointSet]

### DIFF
--- a/Modules/Common/include/mirtk/Math.h
+++ b/Modules/Common/include/mirtk/Math.h
@@ -86,7 +86,7 @@ using std::copysign;
 // Custom floating point functions
 // =============================================================================
 
-// ---------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 /// Check if floating point value is not a number (NaN)
 MIRTKCU_API inline bool IsNaN(double x)
 {
@@ -98,7 +98,7 @@ MIRTKCU_API inline bool IsNaN(double x)
 #endif
 }
 
-// ---------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 /// Check if floating point value represents infinity
 MIRTKCU_API inline bool IsInf(double x)
 {
@@ -110,14 +110,14 @@ MIRTKCU_API inline bool IsInf(double x)
 #endif
 }
 
-// ---------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 /// Determine equality of two floating point numbers
 MIRTKCU_API inline bool fequal(double a, double b, double tol = 1e-12)
 {
   return abs(a - b) < tol;
 }
 
-// ---------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 /// Sign function - https://en.wikipedia.org/wiki/Sign_function
 template <typename T>
 MIRTKCU_API int sgn(T val)
@@ -125,7 +125,7 @@ MIRTKCU_API int sgn(T val)
   return (T(0) < val) - (val < T(0));
 }
 
-// ---------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 /// Round floating-point value to next smaller integer and cast to int
 template <class T>
 MIRTKCU_API inline int ifloor(T x)
@@ -133,7 +133,7 @@ MIRTKCU_API inline int ifloor(T x)
   return static_cast<int>(floor(x));
 }
 
-// ---------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 /// Round floating-point value to next greater integer and cast to int
 template <class T>
 MIRTKCU_API inline int iceil(T x)
@@ -141,7 +141,7 @@ MIRTKCU_API inline int iceil(T x)
   return static_cast<int>(ceil(x));
 }
 
-// ---------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 /// Round floating-point value and cast to int
 template <class T>
 MIRTKCU_API inline int iround(T x)
@@ -149,7 +149,7 @@ MIRTKCU_API inline int iround(T x)
   return static_cast<int>(round(x));
 }
 
-// ---------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 /// Increment floating-point number by the smallest possible amount such that
 /// the resulting number is greater than the original number.
 MIRTKCU_API inline double finc(double f)
@@ -159,7 +159,7 @@ MIRTKCU_API inline double finc(double f)
   return ::ldexp(m + numeric_limits<double>::epsilon(), e);
 }
 
-// ---------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 /// Decrement floating-point number by the smallest possible amount such that
 /// the resulting number is less than the original number.
 MIRTKCU_API inline double fdec(double f)
@@ -169,7 +169,7 @@ MIRTKCU_API inline double fdec(double f)
   return ::ldexp(m - numeric_limits<double>::epsilon(), e);
 }
 
-// ---------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 /// Increment floating point number by a given amount, ensuring that the result
 /// is not equal f.
 ///
@@ -189,7 +189,7 @@ MIRTKCU_API inline double finc(double f, double df)
   return s;
 }
 
-// ---------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 /// Decrement floating point number by a given amount, ensuring that the result
 /// is not equal f.
 ///
@@ -207,6 +207,24 @@ MIRTKCU_API inline double fdec(double f, double df)
     else        s = fdec(f);
   }
   return s;
+}
+
+// -----------------------------------------------------------------------------
+/// S-shaped monotone increasing membership function whose value is in [0, 1]
+/// for x in [a, b]. It is equivalent to MATLAB's smf function.
+inline double SShapedMembershipFunction(double x, double a, double b)
+{
+  if (x <= a) {
+    return 0.;
+  } else if (x >= b) {
+    return 1.;
+  } else if (x <= .5 * (a + b)) {
+    const double t = (x - a) / (b - a);
+    return 2. * t * t;
+  } else {
+    const double t = (x - b) / (b - a);
+    return 1. - 2. * t * t;
+  }
 }
 
 // =============================================================================

--- a/Modules/Numerics/include/mirtk/Point.h
+++ b/Modules/Numerics/include/mirtk/Point.h
@@ -149,6 +149,9 @@ public:
   // Operators for double
   //
 
+  /// Assign scalar value to all coordinates
+  Point& operator =(double);
+
   /// Substraction of double
   Point& operator-=(double);
 
@@ -512,6 +515,15 @@ inline int Point::operator<(Point const& p) const
 inline int Point::operator>(Point const& p) const
 {
   return ((_x > p._x) && (_y > p._y) && (_z > p._z));
+}
+
+// -----------------------------------------------------------------------------
+inline Point& Point::operator =(double x)
+{
+  _x = x;
+  _y = x;
+  _z = x;
+  return *this;
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Numerics/include/mirtk/Point.h
+++ b/Modules/Numerics/include/mirtk/Point.h
@@ -1,8 +1,9 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2008-2015 Imperial College London
+ * Copyright 2008-2016 Imperial College London
  * Copyright 2008-2015 Daniel Rueckert, Julia Schnabel
+ * Copyright 2016      Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -587,6 +588,15 @@ inline Point Point::operator/ (double x) const
   p._y = _y / x;
   p._z = _z / x;
   return p;
+}
+
+// -----------------------------------------------------------------------------
+inline Point& Point::operator =(const Vector3& v)
+{
+  _x = v.x;
+  _y = v.y;
+  _z = v.z;
+  return *this;
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Numerics/include/mirtk/Vector3.h
+++ b/Modules/Numerics/include/mirtk/Vector3.h
@@ -22,6 +22,9 @@
 namespace mirtk {
 
 
+class Point;
+
+
 /**
  * 3D vector
  *
@@ -36,6 +39,7 @@ public:
   Vector3 (double fX, double fY, double fZ);
   Vector3 (const double afCoordinate[3]);
   Vector3 (const Vector3& rkVector);
+  Vector3 (const Point &);
 
   // member access (allows V.x or V[0], V.y or V[1], V.z or V[2])
   double x, y, z;

--- a/Modules/Numerics/src/Point.cc
+++ b/Modules/Numerics/src/Point.cc
@@ -1,8 +1,9 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2008-2015 Imperial College London
+ * Copyright 2008-2016 Imperial College London
  * Copyright 2008-2015 Daniel Rueckert, Julia Schnabel
+ * Copyright 2016      Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Modules/Numerics/src/Vector3.cc
+++ b/Modules/Numerics/src/Vector3.cc
@@ -20,6 +20,7 @@
 
 #include "mirtk/Math.h"
 #include "mirtk/Stream.h"
+#include "mirtk/Point.h"
 
 
 namespace mirtk {
@@ -66,6 +67,14 @@ Vector3::Vector3 (const Vector3& rkVector)
   x = rkVector.x;
   y = rkVector.y;
   z = rkVector.z;
+}
+
+//----------------------------------------------------------------------------
+Vector3::Vector3 (const Point& p)
+{
+  x = p.x;
+  y = p.y;
+  z = p.z;
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
- Add `SShapedMembershipFunction`.
- Add missing `Point::operator=(const Vector3&)` definition.
- Add further assignment operators.
- Add Vector3 from Point constructor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/400)
<!-- Reviewable:end -->
