### PR TITLE
fix: Remove extract-pointset-surface -join option [Applications]

### DIFF
--- a/Applications/src/extract-pointset-surface.cc
+++ b/Applications/src/extract-pointset-surface.cc
@@ -111,182 +111,6 @@ void PrintHelp(const char *name)
 }
 
 // =============================================================================
-// Auxiliaries
-// =============================================================================
-
-// -----------------------------------------------------------------------------
-inline double SquaredDistance(vtkAbstractPointLocator *locator, double p[3])
-{
-  double q[3];
-  vtkIdType ptId = locator->FindClosestPoint(p);
-  locator->GetDataSet()->GetPoint(ptId, q);
-  return vtkMath::Distance2BetweenPoints(p, q);
-}
-
-// -----------------------------------------------------------------------------
-double SquaredDistance(const BoundarySegment &seg, vtkAbstractPointLocator *locator)
-{
-  double dist2 = inf;
-  if (locator->GetDataSet()->GetNumberOfPoints() > 0) {
-    for (int i = 0; i < seg.NumberOfPoints(); ++i) {
-      dist2 = min(dist2, SquaredDistance(locator, seg.Point(i)));
-    }
-  }
-  return dist2;
-}
-
-// -----------------------------------------------------------------------------
-/// Close sharp tooth-like triangles at intersection boundaries
-void FillIntersectionBoundaries(vtkPolyData *surface, vtkPolyData *intersection, double tolerance)
-{
-  if (intersection->GetNumberOfCells() == 0) return;
-  const double max_dist2 = 5. * tolerance * tolerance;
-
-  surface->BuildLinks();
-  vtkCellArray * const polys  = surface->GetPolys();
-
-  vtkSmartPointer<vtkPointLocator> cut;
-  cut = vtkSmartPointer<vtkPointLocator>::New();
-  cut->SetDataSet(intersection);
-  cut->BuildLocator();
-
-  vtkSmartPointer<vtkIdList> cellIds1 = vtkSmartPointer<vtkIdList>::New();
-  vtkSmartPointer<vtkIdList> cellIds2 = vtkSmartPointer<vtkIdList>::New();
-
-  vtkIdType prvId, curId, nxtId, npts, *pts;
-  Vector3   p, q, m, u, v;
-
-  const double max_angle_deg = 100.;
-  const double min_cos_angle = cos(max_angle_deg * rad_per_deg);
-
-  SurfaceBoundary boundary(surface);
-  for (int j = 0; j < boundary.NumberOfSegments(); ++j) {
-    const auto &seg = boundary.Segment(j);
-    if (SquaredDistance(seg, cut) < max_dist2) {
-      int prvIdx = -1;
-      seg.GetPoint(prvIdx, q);
-      for (int i = 0; i <= seg.NumberOfPoints(); ++i) {
-        seg.GetPoint(i,     p);
-        seg.GetPoint(i + 1, v);
-        u = q - p, v -= p;
-        if (u.Dot(v) >= min_cos_angle) {
-          m = p + .5 * (u + v);
-          if (SquaredDistance(cut, p) > SquaredDistance(cut, m)) {
-            prvId = seg.PointId(prvIdx);
-            curId = seg.PointId(i);
-            nxtId = seg.PointId(i + 1);
-            surface->GetPointCells(prvId, cellIds1);
-            surface->GetPointCells(curId, cellIds2);
-            cellIds1->IntersectWith(cellIds2);
-            if (cellIds1->GetNumberOfIds() > 0) {
-              surface->GetCellPoints(cellIds1->GetId(0), npts, pts);
-              for (vtkIdType k = 0; k < npts; ++k) {
-                if (pts[k] == prvId) {
-                  if (k > 0 || pts[npts-1] != curId) {
-                    swap(curId, prvId);
-                  }
-                  break;
-                }
-                if (pts[k] == curId) {
-                  if (k == 0 && pts[npts-1] == prvId) {
-                    swap(curId, prvId);
-                  }
-                  break;
-                }
-              }
-              polys->InsertNextCell(3);
-              polys->InsertCellPoint(prvId);
-              polys->InsertCellPoint(curId);
-              polys->InsertCellPoint(nxtId);
-            }
-          }
-        } else {
-          prvIdx = i;
-          q = p;
-        }
-      }
-    }
-  }
-
-  surface->DeleteCells();
-}
-
-// -----------------------------------------------------------------------------
-/// Join intersected components at the intersection boundary
-void JoinIntersectionBoundaries(vtkPolyData *surface, vtkPolyData *intersection, double tolerance)
-{
-  if (intersection->GetNumberOfCells() == 0) return;
-
-  vtkCellArray * const polys = surface->GetPolys();
-
-  vtkSmartPointer<vtkPolygon> polygon   = vtkSmartPointer<vtkPolygon>::New();
-  vtkSmartPointer<vtkIdList>  triangles = vtkSmartPointer<vtkIdList>::New();
-  polygon->Points->SetDataTypeToDouble();
-  polygon->Points->Allocate(10);
-  polygon->PointIds->Allocate(10);
-
-  vtkSmartPointer<vtkPointLocator> cut;
-  cut = vtkSmartPointer<vtkPointLocator>::New();
-  cut->SetDataSet(intersection);
-  cut->BuildLocator();
-
-  SurfaceBoundary boundary(surface);
-  while (boundary.NumberOfSegments() > 1) {
-
-    Array<double> dist2(boundary.NumberOfSegments());
-    for (int j = 0; j < boundary.NumberOfSegments(); ++j) {
-      dist2[j] = SquaredDistance(boundary.Segment(j), cut);
-    }
-    const auto &order = IncreasingOrder(dist2);
-    //if (dist2[order[1]] > 5. * tolerance * tolerance) break;
-
-    const auto &seg1 = boundary.Segment(order[0]);
-    const auto &seg2 = boundary.Segment(order[1]);
-
-    // Traverse boundary segment backwards to be consistent with node order
-    // of boundary cells, i.e., surface mesh orientation
-    int i1 = seg1.NumberOfPoints();
-    int j1 = seg2.FindClosestPoint(seg1.Point(i1));
-    for (int i2, j2; i1 > 0; i1 = i2) {
-      polygon->Points->Reset();
-      polygon->PointIds->Reset();
-      i2 = i1 - 1;
-      for (int i = i1; i >= i2; --i) {
-        polygon->Points->InsertNextPoint(seg1.Point(i));
-        polygon->PointIds->InsertNextId(seg1.PointId(i));
-      }
-      j2 = seg2.FindClosestPoint(seg1.Point(i2));
-      if (j1 > j2) j2 += seg2.NumberOfPoints();
-      if ((j2 - j1) < seg2.NumberOfPoints() - (j2 - j1)) {
-        for (int j = j2; j >= j1; --j) {
-          polygon->Points->InsertNextPoint(seg2.Point(j));
-          polygon->PointIds->InsertNextId(seg2.PointId(j));
-        }
-      } else {
-        j1 += seg2.NumberOfPoints();
-        for (int j = j2; j <= j1; ++j) {
-          polygon->Points->InsertNextPoint(seg2.Point(j));
-          polygon->PointIds->InsertNextId(seg2.PointId(j));
-        }
-      }
-      j1 = seg2.IndexModuloNumberOfPoints(j2);
-      polygon->NonDegenerateTriangulate(triangles);
-      for (vtkIdType n = 0; n < triangles->GetNumberOfIds(); n += 3) {
-        polys->InsertNextCell(3);
-        polys->InsertCellPoint(polygon->PointIds->GetId(triangles->GetId(n)));
-        polys->InsertCellPoint(polygon->PointIds->GetId(triangles->GetId(n+1)));
-        polys->InsertCellPoint(polygon->PointIds->GetId(triangles->GetId(n+2)));
-      }
-    }
-
-    surface->DeleteCells();
-
-    break;
-    //boundary = SurfaceBoundary(surface);
-  }
-}
-
-// =============================================================================
 // Shock removal (experimental)
 // =============================================================================
 
@@ -429,7 +253,6 @@ int main(int argc, char *argv[])
   const char *ref_name          = NULL;
   double      resolution        = NaN;
   double      tolerance         = 1e-6;
-  bool        join_intersection = false;
   const char *source_array_name = nullptr;
 
   if (NUM_POSARGS > 0) {
@@ -466,13 +289,6 @@ int main(int argc, char *argv[])
     }
     else if (OPTION("-nomerge")) {
       merge_points_tol = -1.;
-    }
-    else if (OPTION("-join")) {
-      if (HAS_ARGUMENT) PARSE_ARGUMENT(join_intersection);
-      else join_intersection = true;
-    }
-    else if (OPTION("-nojoin")) {
-      join_intersection = false;
     }
     else if (OPTION("-remove-shocks") || OPTION("-removeshocks")) {
       shock_dmap_name = nullptr;
@@ -577,11 +393,6 @@ int main(int argc, char *argv[])
     surface->GetCellData ()->RemoveArray("CellSource");
     surface->GetPointData()->RemoveArray("Distance");
     surface->GetCellData ()->RemoveArray("Distance");
-
-    if (join_intersection) {
-      FillIntersectionBoundaries(surface, joiner->GetOutput(1), tolerance);
-      JoinIntersectionBoundaries(surface, joiner->GetOutput(1), tolerance);
-    }
 
     vtkNew<vtkCleanPolyData> cleaner;
     cleaner->ConvertPolysToLinesOff();


### PR DESCRIPTION
- Add `-merge` and `-tolerance` options.
- Remove `-join` option. Use `merge-surfaces` tool instead (see #379).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/425)
<!-- Reviewable:end -->
