### PR TITLE
fix: Change triangle distance threshold used to detect false positives [PointSet]

### DIFF
--- a/Modules/PointSet/src/Triangle.cc
+++ b/Modules/PointSet/src/Triangle.cc
@@ -238,7 +238,7 @@ bool Triangle
                                      const_cast<double *>(a2),
                                      const_cast<double *>(b2),
                                      const_cast<double *>(c2),
-                                     const_cast<double *>(n2)) > 1e-6) {
+                                     const_cast<double *>(n2)) > 1e-3) {
         return false;
       }
     }


### PR DESCRIPTION
Using `1e-6` resulted in non-detected intersections during white surface recon. Thus, be more conservative and "trust" initial intersection test when triangles seem to be pretty close anyway.