### PR TITLE
fix: Sparse matrix destruction

### DIFF
--- a/Modules/Numerics/include/mirtk/SparseMatrix.h
+++ b/Modules/Numerics/include/mirtk/SparseMatrix.h
@@ -156,6 +156,9 @@ public:
 
 #endif
 
+  /// Destructor
+  virtual ~GenericSparseMatrix();
+
   // ---------------------------------------------------------------------------
   // Entries
 
@@ -282,7 +285,7 @@ public:
   void Sub(int, int, const GenericSparseMatrix &);
 
   /// Free all non-zero entries
-  void Clear();
+  virtual void Clear();
 
   /// Set all non-zero entries to zero (i.e., remove)
   void Zero();
@@ -778,6 +781,16 @@ void GenericSparseMatrix<TEntry>::Initialize(const mxArray *pm)
   }
 }
 #endif // MIRTK_Numerics_WITH_MATLAB
+
+// -----------------------------------------------------------------------------
+template <class TEntry>
+GenericSparseMatrix<TEntry>::~GenericSparseMatrix()
+{
+  Deallocate(_Row);
+  Deallocate(_Col);
+  Deallocate(_Data);
+  Deallocate(_Index);
+}
 
 // =============================================================================
 // Entries

--- a/Modules/PointSet/include/mirtk/EdgeConnectivity.h
+++ b/Modules/PointSet/include/mirtk/EdgeConnectivity.h
@@ -75,6 +75,9 @@ public:
   /// Initialize edge-connectivity table from given dataset
   void Initialize(vtkDataSet *, double r, const EdgeTable * = NULL);
 
+  /// Clear edge-connectivity table
+  virtual void Clear();
+
   /// Number of nodes
   int NumberOfPoints() const;
 

--- a/Modules/PointSet/include/mirtk/EdgeTable.h
+++ b/Modules/PointSet/include/mirtk/EdgeTable.h
@@ -71,6 +71,9 @@ public:
   /// Initialize edge table from given dataset
   void Initialize(vtkDataSet *);
 
+  /// Clear edge table
+  virtual void Clear();
+
   /// Number of nodes
   int NumberOfPoints() const;
 


### PR DESCRIPTION
A missing `GenericSparseMatrix` destructor caused a memory leak.