### PR TITLE
compilation error

### DIFF
--- a/Modules/IO/include/mirtk/PointSetIO.h
+++ b/Modules/IO/include/mirtk/PointSetIO.h
@@ -27,12 +27,12 @@
 #include "vtkDataSet.h"
 #include "vtkPointSet.h"
 #include "vtkPolyData.h"
+#include "vtkPointData.h"
+#include "vtkCellArray.h"
 
 #if MIRTK_IO_WITH_GIFTI
   #include "vtkPoints.h"
-  #include "vtkCellArray.h"
   #include "vtkDataArray.h"
-  #include "vtkPointData.h"
   #include "vtkInformationStringKey.h"
   #include "vtkInformationIntegerKey.h"
   #include "vtkInformationDoubleKey.h"


### PR DESCRIPTION
I moved the 2 includes outside the if, because the compiler gives me an error "invalid use of incomplete type" when compiling without MIRTK_IO_WITH_GIFTI
