### PR TITLE
enh: Add morphological image Closing filter [Image]

### DIFF
--- a/Applications/src/close-image.cc
+++ b/Applications/src/close-image.cc
@@ -22,9 +22,7 @@
 #include "mirtk/Options.h"
 
 #include "mirtk/IOConfig.h"
-
-#include "mirtk/Dilation.h"
-#include "mirtk/Erosion.h"
+#include "mirtk/Closing.h"
 
 using namespace mirtk;
 
@@ -52,64 +50,6 @@ void PrintHelp(const char *name)
   PrintStandardOptions(cout);
   cout << "\n";
   cout.flush();
-}
-
-// =============================================================================
-// Auxiliaries
-// =============================================================================
-
-// -----------------------------------------------------------------------------
-template <class TVoxel>
-void Close(BaseImage *image, int iterations, ConnectivityType connectivity)
-{
-  int i1, j1, k1, i2, j2, k2;
-  image->PutBackgroundValueAsDouble(.0);
-  image->BoundingBox(i1, j1, k1, i2, j2, k2);
-
-  i1 -= iterations;
-  j1 -= iterations;
-  k1 -= iterations;
-  i2 += iterations;
-  j2 += iterations;
-  k2 += iterations;
-
-  if (i1 < 0 || i2 >= image->X() ||
-      j1 < 0 || j2 >= image->Y() ||
-      k1 < 0 || k2 >= image->Z()) {
-
-    GenericImage<TVoxel> padded(i2 - i1 + 1, j2 - j1 + 1, k2 - k1 + 1);
-
-    i1 += iterations;
-    j1 += iterations;
-    k1 += iterations;
-    i2 -= iterations;
-    j2 -= iterations;
-    k2 -= iterations;
-
-    for (int k = k1; k <= k2; ++k)
-    for (int j = j1; j <= j2; ++j)
-    for (int i = i1; i <= i2; ++i) {
-      padded(i - i1 + iterations, j - j1 + iterations, k - k1 + iterations)
-          = static_cast<TVoxel>(image->GetAsDouble(i, j, k));
-    }
-
-    Dilate<TVoxel>(&padded, iterations, connectivity);
-    Erode <TVoxel>(&padded, iterations, connectivity);
-
-    for (int k = k1; k <= k2; ++k)
-    for (int j = j1; j <= j2; ++j)
-    for (int i = i1; i <= i2; ++i) {
-      image->PutAsDouble(i, j, k, static_cast<double>(padded(i - i1 + iterations,
-                                                             j - j1 + iterations,
-                                                             k - k1 + iterations)));
-    }
-
-  } else {
-
-    Dilate<TVoxel>(image, iterations, connectivity);
-    Erode <TVoxel>(image, iterations, connectivity);
-
-  }
 }
 
 // =============================================================================

--- a/Modules/Image/include/mirtk/Closing.h
+++ b/Modules/Image/include/mirtk/Closing.h
@@ -1,7 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2008-2015 Imperial College London
+ * Copyright 2016 Imperial College London
+ * Copyright 2016 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +17,8 @@
  * limitations under the License.
  */
 
-#ifndef MIRTK_Erosion_H
-#define MIRTK_Erosion_H
+#ifndef MIRTK_Closing_H
+#define MIRTK_Closing_H
 
 #include "mirtk/ImageToImage.h"
 
@@ -29,33 +30,33 @@ namespace mirtk {
 
 
 /**
- * morphological erosion of images.
+ * morphological closing of images.
  */
 template <class TVoxel>
-class Erosion : public ImageToImage<TVoxel>
+class Closing : public ImageToImage<TVoxel>
 {
-  mirtkImageFilterMacro(Erosion, TVoxel);
+  mirtkInPlaceImageFilterMacro(Closing, TVoxel);
 
   /// What connectivity to assume when running the filter.
   mirtkPublicAttributeMacro(ConnectivityType, Connectivity);
 
-  /// List of voxel offsets of the neighborhood
-  mirtkAttributeMacro(NeighborhoodOffsets, Offsets);
+  /// Number of dilation/erosion iterations
+  mirtkPublicAttributeMacro(int, NumberOfIterations);
 
 public:
 
   /// Constructor
-  Erosion();
+  Closing();
 
   /// Destructor
-  virtual ~Erosion();
+  virtual ~Closing();
 
   /// Run erosion
   virtual void Run();
 
 protected:
 
-  /// Initialize the filter
+  /// Initialize filter
   virtual void Initialize();
 
 };
@@ -63,18 +64,19 @@ protected:
 
 // -----------------------------------------------------------------------------
 template <class TVoxel>
-void Erode(BaseImage *image, int iterations, ConnectivityType connectivity)
+void Close(BaseImage *image, int iterations, ConnectivityType connectivity)
 {
   GenericImage<TVoxel> * const im = dynamic_cast<GenericImage<TVoxel> *>(image);
   mirtkAssert(im != nullptr, "template function called with correct type");
-  Erosion<TVoxel> erosion;
-  erosion.Connectivity(connectivity);
-  erosion.Input (im);
-  erosion.Output(im);
-  for (int i = 0; i < iterations; ++i) erosion.Run();
+  Closing<TVoxel> closing;
+  closing.Connectivity(connectivity);
+  closing.NumberOfIterations(iterations);
+  closing.Input (im);
+  closing.Output(im);
+  closing.Run();
 }
 
 
 } // namespace mirtk
 
-#endif // MIRTK_Erosion_H
+#endif // MIRTK_Closing_H

--- a/Modules/Image/include/mirtk/Dilation.h
+++ b/Modules/Image/include/mirtk/Dilation.h
@@ -21,6 +21,7 @@
 
 #include "mirtk/ImageToImage.h"
 
+#include "mirtk/Assert.h"
 #include "mirtk/NeighborhoodOffsets.h"
 
 

--- a/Modules/Image/src/CMakeLists.txt
+++ b/Modules/Image/src/CMakeLists.txt
@@ -38,6 +38,7 @@ set(HEADERS
   BSplineInterpolateImageFunction4D.h
   BSplineInterpolateImageFunction4D.hxx
   CityBlockDistanceTransform.h
+  Closing.h
   ConnectedComponents.h
   ConstExtrapolateImageFunction.h
   ConstExtrapolateImageFunctionWithPeriodicTime.h
@@ -183,6 +184,7 @@ set(SOURCES
   DifferenceOfCompositionLieBracketImageFilter3D.cc
   Dilation.cc
   DisplacementToVelocityFieldBCH.cc
+  Closing.cc
   ConnectedComponents.cc
   Downsampling.cc
   Erosion.cc

--- a/Modules/Image/src/Closing.cc
+++ b/Modules/Image/src/Closing.cc
@@ -1,0 +1,139 @@
+/*
+ * Medical Image Registration ToolKit (MIRTK)
+ *
+ * Copyright 2016 Imperial College London
+ * Copyright 2016 Andreas Schuh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mirtk/Closing.h"
+#include "mirtk/Dilation.h"
+#include "mirtk/Erosion.h"
+
+
+namespace mirtk {
+
+
+// =============================================================================
+// Construction/Destruction
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+template <class VoxelType>
+Closing<VoxelType>::Closing()
+:
+  _Connectivity(ConnectivityType::CONNECTIVITY_26),
+  _NumberOfIterations(1)
+{
+}
+
+// -----------------------------------------------------------------------------
+template <class VoxelType>
+Closing<VoxelType>::~Closing()
+{
+}
+
+// =============================================================================
+// Execution
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+template <class VoxelType>
+void Closing<VoxelType>::Initialize()
+{
+  ImageToImage<VoxelType>::Initialize(false);
+  *this->_Output = *this->_Input;
+}
+
+// -----------------------------------------------------------------------------
+template <class VoxelType>
+void Closing<VoxelType>::Run()
+{
+  this->Initialize();
+
+  ImageType * const output = this->_Output;
+
+  const double bg_val = output->GetBackgroundValueAsDouble();
+  const bool   bg_set = output->HasBackgroundValue();
+
+  int i1, j1, k1, i2, j2, k2;
+  output->PutBackgroundValueAsDouble(.0);
+  output->BoundingBox(i1, j1, k1, i2, j2, k2);
+
+  if (bg_set) {
+    output->PutBackgroundValueAsDouble(bg_val);
+  } else {
+    output->ClearBackgroundValue();
+  }
+
+  i1 -= _NumberOfIterations;
+  j1 -= _NumberOfIterations;
+  k1 -= _NumberOfIterations;
+  i2 += _NumberOfIterations;
+  j2 += _NumberOfIterations;
+  k2 += _NumberOfIterations;
+
+  if (i1 < 0 || i2 >= output->X() ||
+      j1 < 0 || j2 >= output->Y() ||
+      k1 < 0 || k2 >= output->Z()) {
+
+    GenericImage<VoxelType> padded(i2 - i1 + 1, j2 - j1 + 1, k2 - k1 + 1);
+
+    i1 += _NumberOfIterations;
+    j1 += _NumberOfIterations;
+    k1 += _NumberOfIterations;
+    i2 -= _NumberOfIterations;
+    j2 -= _NumberOfIterations;
+    k2 -= _NumberOfIterations;
+
+    for (int k = k1; k <= k2; ++k)
+    for (int j = j1; j <= j2; ++j)
+    for (int i = i1; i <= i2; ++i) {
+      padded(i - i1 + _NumberOfIterations,
+             j - j1 + _NumberOfIterations,
+             k - k1 + _NumberOfIterations)
+          = static_cast<VoxelType>(output->GetAsDouble(i, j, k));
+    }
+
+    Dilate<VoxelType>(&padded, _NumberOfIterations, _Connectivity);
+    Erode <VoxelType>(&padded, _NumberOfIterations, _Connectivity);
+
+    for (int k = k1; k <= k2; ++k)
+    for (int j = j1; j <= j2; ++j)
+    for (int i = i1; i <= i2; ++i) {
+      output->PutAsDouble(i, j, k, static_cast<double>(padded(i - i1 + _NumberOfIterations,
+                                                              j - j1 + _NumberOfIterations,
+                                                              k - k1 + _NumberOfIterations)));
+    }
+
+  } else {
+
+    Dilate<VoxelType>(output, _NumberOfIterations, _Connectivity);
+    Erode <VoxelType>(output, _NumberOfIterations, _Connectivity);
+
+  }
+
+  this->Finalize();
+}
+
+// =============================================================================
+// Explicit template instantiations
+// =============================================================================
+
+template class Closing<BytePixel>;
+template class Closing<GreyPixel>;
+template class Closing<RealPixel>;
+
+
+} // namespace mirtk


### PR DESCRIPTION
Make code used by `close-image` to pad the image before the dilation/erosion available as filter.