### PR TITLE
enh: Process cell data with calculate-element-wise, -map option

### DIFF
--- a/Applications/src/calculate-element-wise.cc
+++ b/Applications/src/calculate-element-wise.cc
@@ -172,6 +172,10 @@ void PrintHelp(const char *name)
   cout << "      Clamp values greater than a given percentile.\n";
   cout << "  -rescale <min> <max>\n";
   cout << "      Linearly rescale values to the interval [min, max].\n";
+  cout << "  -map <from> <to>...\n";
+  cout << "      Replaces values equal to <from> by the specified <to> value. Multiple pairs of <from>\n";
+  cout << "      and <to> value replacements can be specified in order to perform the substitutions in\n";
+  cout << "      one step. For example, to swap the two values 1 and 2, use ``-map 1 2 2 1``.\n";
   cout << "\n";
   cout << "Arithmetic operation options:\n";
   cout << "  -add, -plus <value> | <file> [<scalars>]\n";
@@ -629,6 +633,17 @@ int main(int argc, char **argv)
       if (HAS_ARGUMENT) PARSE_ARGUMENT(b);
       else b = inf;
       ops.push_back(UniquePtr<Op>(new Binarize(a, b)));
+    } else if (OPTION("-map")) {
+      UniquePtr<Map> map(new Map());
+      do {
+        const char * const arg1 = ARGUMENT;
+        const char * const arg2 = ARGUMENT;
+        if (!FromString(arg1, a) || !FromString(arg2, b)) {
+          FatalError("Arguments of -map option must be pairs of two numbers (i.e., number of arguments must be even)!");
+        }
+        map->Insert(a, b);
+      } while (HAS_ARGUMENT);
+      ops.push_back(UniquePtr<Op>(map.release()));
     } else if (OPTION("-add") || OPTION("-plus") || OPTION("+")) {
       const char *arg = ARGUMENT;
       double c;

--- a/Modules/Image/include/mirtk/DataFunctions.h
+++ b/Modules/Image/include/mirtk/DataFunctions.h
@@ -595,6 +595,42 @@ public:
 };
 
 // -----------------------------------------------------------------------------
+/// Map values (e.g. segmentation labels)
+class Map : public ElementWiseUnaryOp
+{
+  typedef UnorderedMap<double, double> ValueMapType;
+
+  /// Map of values
+  mirtkAttributeMacro(ValueMapType, ValueMap);
+
+public:
+
+  /// Insert map from a to b
+  void Insert(double a, double b)
+  {
+    _ValueMap[a] = b;
+  }
+
+  /// Transform data value and/or mask data value by setting *mask = false
+  virtual double Op(double value, bool &) const
+  {
+    auto it = _ValueMap.find(value);
+    if (it != _ValueMap.end()) {
+      return it->second;
+    } else {
+      return value;
+    }
+  }
+
+  /// Process given data (not thread-safe!)
+  virtual void Process(int n, double *data, bool *mask = NULL)
+  {
+    ElementWiseUnaryOp::Process(n, data, mask);
+    parallel_for(blocked_range<int>(0, n), *this);
+  }
+};
+
+// -----------------------------------------------------------------------------
 /// Mask values
 class Mask : public ElementWiseBinaryOp
 {

--- a/Modules/Image/include/mirtk/DataFunctions.h
+++ b/Modules/Image/include/mirtk/DataFunctions.h
@@ -192,8 +192,11 @@ class ElementWiseBinaryOp : public Op
   mirtkPublicAttributeMacro(string, FileName);
 
 #if MIRTK_Image_WITH_VTK
-  /// Name of input point data array
+  /// Name of input point/cell data array
   mirtkPublicAttributeMacro(string, ArrayName);
+
+  /// Whether input array is cell data
+  mirtkPublicAttributeMacro(bool, IsCellData);
 #endif
 
 private:
@@ -218,9 +221,9 @@ protected:
 
 #if MIRTK_Image_WITH_VTK
   /// Constructor
-  ElementWiseBinaryOp(const char *fname, const char *aname)
+  ElementWiseBinaryOp(const char *fname, const char *aname, bool cell_data = false)
   :
-    _Constant(.0), _FileName(fname), _ArrayName(aname ? aname : ""), _Other(nullptr)
+    _Constant(.0), _FileName(fname), _ArrayName(aname ? aname : ""), _IsCellData(cell_data), _Other(nullptr)
   {}
 #endif
 
@@ -276,7 +279,7 @@ protected:
     if (!_FileName.empty()) {
       if (n !=
       #if MIRTK_Image_WITH_VTK
-        Read(_FileName.c_str(), _Other, nullptr, nullptr, nullptr, _ArrayName.c_str())
+        Read(_FileName.c_str(), _Other, nullptr, nullptr, nullptr, _ArrayName.c_str(), _IsCellData)
       #else
         Read(_FileName.c_str(), _Other)
       #endif

--- a/Modules/Image/include/mirtk/DataOp.h
+++ b/Modules/Image/include/mirtk/DataOp.h
@@ -114,7 +114,8 @@ DataFileType FileType(const char *name);
 /// Read data sequence from any supported input file type
 #if MIRTK_Image_WITH_VTK
 int Read(const char *name, double *&data, int *dtype = nullptr, ImageAttributes *attr = nullptr,
-         vtkSmartPointer<vtkDataSet> *dataset= nullptr, const char *scalar_name = nullptr);
+         vtkSmartPointer<vtkDataSet> *dataset = nullptr,
+         const char *scalars_name = nullptr, bool cell_data = false);
 #else
 int Read(const char *name, double *&data, int *dtype = nullptr, ImageAttributes *attr = nullptr);
 #endif // MIRTK_Image_WITH_VTK
@@ -131,11 +132,14 @@ class Write : public Op
   /// VTK input dataset whose scalar data was modified
   mirtkPublicAttributeMacro(vtkSmartPointer<vtkDataSet>, DataSet);
 
-  /// Name of input point data array
+  /// Name of input data array
   mirtkPublicAttributeMacro(string, ArrayName);
 
-  /// Name of output point data array
+  /// Name of output data array
   mirtkPublicAttributeMacro(string, OutputName);
+
+  /// Whether to add data as cell data instead of point data
+  mirtkPublicAttributeMacro(bool, AsCellData);
 
 #endif // MIRTK_Image_WITH_VTK
 
@@ -154,10 +158,12 @@ public:
         ImageAttributes attr = ImageAttributes(),
         vtkDataSet *dataset     = nullptr,
         const char *array_name  = nullptr,
-        const char *output_name = nullptr)
+        const char *output_name = nullptr,
+        bool        cell_data   = false)
   :
     _FileName(fname),
     _DataSet(dataset),
+    _AsCellData(cell_data),
     _Attributes(attr),
     _DataType(dtype)
   {


### PR DESCRIPTION
This change enables the use of the `calculate-element-wise` tool to process cell data of a VTK data set. It further adds a new `-map` option which can be used to change/swap segmentation labels.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/429)
<!-- Reviewable:end -->
