### PR TITLE
enh: deform-mesh

### DIFF
--- a/Modules/Common/include/mirtk/EnergyMeasure.h
+++ b/Modules/Common/include/mirtk/EnergyMeasure.h
@@ -87,6 +87,7 @@ enum EnergyMeasure
     EM_RepulsiveForce,          ///< Repels too close non-neighboring nodes
     EM_InflationForce,          ///< Inflate point set surface
     EM_SpringForce,             ///< Spring force
+    EM_NormalForce,             ///< Constant force in normal direction
 
   IFT_End,
   // ---------------------------------------------------------------------------
@@ -160,6 +161,7 @@ inline string ToString(const EnergyMeasure &value, int w, char c, bool left)
     case EM_RepulsiveForce:      str = "Repulsion"; break;
     case EM_InflationForce:      str = "Inflation"; break;
     case EM_SpringForce:         str = "Spring"; break;
+    case EM_NormalForce:         str = "NormalForce"; break;
 
     // -------------------------------------------------------------------------
     // Transformation constraints
@@ -230,6 +232,7 @@ inline string ToPrettyString(const EnergyMeasure &value, int w = 0, char c = ' '
     case EM_RepulsiveForce:      str = "Repulsion"; break;
     case EM_InflationForce:      str = "Inflation"; break;
     case EM_SpringForce:         str = "Spring"; break;
+    case EM_NormalForce:         str = "Normal"; break;
 
     // -------------------------------------------------------------------------
     // Transformation constraints

--- a/Modules/PointSet/include/mirtk/ImplicitSurfaceUtils.h
+++ b/Modules/PointSet/include/mirtk/ImplicitSurfaceUtils.h
@@ -94,7 +94,7 @@ inline double Evaluate(const DistanceFunction &dist, const double p[3], double o
     x = clamp(x, xmin, xmax);
     y = clamp(y, ymin, ymax);
     z = clamp(z, zmin, zmax);
-    d = dist.GetInside(x, y, z);
+    d = max(0., dist.GetInside(x, y, z));
     dist.ImageToWorld(x, y, z);
     x -= p[0], y -= p[1], z -= p[2];
     d += sqrt(x*x + y*y + z*z);

--- a/Modules/PointSet/include/mirtk/RegisteredPointSet.h
+++ b/Modules/PointSet/include/mirtk/RegisteredPointSet.h
@@ -351,6 +351,9 @@ public:
   /// (cf. BuildNeighborhoodTables).
   const NodeNeighbors *Neighbors(int = -1) const;
 
+  /// Get initial point status array if any
+  vtkDataArray *InitialStatus() const;
+
   /// Get point status array if any
   vtkDataArray *Status() const;
 
@@ -408,6 +411,9 @@ public:
   /// with a neighborhood radius greater or equal the requested minimum radius
   /// (cf. BuildNeighborhoodTables).
   const NodeNeighbors *SurfaceNeighbors(int = -1) const;
+
+  /// Get point status array if any
+  vtkDataArray *InitialSurfaceStatus() const;
 
   /// Get point status array if any
   vtkDataArray *SurfaceStatus() const;

--- a/Modules/PointSet/src/RegisteredPointSet.cc
+++ b/Modules/PointSet/src/RegisteredPointSet.cc
@@ -587,6 +587,12 @@ void RegisteredPointSet::GetPoints(class PointSet &pset) const
 }
 
 // -----------------------------------------------------------------------------
+vtkDataArray *RegisteredPointSet::InitialStatus() const
+{
+  return _OutputPointSet->GetPointData()->GetArray("InitialStatus");
+}
+
+// -----------------------------------------------------------------------------
 vtkDataArray *RegisteredPointSet::Status() const
 {
   return _OutputPointSet->GetPointData()->GetArray("Status");
@@ -695,6 +701,12 @@ const RegisteredPointSet::NodeNeighbors *RegisteredPointSet::SurfaceNeighbors(in
     _SurfaceNodeNeighbors.Initialize(_InputSurface, max(n, _NeighborhoodRadius), &_SurfaceEdgeTable);
   }
   return &_SurfaceNodeNeighbors;
+}
+
+// -----------------------------------------------------------------------------
+vtkDataArray *RegisteredPointSet::InitialSurfaceStatus() const
+{
+  return _OutputSurface->GetPointData()->GetArray("InitialStatus");
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
- Fix implicit surface distance when outside volume.
- Use `InitialStatus` for `-reset-status` and to save evaluation of implicit surface distance.
- Add `NormalForce`.
- Add `-fix-boundary` option.
- Add option to limit maximum point distance from input surface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biomedia/mirtk/431)
<!-- Reviewable:end -->
