### PR TITLE
enh: Use max of min implicit surface and normal distance [PointSet]

### DIFF
--- a/Modules/PointSet/include/mirtk/ImplicitSurfaceUtils.h
+++ b/Modules/PointSet/include/mirtk/ImplicitSurfaceUtils.h
@@ -133,15 +133,17 @@ inline bool BracketZeroCrossing(const double p[3], const double e[3],
     b = a, db = da;
     return true;
   }
-  double x[3], step = max(minh, abs(da));
-  for (b = step; b <= maxh; b += step) {
-    x[0] = p[0] + b * e[0];
-    x[1] = p[1] + b * e[1];
-    x[2] = p[2] + b * e[2];
-    db = Evaluate(distance, x, offset);
-    if (fequal(db, .0, tol) || da * db <= .0) return true; // zero crossing
-    a = b, da = db;
-    step = max(minh, abs(da));
+  if (abs(da) < maxh) {
+    double x[3], step = max(minh, abs(da));
+    for (b = step; b <= maxh; b += step) {
+      x[0] = p[0] + b * e[0];
+      x[1] = p[1] + b * e[1];
+      x[2] = p[2] + b * e[2];
+      db = Evaluate(distance, x, offset);
+      if (fequal(db, .0, tol) || da * db <= .0) return true; // zero crossing
+      a = b, da = db;
+      step = max(minh, abs(da));
+    }
   }
   return false;
 }


### PR DESCRIPTION
Ensures that the distance in normal direction is at least the minimum surface distances known from the implicit surface function. Further, no need to compute distance in normal direction when max ray depth is less than the known minimum distance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/402)
<!-- Reviewable:end -->
