### PR TITLE
enh: Add threads argument to mirtk.run Python function [Applications]

### DIFF
--- a/Applications/lib/python/mirtk/subprocess.py.in
+++ b/Applications/lib/python/mirtk/subprocess.py.in
@@ -129,10 +129,12 @@ def check_output(argv, verbose=0):
     return _call(argv, verbose=verbose, execfunc=subprocess.check_output)
 
 # ----------------------------------------------------------------------------
-def run(cmd, args=[], opts={}, verbose=0):
+def run(cmd, args=[], opts={}, verbose=0, threads=0):
     """Execute MIRTK command and throw exception on error."""
     argv = [cmd]
     argv.extend(args)
+    if threads > 0:
+        argv.extend(['-threads', str(threads)])
     # ordered list of options
     if isinstance(opts, list):
         for item in opts:


### PR DESCRIPTION
For execution of MIRTK commands within a Python pipeline script executed for a batch of data on a cluster, the number of threads must usually restricted to the number of requested resources. Hence, add this `mirtk.run` argument for convenience.