### PR TITLE
fix: Output array name after dilate/erode-scalars [Applications]

### DIFF
--- a/Applications/src/dilate-scalars.cc
+++ b/Applications/src/dilate-scalars.cc
@@ -111,6 +111,8 @@ vtkSmartPointer<vtkPointSet> Dilate(vtkSmartPointer<vtkPointSet> input,
                                     const EdgeConnectivity &neighbors,
                                     vtkSmartPointer<vtkDataArray> arr, int niter = 1)
 {
+  const int npoints = static_cast<int>(input->GetNumberOfPoints());
+
   vtkSmartPointer<vtkPointSet> output;
   output.TakeReference(input->NewInstance());
   output->ShallowCopy(input);
@@ -125,23 +127,40 @@ vtkSmartPointer<vtkPointSet> Dilate(vtkSmartPointer<vtkPointSet> input,
     }
   }
 
+  // Attention: vtkDataArray::DeepCopy (of older VTK versions?) does not
+  //            copy array name (and possibly not array component names).
   vtkSmartPointer<vtkDataArray> res;
   res.TakeReference(arr->NewInstance());
-  res->DeepCopy(arr); // in particular size, name, and component names if any
-  const int idx = pd->AddArray(res);
-  if (attr >= 0) pd->SetActiveAttribute(idx, attr);
-
-  for (int iter = 0; iter < niter; ++iter) {
-    if (iter > 0) {
-      if (iter == 1) arr.TakeReference(res->NewInstance());
-      arr->DeepCopy(res);
-    }
-    DilateScalars body;
-    body._Input     = arr;
-    body._Output    = res;
-    body._Neighbors = &neighbors;
-    parallel_for(blocked_range<int>(0, static_cast<int>(input->GetNumberOfPoints())), body);
+  res->SetNumberOfComponents(arr->GetNumberOfComponents());
+  res->SetNumberOfTuples(arr->GetNumberOfTuples());
+  res->SetName(arr->GetName());
+  for (int j = 0; j < arr->GetNumberOfComponents(); ++j) {
+    res->SetComponentName(j, arr->GetComponentName(j));
   }
+
+  DilateScalars body;
+  body._Input     = arr;
+  body._Output    = res;
+  body._Neighbors = &neighbors;
+  for (int iter = 0; iter < niter; ++iter) {
+    if (iter == 1) {
+      arr.TakeReference(res->NewInstance());
+      arr->SetNumberOfComponents(res->GetNumberOfComponents());
+      arr->SetNumberOfTuples(res->GetNumberOfTuples());
+      arr->SetName(res->GetName());
+      for (int j = 0; j < res->GetNumberOfComponents(); ++j) {
+        arr->SetComponentName(j, res->GetComponentName(j));
+        arr->CopyComponent(j, res, j);
+      }
+      body._Input = arr;
+    } else if (iter > 1) {
+      swap(body._Input, body._Output);
+    }
+    parallel_for(blocked_range<int>(0, npoints), body);
+  }
+
+  const int idx = pd->AddArray(body._Output);
+  if (attr >= 0) pd->SetActiveAttribute(idx, attr);
 
   return output;
 }


### PR DESCRIPTION
The `vtkDataArray::DeepCopy` function apparently does not copy array name (and possibly neither component names) when using VTK 6.2. With version >=7.0 the array name seems to be copied as well. This change fixes it for all supported VTK versions and avoid use of `DeepCopy`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/414)
<!-- Reviewable:end -->
