### PR TITLE
enh: Add std::flush to mirtk namespace [Common]

### DIFF
--- a/Modules/Common/include/mirtk/Stream.h
+++ b/Modules/Common/include/mirtk/Stream.h
@@ -46,6 +46,7 @@ using std::ostringstream;
 using std::cin;
 using std::cout;
 using std::cerr;
+using std::flush;
 
 // Bidirectional stream
 using std::iostream;


### PR DESCRIPTION
So far always used `cout.flush()` but this allows `cout << flush`.