### PR TITLE
fix: DeformableSurfaceModel::ResolveSurfaceCollisions

### DIFF
--- a/Modules/PointSet/include/mirtk/SurfaceCollisions.h
+++ b/Modules/PointSet/include/mirtk/SurfaceCollisions.h
@@ -234,6 +234,9 @@ private:
   /// Whether to store detailed information about found collisions
   mirtkPublicAttributeMacro(bool, StoreCollisionDetails);
 
+  /// Whether to clear collision type for unchecked triangles (cf. _Mask)
+  mirtkPublicAttributeMacro(bool, ResetCollisionType);
+
   /// Found self-intersections per face
   /// \note Only non-empty after Run when _StoreIntersectionDetails is \c true.
   mirtkReadOnlyAttributeMacro(IntersectionsArray, Intersections);
@@ -336,6 +339,9 @@ public:
 
   /// Enable/disable storage of details about found intersections
   mirtkOnOffMacro(StoreCollisionDetails);
+
+  /// Enable/disable resetting of optional input collision type array
+  mirtkOnOffMacro(ResetCollisionType);
 
 };
 

--- a/Modules/PointSet/include/mirtk/Triangle.h
+++ b/Modules/PointSet/include/mirtk/Triangle.h
@@ -41,8 +41,18 @@ public:
   /// \param[in]  a      Position of triangle vertex A.
   /// \param[in]  b      Position of triangle vertex B.
   /// \param[in]  c      Position of triangle vertex C.
-  /// \param[out] center Positoin of triangle center.
+  /// \param[out] center Position of triangle center.
   static void Center(const double a[3], const double b[3], const double c[3], double center[3]);
+
+  /// Compute center point of triangle
+  ///
+  /// \param[in]  a      Position of triangle vertex A.
+  /// \param[in]  b      Position of triangle vertex B.
+  /// \param[in]  c      Position of triangle vertex C.
+  /// \param[out] center Position of triangle center.
+  ///
+  /// \returns Radius of bounding sphere with optionally returned \p center point.
+  static double BoundingSphereRadius(const double a[3], const double b[3], const double c[3], double *center = nullptr);
 
   /// Compute normal direction of triangle
   ///
@@ -245,6 +255,17 @@ inline void Triangle::Center(const double a[3], const double b[3], const double 
   center[0] = (a[0] + b[0] + c[0]) / 3.0;
   center[1] = (a[1] + b[1] + c[1]) / 3.0;
   center[2] = (a[2] + b[2] + c[2]) / 3.0;
+}
+
+//----------------------------------------------------------------------------
+inline double Triangle::BoundingSphereRadius(const double a[3], const double b[3], const double c[3], double *center)
+{
+  double p[3];
+  Center(a, b, c, p);
+  if (center) memcpy(center, p, 3 * sizeof(double));
+  return sqrt(max(max(vtkMath::Distance2BetweenPoints(a, p),
+                      vtkMath::Distance2BetweenPoints(b, p)),
+                      vtkMath::Distance2BetweenPoints(c, p)));
 }
 
 // =============================================================================

--- a/Modules/PointSet/src/SurfaceCollisions.cc
+++ b/Modules/PointSet/src/SurfaceCollisions.cc
@@ -425,6 +425,7 @@ void SurfaceCollisions::CopyAttributes(const SurfaceCollisions &other)
   _FastCollisionTest           = other._FastCollisionTest;
   _StoreIntersectionDetails    = other._StoreIntersectionDetails;
   _StoreCollisionDetails       = other._StoreCollisionDetails;
+  _ResetCollisionType          = other._ResetCollisionType;
   _Intersections               = other._Intersections;
   _Collisions                  = other._Collisions;
 }
@@ -444,7 +445,8 @@ SurfaceCollisions::SurfaceCollisions()
   _BackfaceCollisionTest(false),
   _FastCollisionTest(false),
   _StoreIntersectionDetails(true),
-  _StoreCollisionDetails(true)
+  _StoreCollisionDetails(true),
+  _ResetCollisionType(true)
 {
 }
 
@@ -557,6 +559,7 @@ void SurfaceCollisions::Initialize()
 
   // Precompute bounding spheres and prepare auxiliary data arrays
   bool compute_bounding_spheres = !_UseInputBoundingSpheres;
+  bool reset_collision_types    = _ResetCollisionType;
   vtkSmartPointer<vtkDataArray> center, radius, types;
   center = _Output->GetCellData()->GetArray("BoundingSphereCenter");
   radius = _Output->GetCellData()->GetArray("BoundingSphereRadius");
@@ -583,8 +586,11 @@ void SurfaceCollisions::Initialize()
     types->SetNumberOfComponents(1);
     types->SetNumberOfTuples(_Output->GetNumberOfCells());
     types->SetName("CollisionType");
-    types->FillComponent(0, static_cast<double>(NoCollision));
     _Output->GetCellData()->AddArray(types);
+    reset_collision_types = true;
+  }
+  if (reset_collision_types) {
+    types->FillComponent(0, static_cast<double>(NoCollision));
   }
 
   if (_StoreIntersectionDetails && (_AdjacentIntersectionTest || _NonAdjacentIntersectionTest)) {


### PR DESCRIPTION
Recheck collisions for nearby triangles, no matter their connectivity to the previously collided cells.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/428)
<!-- Reviewable:end -->
