### PR TITLE
fix: Implicit type cast and signed/unsigned comparison warnings

### DIFF
--- a/Applications/src/evaluate-similarity.cc
+++ b/Applications/src/evaluate-similarity.cc
@@ -314,7 +314,7 @@ int main(int argc, char **argv)
       for (int i = 0; i < target.X(); ++i) {
         x = i, y = j, z = k;
         target.ImageToWorld(x, y, z);
-        mask(i, j, k) = nn.Evaluate(x, y, z);
+        mask(i, j, k) = static_cast<BinaryPixel>(nn.Evaluate(x, y, z));
       }
     }
     if (verbose > 1) cout << " done" << endl;

--- a/Applications/src/subdivide-brain-image.cc
+++ b/Applications/src/subdivide-brain-image.cc
@@ -487,7 +487,7 @@ ByteImage Cut(const ByteImage &regions, const Plane &plane, double r)
     x = i, y = j, z = 0.;
     attr.LatticeToWorld(x, y, z);
     regions.WorldToImage(x, y, z);
-    cut(i, j) = nn.Evaluate(x, y, z);
+    cut(i, j) = static_cast<BytePixel>(nn.Evaluate(x, y, z));
   }
 
   return cut;

--- a/Modules/IO/src/PointSetIO.cc
+++ b/Modules/IO/src/PointSetIO.cc
@@ -397,7 +397,7 @@ vtkSmartPointer<vtkPointSet> ReadPointSetTable(const char *fname, char sep, vtkP
     const auto pos = ifs.tellg();
     Array<Point> coords;
     double p[3] = {0.};
-    size_t ptId = 0;
+    vtkIdType ptId = 0;
     size_t irow = 0;
     while (getline(ifs, line)) {
       ++irow;
@@ -423,12 +423,12 @@ vtkSmartPointer<vtkPointSet> ReadPointSetTable(const char *fname, char sep, vtkP
         }
       }
       if (id_col != -1) {
-        if (!FromString(cols[id_col], value) || static_cast<double>(static_cast<size_t>(value)) != value) {
+        if (!FromString(cols[id_col], value) || static_cast<double>(static_cast<vtkIdType>(value)) != value) {
           if (errmsg) cerr << "Invalid point ID in row " << irow << endl;
           return vtkSmartPointer<vtkPolyData>::New();
         }
-        ptId = static_cast<size_t>(value);
-        if (ptId >= coords.size()) {
+        ptId = static_cast<vtkIdType>(value);
+        if (ptId >= static_cast<vtkIdType>(coords.size())) {
           coords.resize(ptId + 1);
         }
         coords[ptId] = Point(p);
@@ -460,9 +460,9 @@ vtkSmartPointer<vtkPointSet> ReadPointSetTable(const char *fname, char sep, vtkP
     if (pos != string::npos && pos != header[i].length()-1) {
       const string name = header[i].substr(0, pos);
       const string comp = header[i].substr(pos + 1);
-      comps[name].insert(MakePair(i, move(comp)));
+      comps[name].insert(MakePair(static_cast<int>(i), move(comp)));
     } else {
-      comps[header[i]].insert(MakePair(i, ""));
+      comps[header[i]].insert(MakePair(static_cast<int>(i), ""));
     }
   }
 

--- a/Modules/Image/include/mirtk/DataStatistics.h
+++ b/Modules/Image/include/mirtk/DataStatistics.h
@@ -465,7 +465,7 @@ public:
       }
     }
     if (values.size() <= 0) return NaN;
-    return NthElement(values, values.size()/2);
+    return NthElement(values, static_cast<int>(values.size())/2);
   }
 
   void Evaluate(Array<double> &values, int n, const double *data, const bool *mask = nullptr) const

--- a/Modules/PointSet/src/PointSetUtils.cc
+++ b/Modules/PointSet/src/PointSetUtils.cc
@@ -394,7 +394,7 @@ EdgeList BoundaryEdges(vtkDataSet *dataset, const EdgeTable &edgeTable)
     dataset->GetPointCells(ptId2, cellIds2);
     cellIds1->IntersectWith(cellIds2);
     if (cellIds1->GetNumberOfIds() < 2) {
-      boundaryEdges.push_back(MakePair(ptId1, ptId2));
+      boundaryEdges.push_back(MakePair(static_cast<int>(ptId1), static_cast<int>(ptId2)));
     }
   }
   return boundaryEdges;

--- a/Modules/PointSet/src/Stripper.cc
+++ b/Modules/PointSet/src/Stripper.cc
@@ -159,7 +159,7 @@ void Stripper::Execute()
     // Add new joined line (**after** RemoveDeletedCells)
     vtkCellArray * const arr = _Output->GetLines();
     for (const auto &line : lines) {
-      arr->InsertNextCell(line.size());
+      arr->InsertNextCell(static_cast<int>(line.size()));
       for (const auto &ptId : line) {
         arr->InsertCellPoint(ptId);
       }


### PR DESCRIPTION
Fix warnings about implicit type cast with potential loss of precision as well as comparisons of signed with unsigned values.