### PR TITLE
fix: Intersection test of nearly coplanar triangles [PointSet]

### DIFF
--- a/Modules/PointSet/src/Triangle.cc
+++ b/Modules/PointSet/src/Triangle.cc
@@ -204,48 +204,12 @@ bool Triangle
 ::TriangleTriangleIntersection(const double a1[3], const double b1[3], const double c1[3],
                                const double a2[3], const double b2[3], const double c2[3])
 {
-  if (tri_tri_overlap_test_3d(const_cast<double *>(a1),
-                              const_cast<double *>(b1),
-                              const_cast<double *>(c1),
-                              const_cast<double *>(a2),
-                              const_cast<double *>(b2),
-                              const_cast<double *>(c2)) != 0) {
-    // FIXME: Yields on occassion false positive intersection tests of nearby,
-    //        but not even close to intersecting triangles. The following
-    //        additional checks are thus done for the moment...
-    #if 1
-    {
-      double p1[3], p2[3];
-      double d  = Triangle::DistanceBetweenCenters(a1, b1, c1, a2, b2, c2, p1, p2);
-      double r1 = sqrt(max(max(vtkMath::Distance2BetweenPoints(a1, p1),
-                               vtkMath::Distance2BetweenPoints(b1, p1)),
-                               vtkMath::Distance2BetweenPoints(c1, p1)));
-      double r2 = sqrt(max(max(vtkMath::Distance2BetweenPoints(a2, p2),
-                               vtkMath::Distance2BetweenPoints(b2, p2)),
-                               vtkMath::Distance2BetweenPoints(c2, p2)));
-      if (d > r1 + r2) return false;
-    }
-    #endif
-    #if 1
-    {
-      double n1[3], n2[3];
-      Normal(a1, b1, c1, n1);
-      Normal(a2, b2, c2, n2);
-      if (distance_between_triangles(const_cast<double *>(a1),
-                                     const_cast<double *>(b1),
-                                     const_cast<double *>(c1),
-                                     const_cast<double *>(n1),
-                                     const_cast<double *>(a2),
-                                     const_cast<double *>(b2),
-                                     const_cast<double *>(c2),
-                                     const_cast<double *>(n2)) > 1e-3) {
-        return false;
-      }
-    }
-    #endif
-    return true;
-  }
-  return false;
+  return (0 != tri_tri_overlap_test_3d(const_cast<double *>(a1),
+                                       const_cast<double *>(b1),
+                                       const_cast<double *>(c1),
+                                       const_cast<double *>(a2),
+                                       const_cast<double *>(b2),
+                                       const_cast<double *>(c2)));
 }
 
 

--- a/Modules/PointSet/src/triangle_triangle_intersection.h
+++ b/Modules/PointSet/src/triangle_triangle_intersection.h
@@ -1,7 +1,8 @@
 /*		  		
 *  Triangle-Triangle Overlap Test Routines				
 *  July, 2002                                                          
-*  Updated December 2003                                                
+*  Updated December 2003
+*  Modified by Andreas Schuh in September 2016
 *                                                                       
 *  This file contains C implementation of algorithms for                
 *  performing two and three-dimensional triangle-triangle intersection test 
@@ -35,15 +36,18 @@
 *                                                                           
 */
 
-// modified by Aaron to better detect coplanarity
-
 // Andreas: Copied this source file on 6/6/2016 from
 // https://raw.githubusercontent.com/benardp/contours/755cf3c5086d58d07928934384dd185604ea2c2c/freestyle/view_map/triangle_triangle_intersection.c
+// and modified to use eps and zero constants for chosen real data type.
+// Clamp dot products / signed distance to triangle plane to zero when
+// absolute value is less than abs to better detect coplanarity.
 typedef double real;
 
+static const real zero = real(0);
+static const real eps  = static_cast<real>(1e-12);
 
-#define ZERO_TEST(x)  (x == 0.0f)
-//#define ZERO_TEST(x)  ((x) > -0.001f && (x) < 0.001f)
+
+#define ZERO_TEST(x)  (abs(x) <= eps)
 
 
 /* function prototype */
@@ -67,70 +71,67 @@ inline int tri_tri_intersection_test_3d(real p1[3], real q1[3], real r1[3],
 *  intersection if it exists) 
 */
 
+#define CROSS(dest,v1,v2)   dest[0] = v1[1]*v2[2] - v1[2]*v2[1]; \
+                            dest[1] = v1[2]*v2[0] - v1[0]*v2[2]; \
+                            dest[2] = v1[0]*v2[1] - v1[1]*v2[0];
 
-/* some 3D macros */
-
-#define CROSS(dest,v1,v2)                       \
-               dest[0]=v1[1]*v2[2]-v1[2]*v2[1]; \
-               dest[1]=v1[2]*v2[0]-v1[0]*v2[2]; \
-               dest[2]=v1[0]*v2[1]-v1[1]*v2[0];
-
-#define DOT(v1,v2) (v1[0]*v2[0]+v1[1]*v2[1]+v1[2]*v2[2])
+#define DOT(v1,v2) (v1[0]*v2[0] + v1[1]*v2[1] + v1[2]*v2[2])
  
 
 
-#define SUB(dest,v1,v2) dest[0]=v1[0]-v2[0]; \
-                        dest[1]=v1[1]-v2[1]; \
-                        dest[2]=v1[2]-v2[2]; 
+#define SUB(dest,v1,v2)   dest[0] = v1[0] - v2[0]; \
+                          dest[1] = v1[1] - v2[1]; \
+                          dest[2] = v1[2] - v2[2];
 
 
-#define SCALAR(dest,alpha,v) dest[0] = alpha * v[0]; \
-                             dest[1] = alpha * v[1]; \
-                             dest[2] = alpha * v[2];
+#define SCALAR(dest,alpha,v)   dest[0] = alpha * v[0]; \
+                               dest[1] = alpha * v[1]; \
+                               dest[2] = alpha * v[2];
 
 
 
-#define CHECK_MIN_MAX(p1,q1,r1,p2,q2,r2) {\
-  SUB(v1,p2,q1)\
-  SUB(v2,p1,q1)\
-  CROSS(N1,v1,v2)\
-  SUB(v1,q2,q1)\
-  if (DOT(v1,N1) > 0.0f) return 0;\
-  SUB(v1,p2,p1)\
-  SUB(v2,r1,p1)\
-  CROSS(N1,v1,v2)\
-  SUB(v1,r2,p1) \
-  if (DOT(v1,N1) > 0.0f) return 0;\
-  else return 1; }
-
+// Andreas: Changed conditions from DOT(v1,N1) > zero to DOT(v1,N1) >= -eps
+#define CHECK_MIN_MAX(p1,q1,r1,p2,q2,r2) \
+  { \
+    SUB(v1,p2,q1) \
+    SUB(v2,p1,q1) \
+    CROSS(N1,v1,v2) \
+    SUB(v1,q2,q1) \
+    if (DOT(v1,N1) >= -eps) return 0; \
+    SUB(v1,p2,p1) \
+    SUB(v2,r1,p1) \
+    CROSS(N1,v1,v2) \
+    SUB(v1,r2,p1) \
+    if (DOT(v1,N1) >= -eps) return 0; \
+    return 1; \
+  }
 
 
 /* Permutation in a canonical form of T2's vertices */
-
-#define TRI_TRI_3D(p1,q1,r1,p2,q2,r2,dp2,dq2,dr2) { \
-  if (dp2 > 0.0f) { \
-     if (dq2 > 0.0f) CHECK_MIN_MAX(p1,r1,q1,r2,p2,q2) \
-     else if (dr2 > 0.0f) CHECK_MIN_MAX(p1,r1,q1,q2,r2,p2)\
-     else CHECK_MIN_MAX(p1,q1,r1,p2,q2,r2) }\
-  else if (dp2 < 0.0f) { \
-    if (dq2 < 0.0f) CHECK_MIN_MAX(p1,q1,r1,r2,p2,q2)\
-    else if (dr2 < 0.0f) CHECK_MIN_MAX(p1,q1,r1,q2,r2,p2)\
-    else CHECK_MIN_MAX(p1,r1,q1,p2,q2,r2)\
-  } else { \
-    if (dq2 < 0.0f) { \
-      if (dr2 >= 0.0f)  CHECK_MIN_MAX(p1,r1,q1,q2,r2,p2)\
-      else CHECK_MIN_MAX(p1,q1,r1,p2,q2,r2)\
+#define TRI_TRI_3D(p1,q1,r1,p2,q2,r2,dp2,dq2,dr2) \
+  { \
+    if (dp2 > zero) { \
+      if      (dq2 > zero) CHECK_MIN_MAX(p1,r1,q1,r2,p2,q2) \
+      else if (dr2 > zero) CHECK_MIN_MAX(p1,r1,q1,q2,r2,p2) \
+      else                 CHECK_MIN_MAX(p1,q1,r1,p2,q2,r2) \
+    } else if (dp2 < zero) { \
+      if      (dq2 < zero) CHECK_MIN_MAX(p1,q1,r1,r2,p2,q2) \
+      else if (dr2 < zero) CHECK_MIN_MAX(p1,q1,r1,q2,r2,p2) \
+      else                 CHECK_MIN_MAX(p1,r1,q1,p2,q2,r2) \
+    } else { \
+      if (dq2 < zero) { \
+        if (dr2 >= zero) CHECK_MIN_MAX(p1,r1,q1,q2,r2,p2) \
+        else             CHECK_MIN_MAX(p1,q1,r1,p2,q2,r2) \
+      } else if (dq2 > zero) { \
+        if (dr2 > zero) CHECK_MIN_MAX(p1,r1,q1,p2,q2,r2) \
+        else            CHECK_MIN_MAX(p1,q1,r1,q2,r2,p2) \
+      } else { \
+        if      (dr2 > zero) CHECK_MIN_MAX(p1,q1,r1,r2,p2,q2) \
+        else if (dr2 < zero) CHECK_MIN_MAX(p1,r1,q1,r2,p2,q2) \
+        else return coplanar_tri_tri3d(p1,q1,r1,p2,q2,r2,N1,N2); \
+      } \
     } \
-    else if (dq2 > 0.0f) { \
-      if (dr2 > 0.0f) CHECK_MIN_MAX(p1,r1,q1,p2,q2,r2)\
-      else  CHECK_MIN_MAX(p1,q1,r1,q2,r2,p2)\
-    } \
-    else  { \
-      if (dr2 > 0.0f) CHECK_MIN_MAX(p1,q1,r1,r2,p2,q2)\
-      else if (dr2 < 0.0f) CHECK_MIN_MAX(p1,r1,q1,r2,p2,q2)\
-      else return coplanar_tri_tri3d(p1,q1,r1,p2,q2,r2,N1,N2);\
-     }}}
-  
+  }
 
 
 /*
@@ -147,10 +148,7 @@ int tri_tri_overlap_test_3d(real p1[3], real q1[3], real r1[3],
   real v1[3], v2[3];
   real N1[3], N2[3]; 
   
-  /* Compute distance signs  of p1, q1 and r1 to the plane of
-     triangle(p2,q2,r2) */
-
-
+  // Compute distance signs  of p1, q1 and r1 to the plane of triangle(p2,q2,r2)
   SUB(v1,p2,r2)
   SUB(v2,q2,r2)
   CROSS(N2,v1,v2)
@@ -161,13 +159,10 @@ int tri_tri_overlap_test_3d(real p1[3], real q1[3], real r1[3],
   dq1 = DOT(v1,N2);
   SUB(v1,r1,r2)
   dr1 = DOT(v1,N2);
-  
-  if (((dp1 * dq1) > 0.0f) && ((dp1 * dr1) > 0.0f))  return 0; 
 
-  /* Compute distance signs  of p2, q2 and r2 to the plane of
-     triangle(p1,q1,r1) */
+  if (((dp1 * dq1) > zero) && ((dp1 * dr1) > zero))  return 0;
 
-  
+  // Compute distance signs  of p2, q2 and r2 to the plane of triangle(p1,q1,r1)
   SUB(v1,q1,p1)
   SUB(v2,r1,p1)
   CROSS(N1,v1,v2)
@@ -178,73 +173,71 @@ int tri_tri_overlap_test_3d(real p1[3], real q1[3], real r1[3],
   dq2 = DOT(v1,N1);
   SUB(v1,r2,r1)
   dr2 = DOT(v1,N1);
-  
-  if (((dp2 * dq2) > 0.0f) && ((dp2 * dr2) > 0.0f)) return 0;
 
-  /* Permutation in a canonical form of T1's vertices */
+  if (((dp2 * dq2) > zero) && ((dp2 * dr2) > zero)) return 0;
 
+  // Permutation in a canonical form of T1's vertices
+  if (ZERO_TEST(dp1)) dp1 = zero;
+  if (ZERO_TEST(dq1)) dq1 = zero;
+  if (ZERO_TEST(dr1)) dr1 = zero;
 
+  if (ZERO_TEST(dp2)) dp2 = zero;
+  if (ZERO_TEST(dq2)) dq2 = zero;
+  if (ZERO_TEST(dr2)) dr2 = zero;
 
-
-  if (dp1 > 0.0f) {
-    if (dq1 > 0.0f) TRI_TRI_3D(r1,p1,q1,p2,r2,q2,dp2,dr2,dq2)
-    else if (dr1 > 0.0f) TRI_TRI_3D(q1,r1,p1,p2,r2,q2,dp2,dr2,dq2)	
-    else TRI_TRI_3D(p1,q1,r1,p2,q2,r2,dp2,dq2,dr2)
-  } else if (dp1 < 0.0f) {
-    if (dq1 < 0.0f) TRI_TRI_3D(r1,p1,q1,p2,q2,r2,dp2,dq2,dr2)
-    else if (dr1 < 0.0f) TRI_TRI_3D(q1,r1,p1,p2,q2,r2,dp2,dq2,dr2)
-    else TRI_TRI_3D(p1,q1,r1,p2,r2,q2,dp2,dr2,dq2)
+  if (dp1 > zero) {
+    if      (dq1 > zero) TRI_TRI_3D(r1,p1,q1,p2,r2,q2,dp2,dr2,dq2)
+    else if (dr1 > zero) TRI_TRI_3D(q1,r1,p1,p2,r2,q2,dp2,dr2,dq2)
+    else                 TRI_TRI_3D(p1,q1,r1,p2,q2,r2,dp2,dq2,dr2)
+  } else if (dp1 < zero) {
+    if      (dq1 < zero) TRI_TRI_3D(r1,p1,q1,p2,q2,r2,dp2,dq2,dr2)
+    else if (dr1 < zero) TRI_TRI_3D(q1,r1,p1,p2,q2,r2,dp2,dq2,dr2)
+    else                 TRI_TRI_3D(p1,q1,r1,p2,r2,q2,dp2,dr2,dq2)
   } else {
-    if (dq1 < 0.0f) {
-      if (dr1 >= 0.0f) TRI_TRI_3D(q1,r1,p1,p2,r2,q2,dp2,dr2,dq2)
-      else TRI_TRI_3D(p1,q1,r1,p2,q2,r2,dp2,dq2,dr2)
-    }
-    else if (dq1 > 0.0f) {
-      if (dr1 > 0.0f) TRI_TRI_3D(p1,q1,r1,p2,r2,q2,dp2,dr2,dq2)
-      else TRI_TRI_3D(q1,r1,p1,p2,q2,r2,dp2,dq2,dr2)
-    }
-    else  {
-      if (dr1 > 0.0f) TRI_TRI_3D(r1,p1,q1,p2,q2,r2,dp2,dq2,dr2)
-      else if (dr1 < 0.0f) TRI_TRI_3D(r1,p1,q1,p2,r2,q2,dp2,dr2,dq2)
+    if (dq1 < zero) {
+      if (dr1 >= zero) TRI_TRI_3D(q1,r1,p1,p2,r2,q2,dp2,dr2,dq2)
+      else             TRI_TRI_3D(p1,q1,r1,p2,q2,r2,dp2,dq2,dr2)
+    } else if (dq1 > zero) {
+      if (dr1 > zero) TRI_TRI_3D(p1,q1,r1,p2,r2,q2,dp2,dr2,dq2)
+      else            TRI_TRI_3D(q1,r1,p1,p2,q2,r2,dp2,dq2,dr2)
+    } else  {
+      if      (dr1 > zero) TRI_TRI_3D(r1,p1,q1,p2,q2,r2,dp2,dq2,dr2)
+      else if (dr1 < zero) TRI_TRI_3D(r1,p1,q1,p2,r2,q2,dp2,dr2,dq2)
       else return coplanar_tri_tri3d(p1,q1,r1,p2,q2,r2,N1,N2);
     }
   }
 };
 
 
-
 int coplanar_tri_tri3d(real p1[3], real q1[3], real r1[3],
-		               real p2[3], real q2[3], real r2[3],
-		               real normal_1[3], real normal_2[3])
+		                   real p2[3], real q2[3], real r2[3],
+		                   real normal_1[3], real normal_2[3])
 {
-  
   real P1[2],Q1[2],R1[2];
   real P2[2],Q2[2],R2[2];
 
   real n_x, n_y, n_z;
 
-  n_x = ((normal_1[0]<0)?-normal_1[0]:normal_1[0]);
-  n_y = ((normal_1[1]<0)?-normal_1[1]:normal_1[1]);
-  n_z = ((normal_1[2]<0)?-normal_1[2]:normal_1[2]);
-
+  n_x = ((normal_1[0] < zero) ? -normal_1[0] : normal_1[0]);
+  n_y = ((normal_1[1] < zero) ? -normal_1[1] : normal_1[1]);
+  n_z = ((normal_1[2] < zero) ? -normal_1[2] : normal_1[2]);
 
   /* Projection of the triangles in 3D onto 2D such that the area of
      the projection is maximized. */
 
-
+  // Project onto plane YZ
   if (( n_x > n_z ) && ( n_x >= n_y )) {
-    // Project onto plane YZ
 
-      P1[0] = q1[2]; P1[1] = q1[1];
-      Q1[0] = p1[2]; Q1[1] = p1[1];
-      R1[0] = r1[2]; R1[1] = r1[1]; 
-    
-      P2[0] = q2[2]; P2[1] = q2[1];
-      Q2[0] = p2[2]; Q2[1] = p2[1];
-      R2[0] = r2[2]; R2[1] = r2[1]; 
+    P1[0] = q1[2]; P1[1] = q1[1];
+    Q1[0] = p1[2]; Q1[1] = p1[1];
+    R1[0] = r1[2]; R1[1] = r1[1]; 
+  
+    P2[0] = q2[2]; P2[1] = q2[1];
+    Q2[0] = p2[2]; Q2[1] = p2[1];
+    R2[0] = r2[2]; R2[1] = r2[1]; 
 
+  // Project onto plane XZ
   } else if (( n_y > n_z ) && ( n_y >= n_x )) {
-    // Project onto plane XZ
 
     P1[0] = q1[0]; P1[1] = q1[2];
     Q1[0] = p1[0]; Q1[1] = p1[2];
@@ -253,9 +246,9 @@ int coplanar_tri_tri3d(real p1[3], real q1[3], real r1[3],
     P2[0] = q2[0]; P2[1] = q2[2];
     Q2[0] = p2[0]; Q2[1] = p2[2];
     R2[0] = r2[0]; R2[1] = r2[2]; 
-    
+
+  // Project onto plane XY
   } else {
-    // Project onto plane XY
 
     P1[0] = p1[0]; P1[1] = p1[1]; 
     Q1[0] = q1[0]; Q1[1] = q1[1]; 
@@ -263,11 +256,11 @@ int coplanar_tri_tri3d(real p1[3], real q1[3], real r1[3],
     
     P2[0] = p2[0]; P2[1] = p2[1]; 
     Q2[0] = q2[0]; Q2[1] = q2[1]; 
-    R2[0] = r2[0]; R2[1] = r2[1]; 
+    R2[0] = r2[0]; R2[1] = r2[1];
+
   }
 
   return tri_tri_overlap_test_2d(P1,Q1,R1,P2,Q2,R2);
-    
 };
 
 
@@ -284,108 +277,112 @@ int coplanar_tri_tri3d(real p1[3], real q1[3], real r1[3],
    if they are not coplanar.
 */
 
-#define CONSTRUCT_INTERSECTION(p1,q1,r1,p2,q2,r2) { \
-  SUB(v1,q1,p1) \
-  SUB(v2,r2,p1) \
-  CROSS(N,v1,v2) \
-  SUB(v,p2,p1) \
-  if (DOT(v,N) > 0.0f) {\
-    SUB(v1,r1,p1) \
+#define CONSTRUCT_INTERSECTION(p1,q1,r1,p2,q2,r2) \
+  { \
+    SUB(v1,q1,p1) \
+    SUB(v2,r2,p1) \
     CROSS(N,v1,v2) \
-    if (DOT(v,N) <= 0.0f) { \
-      SUB(v2,q2,p1) \
-      CROSS(N,v1,v2) \
-      if (DOT(v,N) > 0.0f) { \
-	SUB(v1,p1,p2) \
-	SUB(v2,p1,r1) \
-	alpha = DOT(v1,N2) / DOT(v2,N2); \
-	SCALAR(v1,alpha,v2) \
-	SUB(source,p1,v1) \
-	SUB(v1,p2,p1) \
-	SUB(v2,p2,r2) \
-	alpha = DOT(v1,N1) / DOT(v2,N1); \
-	SCALAR(v1,alpha,v2) \
-	SUB(target,p2,v1) \
-	return 1; \
-      } else { \
-	SUB(v1,p2,p1) \
-	SUB(v2,p2,q2) \
-	alpha = DOT(v1,N1) / DOT(v2,N1); \
-	SCALAR(v1,alpha,v2) \
-	SUB(source,p2,v1) \
-	SUB(v1,p2,p1) \
-	SUB(v2,p2,r2) \
-	alpha = DOT(v1,N1) / DOT(v2,N1); \
-	SCALAR(v1,alpha,v2) \
-	SUB(target,p2,v1) \
-	return 1; \
-      } \
-    } else { \
-      return 0; \
-    } \
-  } else { \
-    SUB(v2,q2,p1) \
-    CROSS(N,v1,v2) \
-    if (DOT(v,N) < 0.0f) { \
-      return 0; \
-    } else { \
+    SUB(v,p2,p1) \
+    if (DOT(v,N) > zero) {\
       SUB(v1,r1,p1) \
       CROSS(N,v1,v2) \
-      if (DOT(v,N) >= 0.0f) { \
-	SUB(v1,p1,p2) \
-	SUB(v2,p1,r1) \
-	alpha = DOT(v1,N2) / DOT(v2,N2); \
-	SCALAR(v1,alpha,v2) \
-	SUB(source,p1,v1) \
-	SUB(v1,p1,p2) \
-	SUB(v2,p1,q1) \
-	alpha = DOT(v1,N2) / DOT(v2,N2); \
-	SCALAR(v1,alpha,v2) \
-	SUB(target,p1,v1) \
-	return 1; \
+      if (DOT(v,N) <= zero) { \
+        SUB(v2,q2,p1) \
+        CROSS(N,v1,v2) \
+        if (DOT(v,N) > zero) { \
+          SUB(v1,p1,p2) \
+          SUB(v2,p1,r1) \
+          alpha = DOT(v1,N2) / DOT(v2,N2); \
+          SCALAR(v1,alpha,v2) \
+          SUB(source,p1,v1) \
+          SUB(v1,p2,p1) \
+          SUB(v2,p2,r2) \
+          alpha = DOT(v1,N1) / DOT(v2,N1); \
+          SCALAR(v1,alpha,v2) \
+          SUB(target,p2,v1) \
+          return 1; \
+        } else { \
+          SUB(v1,p2,p1) \
+          SUB(v2,p2,q2) \
+          alpha = DOT(v1,N1) / DOT(v2,N1); \
+          SCALAR(v1,alpha,v2) \
+          SUB(source,p2,v1) \
+          SUB(v1,p2,p1) \
+          SUB(v2,p2,r2) \
+          alpha = DOT(v1,N1) / DOT(v2,N1); \
+          SCALAR(v1,alpha,v2) \
+          SUB(target,p2,v1) \
+          return 1; \
+        } \
       } else { \
-	SUB(v1,p2,p1) \
-	SUB(v2,p2,q2) \
-	alpha = DOT(v1,N1) / DOT(v2,N1); \
-	SCALAR(v1,alpha,v2) \
-	SUB(source,p2,v1) \
-	SUB(v1,p1,p2) \
-	SUB(v2,p1,q1) \
-	alpha = DOT(v1,N2) / DOT(v2,N2); \
-	SCALAR(v1,alpha,v2) \
-	SUB(target,p1,v1) \
-	return 1; \
-      }}}} 
-
-								
-
-#define TRI_TRI_INTER_3D(p1,q1,r1,p2,q2,r2,dp2,dq2,dr2) { \
-  if (dp2 > 0.0f) { \
-     if (dq2 > 0.0f) CONSTRUCT_INTERSECTION(p1,r1,q1,r2,p2,q2) \
-     else if (dr2 > 0.0f) CONSTRUCT_INTERSECTION(p1,r1,q1,q2,r2,p2)\
-     else CONSTRUCT_INTERSECTION(p1,q1,r1,p2,q2,r2) }\
-  else if (dp2 < 0.0f) { \
-    if (dq2 < 0.0f) CONSTRUCT_INTERSECTION(p1,q1,r1,r2,p2,q2)\
-    else if (dr2 < 0.0f) CONSTRUCT_INTERSECTION(p1,q1,r1,q2,r2,p2)\
-    else CONSTRUCT_INTERSECTION(p1,r1,q1,p2,q2,r2)\
-  } else { \
-    if (dq2 < 0.0f) { \
-      if (dr2 >= 0.0f)  CONSTRUCT_INTERSECTION(p1,r1,q1,q2,r2,p2)\
-      else CONSTRUCT_INTERSECTION(p1,q1,r1,p2,q2,r2)\
+        return 0; \
+      } \
+    } else { \
+      SUB(v2,q2,p1) \
+      CROSS(N,v1,v2) \
+      if (DOT(v,N) < zero) { \
+        return 0; \
+      } else { \
+        SUB(v1,r1,p1) \
+        CROSS(N,v1,v2) \
+        if (DOT(v,N) >= zero) { \
+          SUB(v1,p1,p2) \
+          SUB(v2,p1,r1) \
+          alpha = DOT(v1,N2) / DOT(v2,N2); \
+          SCALAR(v1,alpha,v2) \
+          SUB(source,p1,v1) \
+          SUB(v1,p1,p2) \
+          SUB(v2,p1,q1) \
+          alpha = DOT(v1,N2) / DOT(v2,N2); \
+          SCALAR(v1,alpha,v2) \
+          SUB(target,p1,v1) \
+          return 1; \
+        } else { \
+          SUB(v1,p2,p1) \
+          SUB(v2,p2,q2) \
+          alpha = DOT(v1,N1) / DOT(v2,N1); \
+          SCALAR(v1,alpha,v2) \
+          SUB(source,p2,v1) \
+          SUB(v1,p1,p2) \
+          SUB(v2,p1,q1) \
+          alpha = DOT(v1,N2) / DOT(v2,N2); \
+          SCALAR(v1,alpha,v2) \
+          SUB(target,p1,v1) \
+          return 1; \
+        } \
+      } \
     } \
-    else if (dq2 > 0.0f) { \
-      if (dr2 > 0.0f) CONSTRUCT_INTERSECTION(p1,r1,q1,p2,q2,r2)\
-      else  CONSTRUCT_INTERSECTION(p1,q1,r1,q2,r2,p2)\
+  }
+
+
+#define TRI_TRI_INTER_3D(p1,q1,r1,p2,q2,r2,dp2,dq2,dr2) \
+  { \
+    if (dp2 > zero) { \
+      if      (dq2 > zero) CONSTRUCT_INTERSECTION(p1,r1,q1,r2,p2,q2) \
+      else if (dr2 > zero) CONSTRUCT_INTERSECTION(p1,r1,q1,q2,r2,p2) \
+      else                 CONSTRUCT_INTERSECTION(p1,q1,r1,p2,q2,r2) \
+    } else if (dp2 < zero) { \
+      if      (dq2 < zero) CONSTRUCT_INTERSECTION(p1,q1,r1,r2,p2,q2) \
+      else if (dr2 < zero) CONSTRUCT_INTERSECTION(p1,q1,r1,q2,r2,p2) \
+      else                 CONSTRUCT_INTERSECTION(p1,r1,q1,p2,q2,r2) \
+    } else { \
+      if (dq2 < zero) { \
+        if (dr2 >= zero) CONSTRUCT_INTERSECTION(p1,r1,q1,q2,r2,p2) \
+        else             CONSTRUCT_INTERSECTION(p1,q1,r1,p2,q2,r2) \
+      } else if (dq2 > zero) { \
+        if (dr2 > zero) CONSTRUCT_INTERSECTION(p1,r1,q1,p2,q2,r2) \
+        else            CONSTRUCT_INTERSECTION(p1,q1,r1,q2,r2,p2) \
+      } else  { \
+        if      (dr2 > zero) CONSTRUCT_INTERSECTION(p1,q1,r1,r2,p2,q2) \
+        else if (dr2 < zero) CONSTRUCT_INTERSECTION(p1,r1,q1,r2,p2,q2) \
+        else { \
+          *coplanar = 1; \
+          return coplanar_tri_tri3d(p1,q1,r1,p2,q2,r2,N1,N2);\
+        } \
+      } \
     } \
-    else  { \
-      if (dr2 > 0.0f) CONSTRUCT_INTERSECTION(p1,q1,r1,r2,p2,q2)\
-      else if (dr2 < 0.0f) CONSTRUCT_INTERSECTION(p1,r1,q1,r2,p2,q2)\
-      else { \
-       	*coplanar = 1; \
-	return coplanar_tri_tri3d(p1,q1,r1,p2,q2,r2,N1,N2);\
-     } \
-  }} }
-  
+  }
+
 
 /*
    The following version computes the segment of intersection of the
@@ -406,8 +403,6 @@ int tri_tri_intersection_test_3d(real p1[3], real q1[3], real r1[3],
 
   // Compute distance signs  of p1, q1 and r1 
   // to the plane of triangle(p2,q2,r2)
-
-
   SUB(v1,p2,r2)
   SUB(v2,q2,r2)
   CROSS(N2,v1,v2)
@@ -418,13 +413,11 @@ int tri_tri_intersection_test_3d(real p1[3], real q1[3], real r1[3],
   dq1 = DOT(v1,N2);
   SUB(v1,r1,r2)
   dr1 = DOT(v1,N2);
-  
-  if (((dp1 * dq1) > 0.0f) && ((dp1 * dr1) > 0.0f))  return 0; 
+
+  if (((dp1 * dq1) > zero) && ((dp1 * dr1) > zero))  return 0;
 
   // Compute distance signs  of p2, q2 and r2 
   // to the plane of triangle(p1,q1,r1)
-
-  
   SUB(v1,q1,p1)
   SUB(v2,r1,p1)
   CROSS(N1,v1,v2)
@@ -436,54 +429,44 @@ int tri_tri_intersection_test_3d(real p1[3], real q1[3], real r1[3],
   SUB(v1,r2,r1)
   dr2 = DOT(v1,N1);
   
-  if (((dp2 * dq2) > 0.0f) && ((dp2 * dr2) > 0.0f)) return 0;
+  if (((dp2 * dq2) > zero) && ((dp2 * dr2) > zero)) return 0;
 
   // Permutation in a canonical form of T1's vertices
+  if (ZERO_TEST(dp1)) dp1 = zero;
+  if (ZERO_TEST(dq1)) dq1 = zero;
+  if (ZERO_TEST(dr1)) dr1 = zero;
 
+  if (ZERO_TEST(dp2)) dp2 = zero;
+  if (ZERO_TEST(dq2)) dq2 = zero;
+  if (ZERO_TEST(dr2)) dr2 = zero;
 
-  //  printf("d1 = [%f %f %f], d2 = [%f %f %f]\n", dp1, dq1, dr1, dp2, dq2, dr2);
-  /*
-  // added by Aaron
-  if (ZERO_TEST(dp1) || ZERO_TEST(dq1) ||ZERO_TEST(dr1) ||ZERO_TEST(dp2) ||ZERO_TEST(dq2) ||ZERO_TEST(dr2))
-    {
-      coplanar = 1;
-      return 0;
-    }
-  */
-
-
-  if (dp1 > 0.0f) {
-    if (dq1 > 0.0f) TRI_TRI_INTER_3D(r1,p1,q1,p2,r2,q2,dp2,dr2,dq2)
-    else if (dr1 > 0.0f) TRI_TRI_INTER_3D(q1,r1,p1,p2,r2,q2,dp2,dr2,dq2)
-	
-    else TRI_TRI_INTER_3D(p1,q1,r1,p2,q2,r2,dp2,dq2,dr2)
-  } else if (dp1 < 0.0f) {
-    if (dq1 < 0.0f) TRI_TRI_INTER_3D(r1,p1,q1,p2,q2,r2,dp2,dq2,dr2)
-    else if (dr1 < 0.0f) TRI_TRI_INTER_3D(q1,r1,p1,p2,q2,r2,dp2,dq2,dr2)
-    else TRI_TRI_INTER_3D(p1,q1,r1,p2,r2,q2,dp2,dr2,dq2)
+  if (dp1 > zero) {
+    if      (dq1 > zero) TRI_TRI_INTER_3D(r1,p1,q1,p2,r2,q2,dp2,dr2,dq2)
+    else if (dr1 > zero) TRI_TRI_INTER_3D(q1,r1,p1,p2,r2,q2,dp2,dr2,dq2)
+    else                 TRI_TRI_INTER_3D(p1,q1,r1,p2,q2,r2,dp2,dq2,dr2)
+  } else if (dp1 < zero) {
+    if      (dq1 < zero) TRI_TRI_INTER_3D(r1,p1,q1,p2,q2,r2,dp2,dq2,dr2)
+    else if (dr1 < zero) TRI_TRI_INTER_3D(q1,r1,p1,p2,q2,r2,dp2,dq2,dr2)
+    else                 TRI_TRI_INTER_3D(p1,q1,r1,p2,r2,q2,dp2,dr2,dq2)
   } else {
-    if (dq1 < 0.0f) {
-      if (dr1 >= 0.0f) TRI_TRI_INTER_3D(q1,r1,p1,p2,r2,q2,dp2,dr2,dq2)
-      else TRI_TRI_INTER_3D(p1,q1,r1,p2,q2,r2,dp2,dq2,dr2)
+    if (dq1 < zero) {
+      if (dr1 >= zero) TRI_TRI_INTER_3D(q1,r1,p1,p2,r2,q2,dp2,dr2,dq2)
+      else             TRI_TRI_INTER_3D(p1,q1,r1,p2,q2,r2,dp2,dq2,dr2)
     }
-    else if (dq1 > 0.0f) {
-      if (dr1 > 0.0f) TRI_TRI_INTER_3D(p1,q1,r1,p2,r2,q2,dp2,dr2,dq2)
-      else TRI_TRI_INTER_3D(q1,r1,p1,p2,q2,r2,dp2,dq2,dr2)
+    else if (dq1 > zero) {
+      if (dr1 > zero) TRI_TRI_INTER_3D(p1,q1,r1,p2,r2,q2,dp2,dr2,dq2)
+      else            TRI_TRI_INTER_3D(q1,r1,p1,p2,q2,r2,dp2,dq2,dr2)
     }
     else  {
-      if (dr1 > 0.0f) TRI_TRI_INTER_3D(r1,p1,q1,p2,q2,r2,dp2,dq2,dr2)
-      else if (dr1 < 0.0f) TRI_TRI_INTER_3D(r1,p1,q1,p2,r2,q2,dp2,dr2,dq2)
+      if      (dr1 > zero) TRI_TRI_INTER_3D(r1,p1,q1,p2,q2,r2,dp2,dq2,dr2)
+      else if (dr1 < zero) TRI_TRI_INTER_3D(r1,p1,q1,p2,r2,q2,dp2,dr2,dq2)
       else {
-	// triangles are co-planar
-
-	*coplanar = 1;
-	return coplanar_tri_tri3d(p1,q1,r1,p2,q2,r2,N1,N2);
+        *coplanar = 1;
+        return coplanar_tri_tri3d(p1,q1,r1,p2,q2,r2,N1,N2);
       }
     }
   }
 };
-
-
 
 
 
@@ -493,95 +476,101 @@ int tri_tri_intersection_test_3d(real p1[3], real q1[3], real r1[3],
 *
 */
 
-
-/* some 2D macros */
-
+// -----------------------------------------------------------------------------
 #define ORIENT_2D(a, b, c)  ((a[0]-c[0])*(b[1]-c[1])-(a[1]-c[1])*(b[0]-c[0]))
 
+// -----------------------------------------------------------------------------
+#define INTERSECTION_TEST_VERTEX(P1, Q1, R1, P2, Q2, R2) \
+  { \
+    if (ORIENT_2D(R2,P2,Q1) >= zero) { \
+      if (ORIENT_2D(R2,Q2,Q1) <= zero) { \
+        if (ORIENT_2D(P1,P2,Q1) > zero) { \
+          if (ORIENT_2D(P1,Q2,Q1) <= zero) return 1; \
+        } else { \
+          if (ORIENT_2D(P1,P2,R1) >= zero) { \
+            if (ORIENT_2D(Q1,R1,P2) >= zero) return 1; \
+          } \
+        } \
+      } else { \
+        if (ORIENT_2D(P1,Q2,Q1) <= zero) { \
+          if (ORIENT_2D(R2,Q2,R1) <= zero) { \
+            if (ORIENT_2D(Q1,R1,Q2) >= zero) return 1; \
+          } \
+        } \
+      } \
+    } else { \
+      if (ORIENT_2D(R2,P2,R1) >= zero) { \
+        if (ORIENT_2D(Q1,R1,R2) >= zero) { \
+          if (ORIENT_2D(P1,P2,R1) >= zero) return 1;\
+        } else { \
+          if (ORIENT_2D(Q1,R1,Q2) >= zero) { \
+            if (ORIENT_2D(R2,R1,Q2) >= zero) return 1; \
+          } \
+        } \
+      } \
+    } \
+    return 0; \
+  }
 
-#define INTERSECTION_TEST_VERTEX(P1, Q1, R1, P2, Q2, R2) {\
-  if (ORIENT_2D(R2,P2,Q1) >= 0.0f)\
-    if (ORIENT_2D(R2,Q2,Q1) <= 0.0f)\
-      if (ORIENT_2D(P1,P2,Q1) > 0.0f) {\
-	if (ORIENT_2D(P1,Q2,Q1) <= 0.0f) return 1; \
-	else return 0;} else {\
-	if (ORIENT_2D(P1,P2,R1) >= 0.0f)\
-	  if (ORIENT_2D(Q1,R1,P2) >= 0.0f) return 1; \
-	  else return 0;\
-	else return 0;}\
-    else \
-      if (ORIENT_2D(P1,Q2,Q1) <= 0.0f)\
-	if (ORIENT_2D(R2,Q2,R1) <= 0.0f)\
-	  if (ORIENT_2D(Q1,R1,Q2) >= 0.0f) return 1; \
-	  else return 0;\
-	else return 0;\
-      else return 0;\
-  else\
-    if (ORIENT_2D(R2,P2,R1) >= 0.0f) \
-      if (ORIENT_2D(Q1,R1,R2) >= 0.0f)\
-	if (ORIENT_2D(P1,P2,R1) >= 0.0f) return 1;\
-	else return 0;\
-      else \
-	if (ORIENT_2D(Q1,R1,Q2) >= 0.0f) {\
-	  if (ORIENT_2D(R2,R1,Q2) >= 0.0f) return 1; \
-	  else return 0; }\
-	else return 0; \
-    else  return 0; \
- };
+// -----------------------------------------------------------------------------
+#define INTERSECTION_TEST_EDGE(P1, Q1, R1, P2, Q2, R2) \
+  { \
+    if (ORIENT_2D(R2,P2,Q1) >= zero) { \
+      if (ORIENT_2D(P1,P2,Q1) >= zero) { \
+        if (ORIENT_2D(P1,Q1,R2) >= zero) return 1; \
+      } else { \
+        if (ORIENT_2D(Q1,R1,P2) >= zero) { \
+          if (ORIENT_2D(R1,P1,P2) >= zero) return 1; \
+        } \
+      } \
+    } else { \
+      if (ORIENT_2D(R2,P2,R1) >= zero) { \
+        if (ORIENT_2D(P1,P2,R1) >= zero) { \
+          if (ORIENT_2D(P1,R1,R2) >= zero) return 1; \
+          if (ORIENT_2D(Q1,R1,R2) >= zero) return 1; \
+        } \
+      } \
+    } \
+    return 0; \
+  }
 
-
-
-#define INTERSECTION_TEST_EDGE(P1, Q1, R1, P2, Q2, R2) { \
-  if (ORIENT_2D(R2,P2,Q1) >= 0.0f) {\
-    if (ORIENT_2D(P1,P2,Q1) >= 0.0f) { \
-        if (ORIENT_2D(P1,Q1,R2) >= 0.0f) return 1; \
-        else return 0;} else { \
-      if (ORIENT_2D(Q1,R1,P2) >= 0.0f){ \
-	if (ORIENT_2D(R1,P1,P2) >= 0.0f) return 1; else return 0;} \
-      else return 0; } \
-  } else {\
-    if (ORIENT_2D(R2,P2,R1) >= 0.0f) {\
-      if (ORIENT_2D(P1,P2,R1) >= 0.0f) {\
-	if (ORIENT_2D(P1,R1,R2) >= 0.0f) return 1;  \
-	else {\
-	  if (ORIENT_2D(Q1,R1,R2) >= 0.0f) return 1; else return 0;}}\
-      else  return 0; }\
-    else return 0; }}
-
-
-
+// -----------------------------------------------------------------------------
 int ccw_tri_tri_intersection_2d(real p1[2], real q1[2], real r1[2], 
-				                real p2[2], real q2[2], real r2[2])
+				                        real p2[2], real q2[2], real r2[2])
 {
-  if ( ORIENT_2D(p2,q2,p1) >= 0.0f ) {
-    if ( ORIENT_2D(q2,r2,p1) >= 0.0f ) {
-      if ( ORIENT_2D(r2,p2,p1) >= 0.0f ) return 1;
-      else INTERSECTION_TEST_EDGE(p1,q1,r1,p2,q2,r2)
-    } else {  
-      if ( ORIENT_2D(r2,p2,p1) >= 0.0f ) 
-	INTERSECTION_TEST_EDGE(p1,q1,r1,r2,p2,q2)
-      else INTERSECTION_TEST_VERTEX(p1,q1,r1,p2,q2,r2)}}
-  else {
-    if ( ORIENT_2D(q2,r2,p1) >= 0.0f ) {
-      if ( ORIENT_2D(r2,p2,p1) >= 0.0f ) 
-	INTERSECTION_TEST_EDGE(p1,q1,r1,q2,r2,p2)
-      else  INTERSECTION_TEST_VERTEX(p1,q1,r1,q2,r2,p2)}
-    else INTERSECTION_TEST_VERTEX(p1,q1,r1,r2,p2,q2)}
+  if (ORIENT_2D(p2,q2,p1) >= zero) {
+    if (ORIENT_2D(q2,r2,p1) >= zero) {
+      if (ORIENT_2D(r2,p2,p1) >= zero) return 1;
+      INTERSECTION_TEST_EDGE(p1,q1,r1,p2,q2,r2)
+    } else {
+      if (ORIENT_2D(r2,p2,p1) >= zero) INTERSECTION_TEST_EDGE(p1,q1,r1,r2,p2,q2)
+      else                             INTERSECTION_TEST_VERTEX(p1,q1,r1,p2,q2,r2)
+    }
+  } else {
+    if (ORIENT_2D(q2,r2,p1) >= zero) {
+      if (ORIENT_2D(r2,p2,p1) >= zero) INTERSECTION_TEST_EDGE(p1,q1,r1,q2,r2,p2)
+      else                             INTERSECTION_TEST_VERTEX(p1,q1,r1,q2,r2,p2)
+    } else {
+      INTERSECTION_TEST_VERTEX(p1,q1,r1,r2,p2,q2)
+    }
+  }
 };
 
-
+// -----------------------------------------------------------------------------
 int tri_tri_overlap_test_2d(real p1[2], real q1[2], real r1[2], 
-			                real p2[2], real q2[2], real r2[2])
+			                      real p2[2], real q2[2], real r2[2])
 {
-  if ( ORIENT_2D(p1,q1,r1) < 0.0f )
-    if ( ORIENT_2D(p2,q2,r2) < 0.0f )
+  if (ORIENT_2D(p1,q1,r1) < zero) {
+    if (ORIENT_2D(p2,q2,r2) < zero) {
       return ccw_tri_tri_intersection_2d(p1,r1,q1,p2,r2,q2);
-    else
+    } else {
       return ccw_tri_tri_intersection_2d(p1,r1,q1,p2,q2,r2);
-  else
-    if ( ORIENT_2D(p2,q2,r2) < 0.0f )
+    }
+  } else {
+    if (ORIENT_2D(p2,q2,r2) < zero) {
       return ccw_tri_tri_intersection_2d(p1,q1,r1,p2,r2,q2);
-    else
+    } else {
       return ccw_tri_tri_intersection_2d(p1,q1,r1,p2,q2,r2);
-
+    }
+  }
 };


### PR DESCRIPTION
This should be the eventual and proper fix of the false intersection detection issue. Hope we still detect all actual intersections correctly after change of `CHECK_MIN_MAX` macro...

Closes #382.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/421)
<!-- Reviewable:end -->
