### PR TITLE
mod: Add optional Scripting package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,7 @@
 	url = https://github.com/MIRTK/Mapping.git
 [submodule "Packages/DrawEM"]
 	path = Packages/DrawEM
-	url = https://github.com/MIRTK/DrawEM
+	url = https://github.com/MIRTK/DrawEM.git
+[submodule "Packages/Scripting"]
+	path = Packages/Scripting
+	url = https://github.com/MIRTK/Scripting.git

--- a/BasisProject.cmake
+++ b/BasisProject.cmake
@@ -74,6 +74,7 @@ basis_project (
     Packages/Deformable
     Packages/Mapping
     Packages/DrawEM
+    Packages/Scripting
 
   # --------------------------------------------------------------------------
   # list of modules enabled by default
@@ -91,6 +92,7 @@ basis_project (
     Deformable
     Mapping
     DrawEM
+    Scripting
 
   # --------------------------------------------------------------------------
   # dependencies


### PR DESCRIPTION
Adds a new optional package intended to contain various utility functions useful for writing pipeline or other pre- or post-precessing scripts. This extra package currently only contains a Python module to render 2D screenshots of NIfTI volume slices with or without surface contours overlaid. Required by the [cortical surface evaluation tools](https://github.com/schuhschuh/CorticalSurfaceEvaluation) used to assess the quality of surfaces produced by the MIRTK `recon-neonatal-cortex` command.