### PR TITLE
fix: No x/y/z references in Point/Vector3D/Vector4D, rename memers of Vector3

### DIFF
--- a/Applications/src/calculate-surface-attributes.cc
+++ b/Applications/src/calculate-surface-attributes.cc
@@ -370,10 +370,10 @@ void EvaluateImageDerivative(vtkPolyData *surface, const RealImage &image, const
     surface->GetPoint(ptId, p);
     normals->GetTuple(ptId, n);
     f.WorldToImage(p);
-    f.Jacobian3D(jac, p.x, p.y, p.z);
-    g.x = jac(0, 0);
-    g.y = jac(0, 1);
-    g.z = jac(0, 2);
+    f.Jacobian3D(jac, p._x, p._y, p._z);
+    g._x = jac(0, 0);
+    g._y = jac(0, 1);
+    g._z = jac(0, 2);
     f.ImageToWorld(g);
     if (normalize) g.Normalize();
     value = n.Dot(g);

--- a/Applications/src/merge-surfaces.cc
+++ b/Applications/src/merge-surfaces.cc
@@ -1094,9 +1094,9 @@ vtkSmartPointer<vtkPolyData> CuttingPlane(const PlaneAttributes &attr, double tn
   // Map to world vectors of unit length
   Vector3 e1(attr.x), e2(attr.y), e3(attr.z);
   e1.Normalize(), e2.Normalize(), e3.Normalize();
-  dx = dx.x * e1 + dx.y * e2 + dx.z * e3;
-  dy = dy.x * e1 + dy.y * e2 + dy.z * e3;
-  n  = n .x * e1 + n .y * e2 + n .z * e3;
+  dx = dx._x * e1 + dx._y * e2 + dx._z * e3;
+  dy = dy._x * e1 + dy._y * e2 + dy._z * e3;
+  n  = n ._x * e1 + n ._y * e2 + n ._z * e3;
 
   // Add plane margin to initial plane extend
   dx *= (attr.x.Length() + 2. * margin);
@@ -1325,9 +1325,9 @@ vtkSmartPointer<vtkPolyData> TesselateDivider(vtkSmartPointer<vtkPolyData> divid
   matrix = vtkSmartPointer<vtkMatrix4x4>::New();
   matrix->Identity();
   for (int i = 0; i < 3; ++i) {
-    matrix->SetElement(i, 0, dir[i].x);
-    matrix->SetElement(i, 1, dir[i].y);
-    matrix->SetElement(i, 2, dir[i].z);
+    matrix->SetElement(i, 0, dir[i]._x);
+    matrix->SetElement(i, 1, dir[i]._y);
+    matrix->SetElement(i, 2, dir[i]._z);
     matrix->SetElement(i, 3, -dir[i].Dot(c));
   }
 
@@ -1343,29 +1343,29 @@ vtkSmartPointer<vtkPolyData> TesselateDivider(vtkSmartPointer<vtkPolyData> divid
   for (vtkIdType ptId = 1; ptId < divider->GetNumberOfPoints(); ++ptId) {
     divider->GetPoint(ptId, p);
     transform->TransformPoint(p, q);
-    if (q.x < minq.x) minq.x = q.x;
-    if (q.y < minq.y) minq.y = q.y;
-    if (q.z < minq.z) minq.z = q.z;
-    if (q.x > maxq.x) maxq.x = q.x;
-    if (q.y > maxq.y) maxq.y = q.y;
-    if (q.z > maxq.z) maxq.z = q.z;
+    if (q._x < minq._x) minq._x = q._x;
+    if (q._y < minq._y) minq._y = q._y;
+    if (q._z < minq._z) minq._z = q._z;
+    if (q._x > maxq._x) maxq._x = q._x;
+    if (q._y > maxq._y) maxq._y = q._y;
+    if (q._z > maxq._z) maxq._z = q._z;
   }
 
   const double margin = ds;
-  minq.x -= margin, maxq.x += margin;
-  minq.y -= margin, maxq.y += margin;
+  minq._x -= margin, maxq._x += margin;
+  minq._y -= margin, maxq._y += margin;
 
-  int nx = iceil((maxq.x - minq.x) / ds) + 1;
-  int ny = iceil((maxq.y - minq.y) / ds) + 1;
+  int nx = iceil((maxq._x - minq._x) / ds) + 1;
+  int ny = iceil((maxq._y - minq._y) / ds) + 1;
 
   if (nx % 2 == 0) ++nx;
   if (ny % 2 == 0) ++ny;
 
-  minq.x = minq.x + .5 * (maxq.x - minq.x) - ((nx - 1) / 2) * ds;
-  maxq.x = minq.x + (nx - 1) * ds + 1e-12;
+  minq._x = minq._x + .5 * (maxq._x - minq._x) - ((nx - 1) / 2) * ds;
+  maxq._x = minq._x + (nx - 1) * ds + 1e-12;
 
-  minq.y = minq.y + .5 * (maxq.y - minq.y) - ((ny - 1) / 2) * ds;
-  maxq.y = minq.y + (ny - 1) * ds + 1e-12;
+  minq._y = minq._y + .5 * (maxq._y - minq._y) - ((ny - 1) / 2) * ds;
+  maxq._y = minq._y + (ny - 1) * ds + 1e-12;
 
   // Add additional discrete divider polygon plane grid points
   vtkNew<vtkPointLocator> locator;
@@ -1381,10 +1381,10 @@ vtkSmartPointer<vtkPolyData> TesselateDivider(vtkSmartPointer<vtkPolyData> divid
     points->InsertNextPoint(p);
   }
 
-  q.z = 0.;
-  for (q.y = minq.y; q.y <= maxq.y; q.y += ds)
-  for (q.x = minq.x; q.x <= maxq.x; q.x += ds) {
-    p = c + q.x * dir[0] + q.y * dir[1];
+  q._z = 0.;
+  for (q._y = minq._y; q._y <= maxq._y; q._y += ds)
+  for (q._x = minq._x; q._x <= maxq._x; q._x += ds) {
+    p = c + q._x * dir[0] + q._y * dir[1];
     otherId = locator->FindClosestPoint(p);
     if (otherId >= 0) {
       divider->GetPoint(otherId, x);

--- a/Applications/src/subdivide-brain-image.cc
+++ b/Applications/src/subdivide-brain-image.cc
@@ -165,20 +165,20 @@ struct Plane
     c(p), n(n)
   {
     this->n.Normalize();
-    b = - this->n.Dot(Vector3(c.x, c.y, c.z));
+    b = - this->n.Dot(Vector3(c._x, c._y, c._z));
   }
 
   void Center(const Point &p)
   {
     c = p;
-    b = - n.Dot(Vector3(c.x, c.y, c.z));
+    b = - n.Dot(Vector3(c._x, c._y, c._z));
   }
 
   void Normal(const Vector3 &v)
   {
     n = v;
     n.Normalize();
-    b = - n.Dot(Vector3(c.x, c.y, c.z));
+    b = - n.Dot(Vector3(c._x, c._y, c._z));
   }
 
   operator bool() const
@@ -188,7 +188,7 @@ struct Plane
 
   double SignedDistance(const Point &p) const
   {
-    return n.Dot(Vector3(p.x, p.y, p.z)) + b;
+    return n.Dot(Vector3(p._x, p._y, p._z)) + b;
   }
 
   static bool Tangents(const Vector3 &n, Vector3 &e1, Vector3 &e2)
@@ -216,7 +216,7 @@ struct Plane
 /// Print plane equation
 ostream &operator <<(ostream &os, const Plane &plane)
 {
-  os << "x^T [" << plane.n.x << " " << plane.n.y << " " << plane.n.z << "] + " << plane.b << " = 0";
+  os << "x^T [" << plane.n._x << " " << plane.n._y << " " << plane.n._z << "] + " << plane.b << " = 0";
   return os;
 }
 
@@ -453,21 +453,21 @@ ByteImage Cut(const ByteImage &regions, const Plane &plane, double r)
   attr._x = attr._y = 2 * iceil(r / ds) + 1;
   attr._z = 1;
 
-  attr._xorigin = plane.c.x;
-  attr._yorigin = plane.c.y;
-  attr._zorigin = plane.c.z;
+  attr._xorigin = plane.c._x;
+  attr._yorigin = plane.c._y;
+  attr._zorigin = plane.c._z;
 
-  attr._xaxis[0] = e1.x;
-  attr._xaxis[1] = e1.y;
-  attr._xaxis[2] = e1.z;
+  attr._xaxis[0] = e1._x;
+  attr._xaxis[1] = e1._y;
+  attr._xaxis[2] = e1._z;
 
-  attr._yaxis[0] = e2.x;
-  attr._yaxis[1] = e2.y;
-  attr._yaxis[2] = e2.z;
+  attr._yaxis[0] = e2._x;
+  attr._yaxis[1] = e2._y;
+  attr._yaxis[2] = e2._z;
 
-  attr._zaxis[0] = plane.n.x;
-  attr._zaxis[1] = plane.n.y;
-  attr._zaxis[2] = plane.n.z;
+  attr._zaxis[0] = plane.n._x;
+  attr._zaxis[1] = plane.n._y;
+  attr._zaxis[2] = plane.n._z;
 
   const Matrix w2i = attr.GetWorldToImageMatrix();
   const Matrix i2w = attr.GetImageToWorldMatrix();
@@ -506,7 +506,7 @@ double MaxBrainstemDiameter(const ByteImage &regions, const Plane &plane)
   for (int i = 0; i < regions.X(); ++i) {
     if (regions(i, j, k) == BS) {
       p = Vector3(i, j, k);
-      regions.ImageToWorld(p.x, p.y, p.z);
+      regions.ImageToWorld(p._x, p._y, p._z);
       x = e1.Dot(p);
       y = e2.Dot(p);
       x1 = min(x1, x);
@@ -642,9 +642,9 @@ Plane SymmetricCuttingPlane(const ByteImage &regions, BrainRegion a, BrainRegion
   center[0] /= numvox[0];
   center[1] /= numvox[1];
   Plane plane;
-  plane.n[0] = center[0].x - center[1].x;
-  plane.n[1] = center[0].y - center[1].y;
-  plane.n[2] = center[0].z - center[1].z;
+  plane.n[0] = center[0]._x - center[1]._x;
+  plane.n[1] = center[0]._y - center[1]._y;
+  plane.n[2] = center[0]._z - center[1]._z;
   plane.n.Normalize();
   plane.Center((center[0] + center[1]) / 2.0);
   return plane;
@@ -704,21 +704,21 @@ ByteImage Resample(const ByteImage &regions, const Plane &rl_plane, const Plane 
   for (int ci = 0; ci < 2; ++ci) {
     p = Point(bi[ci], bj[cj], bk[ck]);
     regions.ImageToWorld(p);
-    bounds[0] = min(bounds[0], p.x);
-    bounds[1] = max(bounds[1], p.x);
-    bounds[2] = min(bounds[2], p.y);
-    bounds[3] = max(bounds[3], p.y);
-    bounds[4] = min(bounds[4], p.z);
-    bounds[5] = max(bounds[5], p.z);
-    q.x = xaxis.Dot(p);
-    q.y = yaxis.Dot(p);
-    q.z = zaxis.Dot(p);
-    limits[0] = min(limits[0], q.x);
-    limits[1] = max(limits[1], q.x);
-    limits[2] = min(limits[2], q.y);
-    limits[3] = max(limits[3], q.y);
-    limits[4] = min(limits[4], q.z);
-    limits[5] = max(limits[5], q.z);
+    bounds[0] = min(bounds[0], p._x);
+    bounds[1] = max(bounds[1], p._x);
+    bounds[2] = min(bounds[2], p._y);
+    bounds[3] = max(bounds[3], p._y);
+    bounds[4] = min(bounds[4], p._z);
+    bounds[5] = max(bounds[5], p._z);
+    q._x = xaxis.Dot(p);
+    q._y = yaxis.Dot(p);
+    q._z = zaxis.Dot(p);
+    limits[0] = min(limits[0], q._x);
+    limits[1] = max(limits[1], q._x);
+    limits[2] = min(limits[2], q._y);
+    limits[3] = max(limits[3], q._y);
+    limits[4] = min(limits[4], q._z);
+    limits[5] = max(limits[5], q._z);
   }
 
   ImageAttributes attr;
@@ -1326,14 +1326,14 @@ int main(int argc, char *argv[])
     // Determine bounding box of interhemisphere WM
     const bool world = false;
     PointSet voxels = BoundaryPoints(regions, RH, LH, world);
-    int bounds[6] = {static_cast<int>(voxels(0).x), static_cast<int>(voxels(0).x),
-                     static_cast<int>(voxels(0).y), static_cast<int>(voxels(0).y),
-                     static_cast<int>(voxels(0).z), static_cast<int>(voxels(0).z)};
+    int bounds[6] = {static_cast<int>(voxels(0)._x), static_cast<int>(voxels(0)._x),
+                     static_cast<int>(voxels(0)._y), static_cast<int>(voxels(0)._y),
+                     static_cast<int>(voxels(0)._z), static_cast<int>(voxels(0)._z)};
     for (int n = 1, i, j, k; n < voxels.Size(); ++n) {
       const auto &voxel = voxels(n);
-      i = static_cast<int>(voxel.x);
-      j = static_cast<int>(voxel.y);
-      k = static_cast<int>(voxel.z);
+      i = static_cast<int>(voxel._x);
+      j = static_cast<int>(voxel._y);
+      k = static_cast<int>(voxel._z);
       bounds[0] = min(bounds[0], i);
       bounds[1] = max(bounds[1], i);
       bounds[2] = min(bounds[2], j);

--- a/Modules/Common/include/mirtk/Assert.h
+++ b/Modules/Common/include/mirtk/Assert.h
@@ -22,7 +22,6 @@
 
 #include "mirtk/Stream.h"
 
-
 // -----------------------------------------------------------------------------
 #ifndef NDEBUG
 #  define mirtkAssert(condition, message)                                      \

--- a/Modules/Image/include/mirtk/BaseImage.h
+++ b/Modules/Image/include/mirtk/BaseImage.h
@@ -1184,10 +1184,10 @@ inline void BaseImage::ImageToWorld(Point &p) const
 // -----------------------------------------------------------------------------
 inline void BaseImage::ImageToWorld(Vector3 &v) const
 {
-  double a = _matI2W(0, 0) * v.x + _matI2W(0, 1) * v.y + _matI2W(0, 2) * v.z;
-  double b = _matI2W(1, 0) * v.x + _matI2W(1, 1) * v.y + _matI2W(1, 2) * v.z;
-  double c = _matI2W(2, 0) * v.x + _matI2W(2, 1) * v.y + _matI2W(2, 2) * v.z;
-  v.x = a, v.y = b, v.z = c;
+  double a = _matI2W(0, 0) * v._x + _matI2W(0, 1) * v._y + _matI2W(0, 2) * v._z;
+  double b = _matI2W(1, 0) * v._x + _matI2W(1, 1) * v._y + _matI2W(1, 2) * v._z;
+  double c = _matI2W(2, 0) * v._x + _matI2W(2, 1) * v._y + _matI2W(2, 2) * v._z;
+  v._x = a, v._y = b, v._z = c;
 }
 
 // -----------------------------------------------------------------------------
@@ -1216,10 +1216,10 @@ inline void BaseImage::WorldToImage(Point &p) const
 // -----------------------------------------------------------------------------
 inline void BaseImage::WorldToImage(Vector3 &v) const
 {
-  double a = _matW2I(0, 0) * v.x + _matW2I(0, 1) * v.y + _matW2I(0, 2) * v.z;
-  double b = _matW2I(1, 0) * v.x + _matW2I(1, 1) * v.y + _matW2I(1, 2) * v.z;
-  double c = _matW2I(2, 0) * v.x + _matW2I(2, 1) * v.y + _matW2I(2, 2) * v.z;
-  v.x = a, v.y = b, v.z = c;
+  double a = _matW2I(0, 0) * v._x + _matW2I(0, 1) * v._y + _matW2I(0, 2) * v._z;
+  double b = _matW2I(1, 0) * v._x + _matW2I(1, 1) * v._y + _matW2I(1, 2) * v._z;
+  double c = _matW2I(2, 0) * v._x + _matW2I(2, 1) * v._y + _matW2I(2, 2) * v._z;
+  v._x = a, v._y = b, v._z = c;
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Image/include/mirtk/InterpolateImageFunction.h
+++ b/Modules/Image/include/mirtk/InterpolateImageFunction.h
@@ -996,13 +996,13 @@ inline bool InterpolateImageFunction::IsInside(double x, double y, double z, dou
 // -----------------------------------------------------------------------------
 inline bool InterpolateImageFunction::IsInside(const Point &p) const
 {
-  return IsInside(p.x, p.y, p.z);
+  return IsInside(p._x, p._y, p._z);
 }
 
 // -----------------------------------------------------------------------------
 inline bool InterpolateImageFunction::IsInside(const Point &p, double t) const
 {
-  return IsInside(p.x, p.y, p.z, t);
+  return IsInside(p._x, p._y, p._z, t);
 }
 
 // -----------------------------------------------------------------------------
@@ -1026,13 +1026,13 @@ inline bool InterpolateImageFunction::IsOutside(double x, double y, double z, do
 // -----------------------------------------------------------------------------
 inline bool InterpolateImageFunction::IsOutside(const Point &p) const
 {
-  return IsOutside(p.x, p.y, p.z);
+  return IsOutside(p._x, p._y, p._z);
 }
 
 // -----------------------------------------------------------------------------
 inline bool InterpolateImageFunction::IsOutside(const Point &p, double t) const
 {
-  return IsOutside(p.x, p.y, p.z, t);
+  return IsOutside(p._x, p._y, p._z, t);
 }
 
 // -----------------------------------------------------------------------------
@@ -1062,13 +1062,13 @@ inline bool InterpolateImageFunction::IsForeground(double x, double y, double z,
 // -----------------------------------------------------------------------------
 inline bool InterpolateImageFunction::IsForeground(const Point &p) const
 {
-  return IsForeground(p.x, p.y, p.z);
+  return IsForeground(p._x, p._y, p._z);
 }
 
 // -----------------------------------------------------------------------------
 inline bool InterpolateImageFunction::IsForeground(const Point &p, double t) const
 {
-  return IsForeground(p.x, p.y, p.z, t);
+  return IsForeground(p._x, p._y, p._z, t);
 }
 
 // =============================================================================
@@ -1091,7 +1091,7 @@ inline double InterpolateImageFunction::Evaluate(double x, double y, double z, d
 // -----------------------------------------------------------------------------
 inline double InterpolateImageFunction::Evaluate(const Point &p, double t) const
 {
-  return Evaluate(p.x, p.y, p.z, t);
+  return Evaluate(p._x, p._y, p._z, t);
 }
 
 // -----------------------------------------------------------------------------
@@ -1127,7 +1127,7 @@ inline void InterpolateImageFunction::Evaluate(double *v, double x, double y, do
 // -----------------------------------------------------------------------------
 inline void InterpolateImageFunction::Evaluate(double *v, const Point &p, int vt) const
 {
-  Evaluate(v, p.x, p.y, p.z, vt);
+  Evaluate(v, p._x, p._y, p._z, vt);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Numerics/include/mirtk/Point.h
+++ b/Modules/Numerics/include/mirtk/Point.h
@@ -47,10 +47,6 @@ public:
   double _y; ///< y coordinate of Point
   double _z; ///< z coordinate of Point
 
-  double &x = _x;
-  double &y = _y;
-  double &z = _z;
-
   //
   // Constructors and destructor
   //
@@ -323,9 +319,9 @@ inline Point::Point(const Point& p)
 // -----------------------------------------------------------------------------
 inline Point::Point(const Vector3& v)
 {
-  _x = v.x;
-  _y = v.y;
-  _z = v.z;
+  _x = v._x;
+  _y = v._y;
+  _z = v._z;
 }
 
 // -----------------------------------------------------------------------------
@@ -605,45 +601,45 @@ inline Point Point::operator/ (double x) const
 // -----------------------------------------------------------------------------
 inline Point& Point::operator =(const Vector3& v)
 {
-  _x = v.x;
-  _y = v.y;
-  _z = v.z;
+  _x = v._x;
+  _y = v._y;
+  _z = v._z;
   return *this;
 }
 
 // -----------------------------------------------------------------------------
 inline Point& Point::operator +=(const Vector3 &v)
 {
-  _x += v.x;
-  _y += v.y;
-  _z += v.z;
+  _x += v._x;
+  _y += v._y;
+  _z += v._z;
   return *this;
 }
 
 // -----------------------------------------------------------------------------
 inline Point& Point::operator -=(const Vector3 &v)
 {
-  _x -= v.x;
-  _y -= v.y;
-  _z -= v.z;
+  _x -= v._x;
+  _y -= v._y;
+  _z -= v._z;
   return *this;
 }
 
 // -----------------------------------------------------------------------------
 inline Point& Point::operator *=(const Vector3 &v)
 {
-  _x *= v.x;
-  _y *= v.y;
-  _z *= v.z;
+  _x *= v._x;
+  _y *= v._y;
+  _z *= v._z;
   return *this;
 }
 
 // -----------------------------------------------------------------------------
 inline Point& Point::operator /=(const Vector3 &v)
 {
-  _x /= v.x;
-  _y /= v.y;
-  _z /= v.z;
+  _x /= v._x;
+  _y /= v._y;
+  _z /= v._z;
   return *this;
 }
 

--- a/Modules/Numerics/include/mirtk/Vector3.h
+++ b/Modules/Numerics/include/mirtk/Vector3.h
@@ -41,10 +41,13 @@ public:
   Vector3 (const Vector3& rkVector);
   Vector3 (const Point &);
 
-  // member access (allows V.x or V[0], V.y or V[1], V.z or V[2])
-  double x, y, z;
-  double& operator[] (int i) const;
+  // member access
+  // (allows V._x or V(0) or V[0], V._y or V(1) or V[1], V._z or V(2) or or V[2])
+  double _x, _y, _z;
+  double& operator[] (int i);
+  const double& operator[] (int i) const;
   operator double* ();
+  operator const double* () const;
 
   // assignment and comparison
   Vector3& operator= (const Vector3& rkVector);

--- a/Modules/Numerics/include/mirtk/Vector3D.h
+++ b/Modules/Numerics/include/mirtk/Vector3D.h
@@ -59,10 +59,6 @@ struct Vector3D
   T _y; ///< The y component
   T _z; ///< The z component
 
-  T &x = _x;
-  T &y = _y;
-  T &z = _z;
-
   // ---------------------------------------------------------------------------
   // Construction/Destruction
 

--- a/Modules/Numerics/include/mirtk/Vector4D.h
+++ b/Modules/Numerics/include/mirtk/Vector4D.h
@@ -45,11 +45,6 @@ struct Vector4D
   T _z; ///< The z component
   T _t; ///< The t component
 
-  T &x = _x; ///< More convenient/readable _x attribute accessor
-  T &y = _y; ///< More convenient/readable _y attribute accessor
-  T &z = _z; ///< More convenient/readable _z attribute accessor
-  T &t = _t; ///< More convenient/readable _t attribute accessor
-
   // ---------------------------------------------------------------------------
 
   /** Constructor. */

--- a/Modules/Numerics/src/Matrix3x3.cc
+++ b/Modules/Numerics/src/Matrix3x3.cc
@@ -1084,9 +1084,9 @@ void Matrix3x3::ToAxisAngle (Vector3& rkAxis, double& rfRadians) const
 
   if ( rfRadians > 0.0 ) {
     if ( rfRadians < pi ) {
-      rkAxis.x = m_aafEntry[2][1]-m_aafEntry[1][2];
-      rkAxis.y = m_aafEntry[0][2]-m_aafEntry[2][0];
-      rkAxis.z = m_aafEntry[1][0]-m_aafEntry[0][1];
+      rkAxis._x = m_aafEntry[2][1]-m_aafEntry[1][2];
+      rkAxis._y = m_aafEntry[0][2]-m_aafEntry[2][0];
+      rkAxis._z = m_aafEntry[1][0]-m_aafEntry[0][1];
       rkAxis.Unitize();
     } else {
       // angle is PI
@@ -1095,40 +1095,40 @@ void Matrix3x3::ToAxisAngle (Vector3& rkAxis, double& rfRadians) const
         // r00 >= r11
         if ( m_aafEntry[0][0] >= m_aafEntry[2][2] ) {
           // r00 is maximum diagonal term
-          rkAxis.x = 0.5*Sqrt(m_aafEntry[0][0] - m_aafEntry[1][1] - m_aafEntry[2][2] + 1.0);
-          fHalfInverse = 0.5/rkAxis.x;
-          rkAxis.y = fHalfInverse*m_aafEntry[0][1];
-          rkAxis.z = fHalfInverse*m_aafEntry[0][2];
+          rkAxis._x = 0.5*Sqrt(m_aafEntry[0][0] - m_aafEntry[1][1] - m_aafEntry[2][2] + 1.0);
+          fHalfInverse = 0.5/rkAxis._x;
+          rkAxis._y = fHalfInverse*m_aafEntry[0][1];
+          rkAxis._z = fHalfInverse*m_aafEntry[0][2];
         } else {
           // r22 is maximum diagonal term
-          rkAxis.z = 0.5*Sqrt(m_aafEntry[2][2] - m_aafEntry[0][0] - m_aafEntry[1][1] + 1.0);
-          fHalfInverse = 0.5/rkAxis.z;
-          rkAxis.x = fHalfInverse*m_aafEntry[0][2];
-          rkAxis.y = fHalfInverse*m_aafEntry[1][2];
+          rkAxis._z = 0.5*Sqrt(m_aafEntry[2][2] - m_aafEntry[0][0] - m_aafEntry[1][1] + 1.0);
+          fHalfInverse = 0.5/rkAxis._z;
+          rkAxis._x = fHalfInverse*m_aafEntry[0][2];
+          rkAxis._y = fHalfInverse*m_aafEntry[1][2];
         }
       } else {
         // r11 > r00
         if ( m_aafEntry[1][1] >= m_aafEntry[2][2] ) {
           // r11 is maximum diagonal term
-          rkAxis.y = 0.5*Sqrt(m_aafEntry[1][1] - m_aafEntry[0][0] - m_aafEntry[2][2] + 1.0);
-          fHalfInverse  = 0.5/rkAxis.y;
-          rkAxis.x = fHalfInverse*m_aafEntry[0][1];
-          rkAxis.z = fHalfInverse*m_aafEntry[1][2];
+          rkAxis._y = 0.5*Sqrt(m_aafEntry[1][1] - m_aafEntry[0][0] - m_aafEntry[2][2] + 1.0);
+          fHalfInverse  = 0.5/rkAxis._y;
+          rkAxis._x = fHalfInverse*m_aafEntry[0][1];
+          rkAxis._z = fHalfInverse*m_aafEntry[1][2];
         } else {
           // r22 is maximum diagonal term
-          rkAxis.z = 0.5*Sqrt(m_aafEntry[2][2] - m_aafEntry[0][0] - m_aafEntry[1][1] + 1.0);
-          fHalfInverse = 0.5/rkAxis.z;
-          rkAxis.x = fHalfInverse*m_aafEntry[0][2];
-          rkAxis.y = fHalfInverse*m_aafEntry[1][2];
+          rkAxis._z = 0.5*Sqrt(m_aafEntry[2][2] - m_aafEntry[0][0] - m_aafEntry[1][1] + 1.0);
+          fHalfInverse = 0.5/rkAxis._z;
+          rkAxis._x = fHalfInverse*m_aafEntry[0][2];
+          rkAxis._y = fHalfInverse*m_aafEntry[1][2];
         }
       }
     }
   } else {
     // The angle is 0 and the matrix is the identity.  Any axis will
     // work, so just use the x-axis.
-    rkAxis.x = 1.0;
-    rkAxis.y = 0.0;
-    rkAxis.z = 0.0;
+    rkAxis._x = 1.0;
+    rkAxis._y = 0.0;
+    rkAxis._z = 0.0;
   }
 }
 
@@ -1138,15 +1138,15 @@ void Matrix3x3::FromAxisAngle (const Vector3& rkAxis, double fRadians)
   double fCos = Cos(fRadians);
   double fSin = Sin(fRadians);
   double fOneMinusCos = 1.0-fCos;
-  double fX2 = rkAxis.x*rkAxis.x;
-  double fY2 = rkAxis.y*rkAxis.y;
-  double fZ2 = rkAxis.z*rkAxis.z;
-  double fXYM = rkAxis.x*rkAxis.y*fOneMinusCos;
-  double fXZM = rkAxis.x*rkAxis.z*fOneMinusCos;
-  double fYZM = rkAxis.y*rkAxis.z*fOneMinusCos;
-  double fXSin = rkAxis.x*fSin;
-  double fYSin = rkAxis.y*fSin;
-  double fZSin = rkAxis.z*fSin;
+  double fX2 = rkAxis._x*rkAxis._x;
+  double fY2 = rkAxis._y*rkAxis._y;
+  double fZ2 = rkAxis._z*rkAxis._z;
+  double fXYM = rkAxis._x*rkAxis._y*fOneMinusCos;
+  double fXZM = rkAxis._x*rkAxis._z*fOneMinusCos;
+  double fYZM = rkAxis._y*rkAxis._z*fOneMinusCos;
+  double fXSin = rkAxis._x*fSin;
+  double fYSin = rkAxis._y*fSin;
+  double fZSin = rkAxis._z*fSin;
 
   m_aafEntry[0][0] = fX2*fOneMinusCos+fCos;
   m_aafEntry[0][1] = fXYM-fZSin;

--- a/Modules/Numerics/src/Vector3.cc
+++ b/Modules/Numerics/src/Vector3.cc
@@ -18,6 +18,7 @@
 
 #include "mirtk/Vector3.h"
 
+#include "mirtk/Assert.h"
 #include "mirtk/Math.h"
 #include "mirtk/Stream.h"
 #include "mirtk/Point.h"
@@ -42,90 +43,112 @@ Vector3::Vector3 ()
 //----------------------------------------------------------------------------
 Vector3::Vector3 (double fScalar)
 {
-  x = y = z = fScalar;
+  _x = _y = _z = fScalar;
 }
 
 //----------------------------------------------------------------------------
 Vector3::Vector3 (double fX, double fY, double fZ)
 {
-  x = fX;
-  y = fY;
-  z = fZ;
+  _x = fX;
+  _y = fY;
+  _z = fZ;
 }
 
 //----------------------------------------------------------------------------
 Vector3::Vector3 (const double afCoordinate[3])
 {
-  x = afCoordinate[0];
-  y = afCoordinate[1];
-  z = afCoordinate[2];
+  _x = afCoordinate[0];
+  _y = afCoordinate[1];
+  _z = afCoordinate[2];
 }
 
 //----------------------------------------------------------------------------
 Vector3::Vector3 (const Vector3& rkVector)
 {
-  x = rkVector.x;
-  y = rkVector.y;
-  z = rkVector.z;
+  _x = rkVector._x;
+  _y = rkVector._y;
+  _z = rkVector._z;
 }
 
 //----------------------------------------------------------------------------
 Vector3::Vector3 (const Point& p)
 {
-  x = p.x;
-  y = p.y;
-  z = p.z;
+  _x = p._x;
+  _y = p._y;
+  _z = p._z;
 }
 
 //----------------------------------------------------------------------------
-double& Vector3::operator[] (int i) const
+double& Vector3::operator[] (int i)
 {
   // assert:  0 <= i < 2; x, y, and z are packed into 3*sizeof(double)
   //          bytes
-  return (double&) *(&x + i);
+  mirtkAssert(&_y == (&_x + 1), "x, y, and z are packed into 3*sizeof(double) bytes");
+  mirtkAssert(&_z == (&_x + 2), "x, y, and z are packed into 3*sizeof(double) bytes");
+  return *(&_x + i);
+}
+
+//----------------------------------------------------------------------------
+const double& Vector3::operator[] (int i) const
+{
+  // assert:  0 <= i < 2; x, y, and z are packed into 3*sizeof(double)
+  //          bytes
+  mirtkAssert(&_y == (&_x + 1), "x, y, and z are packed into 3*sizeof(double) bytes");
+  mirtkAssert(&_z == (&_x + 2), "x, y, and z are packed into 3*sizeof(double) bytes");
+  return *(&_x + i);
 }
 
 //----------------------------------------------------------------------------
 Vector3::operator double* ()
 {
-  return &x;
+  mirtkAssert(&_y == (&_x + 1), "x, y, and z are packed into 3*sizeof(double) bytes");
+  mirtkAssert(&_z == (&_x + 2), "x, y, and z are packed into 3*sizeof(double) bytes");
+  return &_x;
+}
+
+//----------------------------------------------------------------------------
+Vector3::operator const double* () const
+{
+  mirtkAssert(&_y == (&_x + 1), "x, y, and z are packed into 3*sizeof(double) bytes");
+  mirtkAssert(&_z == (&_x + 2), "x, y, and z are packed into 3*sizeof(double) bytes");
+  return &_x;
 }
 
 //----------------------------------------------------------------------------
 Vector3& Vector3::operator= (const Vector3& rkVector)
 {
-  x = rkVector.x;
-  y = rkVector.y;
-  z = rkVector.z;
+  _x = rkVector._x;
+  _y = rkVector._y;
+  _z = rkVector._z;
   return *this;
 }
 
 //----------------------------------------------------------------------------
 Vector3& Vector3::operator= (double fScalar)
 {
-  x = y = z = fScalar;
+  _x = _y = _z = fScalar;
   return *this;
 }
 
 //----------------------------------------------------------------------------
 bool Vector3::operator== (const Vector3& rkVector) const
 {
-  return ( x == rkVector.x && y == rkVector.y && z == rkVector.z );
+  return (_x == rkVector._x && _y == rkVector._y && _z == rkVector._z);
 }
 
 //----------------------------------------------------------------------------
 bool Vector3::operator!= (const Vector3& rkVector) const
 {
-  return ( x != rkVector.x || y != rkVector.y || z != rkVector.z );
+  return (_x != rkVector._x || _y != rkVector._y || _z != rkVector._z);
 }
 
 //----------------------------------------------------------------------------
 Vector3 Vector3::operator+ (const Vector3& rkVector) const
 {
   Vector3 kSum;
-  kSum.x = x + rkVector.x;
-  kSum.y = y + rkVector.y;
-  kSum.z = z + rkVector.z;
+  kSum._x = _x + rkVector._x;
+  kSum._y = _y + rkVector._y;
+  kSum._z = _z + rkVector._z;
   return kSum;
 }
 
@@ -133,9 +156,9 @@ Vector3 Vector3::operator+ (const Vector3& rkVector) const
 Vector3 Vector3::operator- (const Vector3& rkVector) const
 {
   Vector3 kDiff;
-  kDiff.x = x - rkVector.x;
-  kDiff.y = y - rkVector.y;
-  kDiff.z = z - rkVector.z;
+  kDiff._x = _x - rkVector._x;
+  kDiff._y = _y - rkVector._y;
+  kDiff._z = _z - rkVector._z;
   return kDiff;
 }
 
@@ -143,9 +166,9 @@ Vector3 Vector3::operator- (const Vector3& rkVector) const
 Vector3 Vector3::operator* (double fScalar) const
 {
   Vector3 kProd;
-  kProd.x = fScalar*x;
-  kProd.y = fScalar*y;
-  kProd.z = fScalar*z;
+  kProd._x = fScalar*_x;
+  kProd._y = fScalar*_y;
+  kProd._z = fScalar*_z;
   return kProd;
 }
 
@@ -153,9 +176,9 @@ Vector3 Vector3::operator* (double fScalar) const
 Vector3 Vector3::operator- () const
 {
   Vector3 kNeg;
-  kNeg.x = -x;
-  kNeg.y = -y;
-  kNeg.z = -z;
+  kNeg._x = -_x;
+  kNeg._y = -_y;
+  kNeg._z = -_z;
   return kNeg;
 }
 
@@ -163,49 +186,49 @@ Vector3 Vector3::operator- () const
 Vector3 operator* (double fScalar, const Vector3& rkVector)
 {
   Vector3 kProd;
-  kProd.x = fScalar*rkVector.x;
-  kProd.y = fScalar*rkVector.y;
-  kProd.z = fScalar*rkVector.z;
+  kProd._x = fScalar*rkVector._x;
+  kProd._y = fScalar*rkVector._y;
+  kProd._z = fScalar*rkVector._z;
   return kProd;
 }
 
 //----------------------------------------------------------------------------
 Vector3& Vector3::operator+= (const Vector3& rkVector)
 {
-  x += rkVector.x;
-  y += rkVector.y;
-  z += rkVector.z;
+  _x += rkVector._x;
+  _y += rkVector._y;
+  _z += rkVector._z;
   return *this;
 }
 
 //----------------------------------------------------------------------------
 Vector3& Vector3::operator-= (const Vector3& rkVector)
 {
-  x -= rkVector.x;
-  y -= rkVector.y;
-  z -= rkVector.z;
+  _x -= rkVector._x;
+  _y -= rkVector._y;
+  _z -= rkVector._z;
   return *this;
 }
 
 //----------------------------------------------------------------------------
 Vector3& Vector3::operator*= (double fScalar)
 {
-  x *= fScalar;
-  y *= fScalar;
-  z *= fScalar;
+  _x *= fScalar;
+  _y *= fScalar;
+  _z *= fScalar;
   return *this;
 }
 
 //----------------------------------------------------------------------------
 double Vector3::SquaredLength () const
 {
-  return x*x + y*y + z*z;
+  return _x*_x + _y*_y + _z*_z;
 }
 
 //----------------------------------------------------------------------------
 double Vector3::Dot (const Vector3& rkVector) const
 {
-  return x*rkVector.x + y*rkVector.y + z*rkVector.z;
+  return _x*rkVector._x + _y*rkVector._y + _z*rkVector._z;
 }
 
 //----------------------------------------------------------------------------
@@ -215,9 +238,9 @@ Vector3 Vector3::operator/ (double fScalar) const
 
   if ( fScalar != 0.0 ) {
     double fInvScalar = 1.0/fScalar;
-    kQuot.x = fInvScalar*x;
-    kQuot.y = fInvScalar*y;
-    kQuot.z = fInvScalar*z;
+    kQuot._x = fInvScalar*_x;
+    kQuot._y = fInvScalar*_y;
+    kQuot._z = fInvScalar*_z;
     return kQuot;
   } else {
     cerr << "Vector3::operator/: division by 0" << endl;
@@ -230,9 +253,9 @@ Vector3& Vector3::operator/= (double fScalar)
 {
   if ( fScalar != 0.0 ) {
     double fInvScalar = 1.0/fScalar;
-    x *= fInvScalar;
-    y *= fInvScalar;
-    z *= fInvScalar;
+    _x *= fInvScalar;
+    _y *= fInvScalar;
+    _z *= fInvScalar;
   } else {
     cerr << "Vector3::operator/=: division by 0" << endl;
     exit(1);
@@ -244,7 +267,7 @@ Vector3& Vector3::operator/= (double fScalar)
 //----------------------------------------------------------------------------
 double Vector3::Length () const
 {
-  return sqrt(x*x + y*y + z*z);
+  return sqrt(_x*_x + _y*_y + _z*_z);
 }
 
 //----------------------------------------------------------------------------
@@ -254,9 +277,9 @@ double Vector3::Normalize(double fTolerance)
 
   if ( fLength > fTolerance ) {
     double fInvLength = 1.0/fLength;
-    x *= fInvLength;
-    y *= fInvLength;
-    z *= fInvLength;
+    _x *= fInvLength;
+    _y *= fInvLength;
+    _z *= fInvLength;
   } else {
     fLength = 0.0;
   }
@@ -275,9 +298,9 @@ Vector3 Vector3::Cross (const Vector3& rkVector) const
 {
   Vector3 kCross;
 
-  kCross.x = y*rkVector.z - z*rkVector.y;
-  kCross.y = z*rkVector.x - x*rkVector.z;
-  kCross.z = x*rkVector.y - y*rkVector.x;
+  kCross._x = _y*rkVector._z - _z*rkVector._y;
+  kCross._y = _z*rkVector._x - _x*rkVector._z;
+  kCross._z = _x*rkVector._y - _y*rkVector._x;
 
   return kCross;
 }
@@ -287,9 +310,9 @@ Vector3 Vector3::UnitCross (const Vector3& rkVector) const
 {
   Vector3 kCross;
 
-  kCross.x = y*rkVector.z - z*rkVector.y;
-  kCross.y = z*rkVector.x - x*rkVector.z;
-  kCross.z = x*rkVector.y - y*rkVector.x;
+  kCross._x = _y*rkVector._z - _z*rkVector._y;
+  kCross._y = _z*rkVector._x - _x*rkVector._z;
+  kCross._z = _x*rkVector._y - _y*rkVector._x;
   kCross.Unitize();
 
   return kCross;
@@ -330,15 +353,15 @@ void Vector3::GenerateOrthonormalBasis(Vector3& rkU, Vector3& rkV,
   if ( !bUnitLengthW )
     rkW.Unitize();
 
-  if (abs(rkW.x) >= abs(rkW.y) &&
-      abs(rkW.x) >= abs(rkW.z)) {
-    rkU.x = -rkW.y;
-    rkU.y = +rkW.x;
-    rkU.z = 0.0;
+  if (abs(rkW._x) >= abs(rkW._y) &&
+      abs(rkW._x) >= abs(rkW._z)) {
+    rkU._x = -rkW._y;
+    rkU._y = +rkW._x;
+    rkU._z = 0.0;
   } else {
-    rkU.x = 0.0;
-    rkU.y = +rkW.z;
-    rkU.z = -rkW.y;
+    rkU._x = 0.0;
+    rkU._y = +rkW._z;
+    rkU._z = -rkW._y;
   }
 
   rkU.Unitize();

--- a/Modules/PointSet/src/ImageSurfaceStatistics.cc
+++ b/Modules/PointSet/src/ImageSurfaceStatistics.cc
@@ -66,7 +66,7 @@ protected:
 
     // Sample patch values
     _Points->GetPoint(ptId, o);
-    _Image->WorldToImage(o.x, o.y, o.z);
+    _Image->WorldToImage(o._x, o._y, o._z);
     o -= (_Size.x / 2.) * dx;
     o -= (_Size.y / 2.) * dy;
     o -= (_Size.z / 2.) * dz;
@@ -75,7 +75,7 @@ protected:
     for (int j = 0; j < _Size.y; ++j) {
       p = o + j * dy + k * dz;
       for (int i = 0; i < _Size.x; ++i, ++v, p += dx) {
-        (*v) = _Image->Evaluate(p.x, p.y, p.z);
+        (*v) = _Image->Evaluate(p._x, p._y, p._z);
       }
     }
 

--- a/Modules/PointSet/src/SurfaceRemeshing.cc
+++ b/Modules/PointSet/src/SurfaceRemeshing.cc
@@ -597,7 +597,7 @@ bool SurfaceRemeshing
 
   // Move first point to edge middlepoint
   const Point m = MiddlePoint(ptId1, ptId2);
-  _Output->GetPoints()->SetPoint(ptId1, m.x, m.y, m.z);
+  _Output->GetPoints()->SetPoint(ptId1, m._x, m._y, m._z);
   _Output->GetPoints()->Modified();
 
   // Replace second point in (remaining) adjacent cells by first point
@@ -903,7 +903,7 @@ void SurfaceRemeshing
   vtkCellData  * const cd     = output->GetCellData();
 
   const Point     midPoint = MiddlePoint(ptId1, ptId2);
-  const vtkIdType midPtId  = points->InsertNextPoint(midPoint.x, midPoint.y, midPoint.z);
+  const vtkIdType midPtId  = points->InsertNextPoint(midPoint._x, midPoint._y, midPoint._z);
   vtkIdType       newId, pts[3];
 
   InterpolatePointData(pd, midPtId, ptId1, ptId2);
@@ -934,8 +934,8 @@ void SurfaceRemeshing
 
   const Point     midPoint1 = MiddlePoint(ptId1, ptId2);
   const Point     midPoint2 = MiddlePoint(ptId2, ptId3);
-  const vtkIdType midPtId1  = points->InsertNextPoint(midPoint1.x, midPoint1.y, midPoint1.z);
-  const vtkIdType midPtId2  = points->InsertNextPoint(midPoint2.x, midPoint2.y, midPoint2.z);
+  const vtkIdType midPtId1  = points->InsertNextPoint(midPoint1._x, midPoint1._y, midPoint1._z);
+  const vtkIdType midPtId2  = points->InsertNextPoint(midPoint2._x, midPoint2._y, midPoint2._z);
   vtkIdType       newId, pts[3];
 
   InterpolatePointData(pd, midPtId1, ptId1, ptId2);
@@ -974,9 +974,9 @@ void SurfaceRemeshing
   const Point     midPoint1 = MiddlePoint(ptId1, ptId2);
   const Point     midPoint2 = MiddlePoint(ptId2, ptId3);
   const Point     midPoint3 = MiddlePoint(ptId3, ptId1);
-  const vtkIdType midPtId1  = points->InsertNextPoint(midPoint1.x, midPoint1.y, midPoint1.z);
-  const vtkIdType midPtId2  = points->InsertNextPoint(midPoint2.x, midPoint2.y, midPoint2.z);
-  const vtkIdType midPtId3  = points->InsertNextPoint(midPoint3.x, midPoint3.y, midPoint3.z);
+  const vtkIdType midPtId1  = points->InsertNextPoint(midPoint1._x, midPoint1._y, midPoint1._z);
+  const vtkIdType midPtId2  = points->InsertNextPoint(midPoint2._x, midPoint2._y, midPoint2._z);
+  const vtkIdType midPtId3  = points->InsertNextPoint(midPoint3._x, midPoint3._y, midPoint3._z);
   vtkIdType       newId, pts[3];
 
   InterpolatePointData(pd, midPtId1, ptId1, ptId2);


### PR DESCRIPTION
A reference member variable increases the size of the type.