### PR TITLE
fix: Memory leaks in Debug config

### DIFF
--- a/Modules/IO/include/mirtk/NiftiImageReader.h
+++ b/Modules/IO/include/mirtk/NiftiImageReader.h
@@ -21,6 +21,7 @@
 #define MIRTK_NiftiImageReader_H
 
 #include "mirtk/ImageReader.h"
+#include "mirtk/Memory.h"
 
 
 namespace mirtk {
@@ -46,7 +47,7 @@ class NiftiImageReader : public ImageReader
   mirtkReadOnlyAttributeMacro(string, ImageName);
 
   /// NIfTI image
-  NiftiImage *_Nifti;
+  UniquePtr<NiftiImage> _Nifti;
 
 public:
 

--- a/Modules/IO/include/mirtk/NiftiImageWriter.h
+++ b/Modules/IO/include/mirtk/NiftiImageWriter.h
@@ -23,6 +23,7 @@
 
 #include "mirtk/ImageWriter.h"
 
+#include "mirtk/Memory.h"
 #include "mirtk/Array.h"
 
 
@@ -44,7 +45,7 @@ class NiftiImageWriter : public ImageWriter
   mirtkObjectMacro(NiftiImageWriter);
 
   /// NIfTI image
-  NiftiImage *_Nifti;
+  UniquePtr<NiftiImage> _Nifti;
 
 public:
 

--- a/Modules/IO/src/NiftiImage.cc
+++ b/Modules/IO/src/NiftiImage.cc
@@ -34,7 +34,6 @@ NiftiImage::NiftiImage(const char *fname)
   nim(nullptr)
 {
   if (fname) Read(fname);
-  else nim = nifti_simple_init_nim();
 }
 
 // -----------------------------------------------------------------------------
@@ -50,7 +49,10 @@ NiftiImage::~NiftiImage()
 // -----------------------------------------------------------------------------
 void NiftiImage::Read(const char *filename)
 {
-  if (nim != nullptr) nifti_image_free(nim);
+  if (nim != nullptr) {
+    nim->data = nullptr; // (de)allocated elsewhere
+    nifti_image_free(nim);
+  }
   const int read_data = 0;
   nim = nifti_image_read(filename, read_data);
 }
@@ -65,6 +67,13 @@ void NiftiImage::Initialize(int x, int y, int z, int t, int u,
   nifti_dmat44 mat_44;
   int nbytepix = 0, ss = 0;
   int i, j;
+
+  // Initialize NIfTI I/O data structure
+  if (nim != nullptr) {
+    nim->data = nullptr; // (de)allocated elsewhere
+    nifti_image_free(nim);
+  }
+  nim = nifti_simple_init_nim();
 
   // Spatial dimensions
   nim->nifti_type = 1;               // 1==nii (1 file) - should set the magic in nhdr in Write()

--- a/Modules/IO/src/NiftiImageWriter.cc
+++ b/Modules/IO/src/NiftiImageWriter.cc
@@ -86,7 +86,6 @@ NiftiImageWriter::NiftiImageWriter()
 // -----------------------------------------------------------------------------
 NiftiImageWriter::~NiftiImageWriter()
 {
-  delete _Nifti;
 }
 
 // =============================================================================
@@ -105,90 +104,90 @@ void NiftiImageWriter::Initialize()
   double xsize, ysize, zsize, tsize;
   _Input->GetPixelSize(&xsize, &ysize, &zsize, &tsize);
 
-  Matrix  qmat = _Input->GetImageToWorldMatrix();
-  Matrix *smat = NULL;
+  Matrix qmat = _Input->GetImageToWorldMatrix();
+  UniquePtr<Matrix> smat;
   if (!_Input->GetAffineMatrix().IsIdentity()) {
-    smat = new Matrix(qmat);
+    smat.reset(new Matrix(qmat));
     qmat = _Input->GetAffineMatrix().Inverse() * qmat;
   }
   const double torigin = _Input->ImageToTime(0);
 
   // Init header
-  const void *data = _Input->GetDataPointer();
+  const void * const data = _Input->GetDataPointer();
   switch (_Input->GetDataType()) {
     case MIRTK_VOXEL_CHAR: {
       _Nifti->Initialize(nx, ny, nz, nt, xsize, ysize, zsize, tsize,
-                         NIFTI_TYPE_INT8, qmat, smat, torigin, data);
+                         NIFTI_TYPE_INT8, qmat, smat.get(), torigin, data);
       break;
     }
     case MIRTK_VOXEL_UNSIGNED_CHAR: {
       _Nifti->Initialize(nx, ny, nz, nt, xsize, ysize, zsize, tsize,
-                         NIFTI_TYPE_UINT8, qmat, smat, torigin, data);
+                         NIFTI_TYPE_UINT8, qmat, smat.get(), torigin, data);
       break;
     }
     case MIRTK_VOXEL_SHORT: {
       _Nifti->Initialize(nx, ny, nz, nt, xsize, ysize, zsize, tsize,
-                         NIFTI_TYPE_INT16, qmat, smat, torigin, data);
+                         NIFTI_TYPE_INT16, qmat, smat.get(), torigin, data);
       break;
     }
     case MIRTK_VOXEL_UNSIGNED_SHORT: {
       _Nifti->Initialize(nx, ny, nz, nt, xsize, ysize, zsize, tsize,
-                         NIFTI_TYPE_UINT16, qmat, smat, torigin, data);
+                         NIFTI_TYPE_UINT16, qmat, smat.get(), torigin, data);
       break;
     }
     case MIRTK_VOXEL_INT: {
       _Nifti->Initialize(nx, ny, nz, nt, xsize, ysize, zsize, tsize,
-                         NIFTI_TYPE_INT32, qmat, smat, torigin, data);
+                         NIFTI_TYPE_INT32, qmat, smat.get(), torigin, data);
       break;
     }
     case MIRTK_VOXEL_UNSIGNED_INT: {
       _Nifti->Initialize(nx, ny, nz, nt, xsize, ysize, zsize, tsize,
-                         NIFTI_TYPE_UINT32, qmat, smat, torigin, data);
+                         NIFTI_TYPE_UINT32, qmat, smat.get(), torigin, data);
       break;
     }
     case MIRTK_VOXEL_FLOAT: {
       _Nifti->Initialize(nx, ny, nz, nt, xsize, ysize, zsize, tsize,
-                         NIFTI_TYPE_FLOAT32, qmat, smat, torigin, data);
+                         NIFTI_TYPE_FLOAT32, qmat, smat.get(), torigin, data);
       break;
     }
 //    case MIRTK_VOXEL_FLOAT2: {
 //      _Nifti->Initialize(nx, ny, nz, nt, 2, xsize, ysize, zsize, tsize,
-//                         NIFTI_TYPE_FLOAT32, qmat, smat, torigin,
+//                         NIFTI_TYPE_FLOAT32, qmat, smat.get(), torigin,
 //                         ReformatImageData<Float2>(data, nx, ny, nz, nt, 2));
 //      break;
 //    }
     case MIRTK_VOXEL_FLOAT3: {
       _Nifti->Initialize(nx, ny, nz, nt, 3, xsize, ysize, zsize, tsize,
-                         NIFTI_TYPE_FLOAT32, qmat, smat, torigin,
+                         NIFTI_TYPE_FLOAT32, qmat, smat.get(), torigin,
                          ReformatImageData<Float3>(data, nx, ny, nz, nt, 3));
       break;
     }
     case MIRTK_VOXEL_FLOAT4: {
       _Nifti->Initialize(nx, ny, nz, nt, 4, xsize, ysize, zsize, tsize,
-                         NIFTI_TYPE_FLOAT32, qmat, smat, torigin,
+                         NIFTI_TYPE_FLOAT32, qmat, smat.get(), torigin,
                          ReformatImageData<Float4>(data, nx, ny, nz, nt, 4));
       break;
     }
     case MIRTK_VOXEL_DOUBLE: {
       _Nifti->Initialize(nx, ny, nz, nt, xsize, ysize, zsize, tsize,
-                         NIFTI_TYPE_FLOAT64, qmat, smat, torigin, data);
+                         NIFTI_TYPE_FLOAT64, qmat, smat.get(), torigin, data);
       break;
     }
 //    case MIRTK_VOXEL_DOUBLE2: {
 //      _Nifti->Initialize(nx, ny, nz, nt, 2, xsize, ysize, zsize, tsize,
-//                         NIFTI_TYPE_FLOAT64, qmat, smat, torigin,
+//                         NIFTI_TYPE_FLOAT64, qmat, smat.get(), torigin,
 //                         ReformatImageData<Double2>(data, nx, ny, nz, nt, 2));
 //      break;
 //    }
     case MIRTK_VOXEL_DOUBLE3: {
       _Nifti->Initialize(nx, ny, nz, nt, 3, xsize, ysize, zsize, tsize,
-                         NIFTI_TYPE_FLOAT64, qmat, smat, torigin,
+                         NIFTI_TYPE_FLOAT64, qmat, smat.get(), torigin,
                          ReformatImageData<Double3>(data, nx, ny, nz, nt, 3));
       break;
     }
     case MIRTK_VOXEL_DOUBLE4: {
       _Nifti->Initialize(nx, ny, nz, nt, 4, xsize, ysize, zsize, tsize,
-                         NIFTI_TYPE_FLOAT64, qmat, smat, torigin,
+                         NIFTI_TYPE_FLOAT64, qmat, smat.get(), torigin,
                          ReformatImageData<Double4>(data, nx, ny, nz, nt, 4));
       break;
     }
@@ -196,8 +195,6 @@ void NiftiImageWriter::Initialize()
       cerr << this->NameOfClass() << "::Initialize(): Unsupported voxel type: " << _Input->GetDataType() << endl;
       exit(1);
   }
-
-  delete smat;
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Image/src/ImageWriterFactory.cc
+++ b/Modules/Image/src/ImageWriterFactory.cc
@@ -47,7 +47,10 @@ ImageWriterFactory::~ImageWriterFactory()
 // -----------------------------------------------------------------------------
 bool ImageWriterFactory::Register(const Array<string> &exts, ImageWriterCreator creator)
 {
-  mirtkAssert(creator() != nullptr, "ImageWriterCreator produces object");
+  #ifndef NDEBUG
+    UniquePtr<ImageWriter> writer(creator());
+    mirtkAssert(writer != nullptr, "ImageWriterCreator produces object");
+  #endif
   for (auto ext = exts.begin(); ext != exts.end(); ++ext) {
     _Associations[*ext] = creator;
   }


### PR DESCRIPTION
Fixes memory leaks caused by assertions when built with `NDEBUG` not defined. Further introduces use of `UniqePtr` in NIfTI I/O filters to reduce risk of memory leaks.