### PR TITLE
fix: Add missing EdgeConnectivity constructor called by RegisteredPointSet [PointSet]

### DIFF
--- a/Modules/PointSet/include/mirtk/EdgeConnectivity.h
+++ b/Modules/PointSet/include/mirtk/EdgeConnectivity.h
@@ -58,7 +58,10 @@ class EdgeConnectivity : public GenericSparseMatrix<int>
 public:
 
   /// Construct edge-connectivity table for given dataset
-  EdgeConnectivity(vtkDataSet * = NULL, int n = 3, const EdgeTable * = NULL);
+  EdgeConnectivity(vtkDataSet * = nullptr, int n = 3, const EdgeTable * = nullptr);
+
+  /// Construct edge-connectivity table for given dataset
+  EdgeConnectivity(vtkDataSet *, double r, const EdgeTable * = nullptr);
 
   /// Copy constructor
   EdgeConnectivity(const EdgeConnectivity &);
@@ -70,10 +73,10 @@ public:
   virtual ~EdgeConnectivity();
 
   /// Initialize edge-connectivity table from given dataset
-  void Initialize(vtkDataSet *, int n = 3, const EdgeTable * = NULL);
+  void Initialize(vtkDataSet *, int n = 3, const EdgeTable * = nullptr);
 
   /// Initialize edge-connectivity table from given dataset
-  void Initialize(vtkDataSet *, double r, const EdgeTable * = NULL);
+  void Initialize(vtkDataSet *, double r, const EdgeTable * = nullptr);
 
   /// Clear edge-connectivity table
   virtual void Clear();

--- a/Modules/PointSet/src/EdgeConnectivity.cc
+++ b/Modules/PointSet/src/EdgeConnectivity.cc
@@ -157,6 +157,14 @@ EdgeConnectivity::EdgeConnectivity(vtkDataSet *mesh, int n, const EdgeTable *edg
 }
 
 // -----------------------------------------------------------------------------
+EdgeConnectivity::EdgeConnectivity(vtkDataSet *mesh, double r, const EdgeTable *edgeTable)
+  :
+  _Maximum(-1)
+{
+  if (mesh) Initialize(mesh, r, edgeTable);
+}
+
+// -----------------------------------------------------------------------------
 EdgeConnectivity::EdgeConnectivity(const EdgeConnectivity &other)
 :
   GenericSparseMatrix(other),


### PR DESCRIPTION
`RegisteredPointSet` now calls `NewShared<EdgeConnectivity>(dataset, radius, edgeTable)` instead of the `Initialize` function. This change silently introduced a bug where radius would be interpreted as max edge connectivity instead and the wrong constructor being called.