### PR TITLE
enh: Decode command output by default as UTF-8 [Applications]

### DIFF
--- a/Applications/lib/python/mirtk/subprocess.py.in
+++ b/Applications/lib/python/mirtk/subprocess.py.in
@@ -124,9 +124,11 @@ def check_call(argv, verbose=0):
     _call(argv, verbose=verbose, execfunc=subprocess.check_call)
 
 # ----------------------------------------------------------------------------
-def check_output(argv, verbose=0):
+def check_output(argv, verbose=0, code='utf-8'):
     """Execute MIRTK command and return its output."""
-    return _call(argv, verbose=verbose, execfunc=subprocess.check_output)
+    output = _call(argv, verbose=verbose, execfunc=subprocess.check_output)
+    if code: output = output.decode(code)
+    return output
 
 # ----------------------------------------------------------------------------
 def run(cmd, args=[], opts={}, verbose=0, threads=0):


### PR DESCRIPTION
This is needed for Python 3 when the returned value should be a `str` rather than a bytes-like object.