### PR TITLE
fix: All tools accept the common options (even if ignored) [Applications]

### DIFF
--- a/Applications/src/average-dofs.cc
+++ b/Applications/src/average-dofs.cc
@@ -266,7 +266,7 @@ int main(int argc, char **argv)
     else if (OPTION("-add-identity-with-weight")) { PARSE_ARGUMENT(identity_value); }
     else if (OPTION("-add-identity-for-dofname")) { identity_name  = ARGUMENT; }
     else if (OPTION("-max-frechet-iterations")) PARSE_ARGUMENT(frechet_iter);
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   if (sigma < .0) {

--- a/Applications/src/close-image.cc
+++ b/Applications/src/close-image.cc
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
     else if (OPTION("-connectivity") || OPTION("-neighbors") || OPTION("-number-of-neighbors")) {
       PARSE_ARGUMENT(connectivity);
     }
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   InitializeIOLibrary();

--- a/Applications/src/compose-dofs.cc
+++ b/Applications/src/compose-dofs.cc
@@ -196,7 +196,7 @@ int main(int argc, char **argv)
     else if (OPTION("-approximate")) {
       approximate = true;
     }
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   HomogeneousTransformation                  *aff;

--- a/Applications/src/convert-dof.cc
+++ b/Applications/src/convert-dof.cc
@@ -2062,7 +2062,7 @@ int main(int argc, char *argv[])
         ARGUMENT; // unused, but needs to be parsed
       #endif // MIRTK_IO_WITH_NIfTI
     }
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   if (precision < 0) precision = 5;

--- a/Applications/src/convert-image.cc
+++ b/Applications/src/convert-image.cc
@@ -79,7 +79,7 @@ int main(int argc, char *argv[])
       PARSE_ARGUMENT(min_value);
       PARSE_ARGUMENT(max_value);
     }
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   // Read image

--- a/Applications/src/copy-pointset-attributes-from-mat.cc
+++ b/Applications/src/copy-pointset-attributes-from-mat.cc
@@ -212,7 +212,7 @@ int main(int argc, char *argv[])
     else if (OPTION("-float"))  out_type = OutputFloat;
     else if (OPTION("-double")) out_type = OutputDouble;
     else HANDLE_POINTSETIO_OPTION(fopt);
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   // Initialize MCR

--- a/Applications/src/dilate-image.cc
+++ b/Applications/src/dilate-image.cc
@@ -75,7 +75,7 @@ int main(int argc, char *argv[])
     else if (OPTION("-connectivity") || OPTION("-neighbors") || OPTION("-number-of-neighbors")) {
       PARSE_ARGUMENT(connectivity);
     }
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   InitializeIOLibrary();

--- a/Applications/src/dilate-scalars.cc
+++ b/Applications/src/dilate-scalars.cc
@@ -202,7 +202,7 @@ int main(int argc, char *argv[])
       PARSE_ARGUMENT(radius);
     }
     else HANDLE_POINTSETIO_OPTION(fopt);
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   if (verbose) cout << "Reading " << input_name << "...", cout.flush();

--- a/Applications/src/downsample-image.cc
+++ b/Applications/src/downsample-image.cc
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
   // Parse optional arguments
   for (ALL_OPTIONS) {
     if (OPTION("-iterations") || OPTION("-iter")) iter = atoi(ARGUMENT);
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   // Read input image

--- a/Applications/src/edit-image.cc
+++ b/Applications/src/edit-image.cc
@@ -201,7 +201,7 @@ int main(int argc, char *argv[])
       image->GetOrientation(xaxis, yaxis, zaxis);
       image->PutOrientation(xaxis, zaxis, yaxis);
     }
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   if (verbose) image->Print();

--- a/Applications/src/erode-image.cc
+++ b/Applications/src/erode-image.cc
@@ -75,7 +75,7 @@ int main(int argc, char *argv[])
     else if (OPTION("-connectivity") || OPTION("-neighbors") || OPTION("-number-of-neighbors")) {
       PARSE_ARGUMENT(connectivity);
     }
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   InitializeIOLibrary();

--- a/Applications/src/erode-scalars.cc
+++ b/Applications/src/erode-scalars.cc
@@ -202,7 +202,7 @@ int main(int argc, char *argv[])
       PARSE_ARGUMENT(radius);
     }
     else HANDLE_POINTSETIO_OPTION(fopt);
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   if (verbose) cout << "Reading " << input_name << "...", cout.flush();

--- a/Applications/src/evaluate-cardiac-motion.cc
+++ b/Applications/src/evaluate-cardiac-motion.cc
@@ -350,7 +350,7 @@ int main(int argc, char **argv)
     else if (OPTION("-strain")) compute_strain = true;
     else if (OPTION("-save-local-coord")) save_local_coord = true;
     else HANDLE_POINTSETIO_OPTION(output_mesh_fopt);
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   if (image_name == nullptr) {

--- a/Applications/src/evaluate-distortion.cc
+++ b/Applications/src/evaluate-distortion.cc
@@ -262,7 +262,7 @@ int main(int argc, char *argv[])
     if      (OPTION("-angular"))   measures.push_back(Distortion_Angular);
     else if (OPTION("-areal"))     measures.push_back(Distortion_Areal);
     else if (OPTION("-abs-areal")) measures.push_back(Distortion_ArealAbs);
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   if (measures.empty()) {

--- a/Applications/src/evaluate-dof.cc
+++ b/Applications/src/evaluate-dof.cc
@@ -171,7 +171,7 @@ int main(int argc, char **argv)
     else if (OPTION("-cice")) { metric = InverseConsistency; cumulative = true;  }
     else if (OPTION("-mte"))  { metric = Transitivity;       cumulative = false; }
     else if (OPTION("-cte"))  { metric = Transitivity;       cumulative = true;  }
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   if (list_name) read_list_file(list_name, dofin_name);

--- a/Applications/src/extract-connected-components.cc
+++ b/Applications/src/extract-connected-components.cc
@@ -118,7 +118,7 @@ int main(int argc, char *argv[])
     else if (OPTION("-ordering"))     PARSE_ARGUMENT(ordering);
     else if (OPTION("-output-component-labels")) output_type = ComponentLabels;
     else if (OPTION("-output-component-mask"))   output_type = ComponentMask;
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   InitializeIOLibrary();

--- a/Applications/src/extract-connected-points.cc
+++ b/Applications/src/extract-connected-points.cc
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
     if      (OPTION("-m")) PARSE_ARGUMENT(m);
     else if (OPTION("-n")) PARSE_ARGUMENT(n);
     else HANDLE_POINTSETIO_OPTION(fopt);
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   vtkSmartPointer<vtkPolyData> input = ReadPolyData(input_name, fopt);

--- a/Applications/src/flip-image.cc
+++ b/Applications/src/flip-image.cc
@@ -76,7 +76,7 @@ int main(int argc, char **argv)
     else if (OPTION("-yz") || OPTION("-zy")) image->FlipYZ(true);
     else if (OPTION("-yt") || OPTION("-ty")) image->FlipYT(true);
     else if (OPTION("-zt") || OPTION("-tz")) image->FlipZT(true);
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   image->Write(output_name);

--- a/Applications/src/info.cc
+++ b/Applications/src/info.cc
@@ -442,7 +442,7 @@ int main(int argc, char *argv[])
 
     for (ALL_OPTIONS) {
       if (OPTION("-a") || OPTION("-attributes") || OPTION("-attr")) attributes = true;
-      else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+      else HANDLE_COMMON_OR_UNKNOWN_OPTION();
     }
 
     UniquePtr<BaseImage> image(image_reader->Run());
@@ -488,7 +488,7 @@ int main(int argc, char *argv[])
       if      (OPTION("-attributes") || OPTION("-attr") || OPTION("-a")) attributes = true;
       else if (OPTION("-type-name")  || OPTION("-type")) type_name  = true;
       else if (OPTION("-type-id")    || OPTION("-id"))   type_id    = true;
-      else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+      else HANDLE_COMMON_OR_UNKNOWN_OPTION();
     }
     if (!type_name && !type_id && !attributes) {
       attributes = true;

--- a/Applications/src/invert-dof.cc
+++ b/Applications/src/invert-dof.cc
@@ -63,7 +63,7 @@ int main(int argc, char **argv)
   const char *dofout_name = POSARG(2);
 
   for (ALL_OPTIONS) {
-    HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   // Read transformation

--- a/Applications/src/open-image.cc
+++ b/Applications/src/open-image.cc
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
     else if (OPTION("-connectivity") || OPTION("-neighbors") || OPTION("-number-of-neighbors")) {
       PARSE_ARGUMENT(connectivity);
     }
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   InitializeIOLibrary();

--- a/Applications/src/reflect-image.cc
+++ b/Applications/src/reflect-image.cc
@@ -75,7 +75,7 @@ int main(int argc, char *argv[])
     else if (OPTION("-xy") || OPTION("-yx")) image->FlipXY(false);
     else if (OPTION("-xz") || OPTION("-zx")) image->FlipXZ(false);
     else if (OPTION("-yz") || OPTION("-zy")) image->FlipYZ(false);
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
 
   image->Write(output_name);

--- a/Applications/src/resample-image.cc
+++ b/Applications/src/resample-image.cc
@@ -200,7 +200,7 @@ int main(int argc, char *argv[])
     else if (OPTION("-extrap")) {
       PARSE_ARGUMENT(extrapolation_mode);
     }
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
  
   if (!IsNaN(padding_value) && interpolation_mode != Interpolation_Linear) {

--- a/Applications/src/transform-points.cc
+++ b/Applications/src/transform-points.cc
@@ -157,7 +157,7 @@ int main(int argc, char **argv)
     else if (OPTION("-point-normals")) compute_point_normals = true;
     else if (OPTION("-cell-normals")) compute_cell_normals = true;
     else HANDLE_POINTSETIO_OPTION(fopt);
-    else HANDLE_STANDARD_OR_UNKNOWN_OPTION();
+    else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
   dofin_invert.resize(dofin_name.size(), false);
 


### PR DESCRIPTION
Always use `HANDLE_COMMON_OPTIONS` instead of `HANDLE_STANDARD_OPTIONS` even when command just ignores the additional common options.