### PR TITLE
fix: Emit IterationEndEvent also when optimization converged

### DIFF
--- a/Modules/Numerics/include/mirtk/LocalOptimizer.h
+++ b/Modules/Numerics/include/mirtk/LocalOptimizer.h
@@ -49,7 +49,7 @@ class LocalOptimizer : public Observable
   /// Objective function
   mirtkPublicAggregateMacro(ObjectiveFunction, Function);
 
-  /// Maximum number of gradient steps
+  /// Maximum number of iterative steps
   mirtkPublicAttributeMacro(int, NumberOfSteps);
 
   /// First convergence criterium: Required minimum change of objective function
@@ -57,6 +57,9 @@ class LocalOptimizer : public Observable
 
   /// Second convergence criterium: Required maximum change of DoFs
   mirtkPublicAttributeMacro(double, Delta);
+
+  /// Whether optimization converged within maximum number of steps
+  mirtkReadOnlyAttributeMacro(bool, Converged);
 
   /// List of stopping criteria
   Array<class StoppingCriterion *> _StoppingCriteria;

--- a/Modules/Numerics/src/GradientDescent.cc
+++ b/Modules/Numerics/src/GradientDescent.cc
@@ -262,7 +262,8 @@ double GradientDescent::Run()
     const int iter = step.Iter();
 
     // Descent along computed gradient
-    while (step.Next()) {
+    _Converged = false;
+    while (!_Converged && step.Next()) {
 
       // Notify observers about start of gradient descent iteration
       Broadcast(IterationStartEvent, &step);
@@ -295,13 +296,13 @@ double GradientDescent::Run()
       // Perform line search along computed gradient direction
       value = _LineSearch->Run();
 
-      // Check convergence
-      if (value == _LineSearch->CurrentValue()) break;
-      if (Converged(step.Iter(), _LineSearch->CurrentValue(), value, _Gradient)) break;
-
       // Adjust epsilon if relative to current best value, i.e.,
       // epsilon parameter is set to a negative value
       if (_Epsilon < .0) _LineSearch->Epsilon(abs(_Epsilon * value));
+
+      // Check convergence
+      _Converged = (value == _LineSearch->CurrentValue())
+          || Converged(step.Iter(), _LineSearch->CurrentValue(), value, _Gradient);
 
       // Notify observers about end of gradient descent iteration
       Broadcast(IterationEndEvent, &step);

--- a/Modules/Numerics/src/LocalOptimizer.cc
+++ b/Modules/Numerics/src/LocalOptimizer.cc
@@ -64,7 +64,8 @@ LocalOptimizer::LocalOptimizer(ObjectiveFunction *f)
   _Function(f),
   _NumberOfSteps(100),
   _Epsilon(1e-4),
-  _Delta(1e-12)
+  _Delta(1e-12),
+  _Converged(false)
 {
 }
 
@@ -75,6 +76,7 @@ void LocalOptimizer::CopyAttributes(const LocalOptimizer &other)
   _NumberOfSteps = other._NumberOfSteps;
   _Epsilon       = other._Epsilon;
   _Delta         = other._Delta;
+  _Converged     = other._Converged;
 
   ClearStoppingCriteria();
   for (int i = 0; i < other.NumberOfStoppingCriteria(); ++i) {
@@ -126,6 +128,7 @@ void LocalOptimizer::Initialize()
     criterion->Function(_Function);
     criterion->Initialize();
   }
+  _Converged = false;
 }
 
 // =============================================================================

--- a/Modules/Registration/include/mirtk/GenericRegistrationLogger.h
+++ b/Modules/Registration/include/mirtk/GenericRegistrationLogger.h
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2016 Imperial College London
+ * Copyright 2013-2016 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,10 +48,9 @@ class GenericRegistrationLogger : public Observer
   /// Whether to flush stream buffer after each printed message
   mirtkPublicAttributeMacro(bool, FlushBuffer);
 
-  bool _Converged;             ///< Track whether line search converged
-  int  _NumberOfIterations;    ///< Number of actual line search iterations
-  int  _NumberOfSteps;         ///< Number of iterative line search steps
-  int  _NumberOfGradientSteps; ///< Number of gradient descent steps
+  int _NumberOfIterations;    ///< Number of actual line search iterations
+  int _NumberOfSteps;         ///< Number of iterative line search steps
+  int _NumberOfGradientSteps; ///< Number of gradient descent steps
 
   // ---------------------------------------------------------------------------
   // Construction/Destruction

--- a/Modules/Registration/src/GenericRegistrationLogger.cc
+++ b/Modules/Registration/src/GenericRegistrationLogger.cc
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2016 Imperial College London
+ * Copyright 2013-2016 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -301,7 +301,6 @@ void GenericRegistrationLogger::HandleEvent(Observable *obj, Event event, const 
       }
       _NumberOfIterations = 0;
       _NumberOfSteps      = 0;
-      _Converged          = false;
       break;
     }
 
@@ -310,10 +309,6 @@ void GenericRegistrationLogger::HandleEvent(Observable *obj, Event event, const 
         if (debug_time) os << "\nStep " << left << setw(3) << iter->Count() << "\n";
         else            os <<   "     " << setw(3) << iter->Count() << "   ";
       }
-      // If this event is followed by LineSearchEndEvent without a
-      // LineSearchIterationEndEvent before, one of the convergence
-      // criteria must have been fullfilled
-      _Converged = true;
       break;
 
     case AcceptedStepEvent:
@@ -342,7 +337,6 @@ void GenericRegistrationLogger::HandleEvent(Observable *obj, Event event, const 
         os << "\n              Maximum number of iterations exceeded\n";
         if (_Color) os << xreset;
       }
-      _Converged = false;
       break;
     }
 
@@ -386,7 +380,8 @@ void GenericRegistrationLogger::HandleEvent(Observable *obj, Event event, const 
 
     // End of optimization, but before GenericRegistrationFilter::Finalize
     case EndEvent: {
-      HomogeneousTransformation *lin = dynamic_cast<HomogeneousTransformation *>(reg->_Transformation);
+      HomogeneousTransformation *lin;
+      lin = dynamic_cast<HomogeneousTransformation *>(reg->_Transformation);
       if (lin) {
         bool print_params;
         if (_Verbosity > 0) {


### PR DESCRIPTION
Add `_Converged` attribute to `LocalOptimizer` base class which may be used by observers such as the logger classes to determine whether the optimization converged due to a stopping criterion or if the max. number of iterations was reached.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/427)
<!-- Reviewable:end -->
