### PR TITLE
enh/fix: Normalized cross correlation [Registration]

### DIFF
--- a/Modules/Common/include/mirtk/EnergyMeasure.h
+++ b/Modules/Common/include/mirtk/EnergyMeasure.h
@@ -47,7 +47,8 @@ enum EnergyMeasure
     EM_K,                       ///< Kappa statistic
     EM_ML,                      ///< Maximum likelihood
     EM_NGF_COS,                 ///< Cosine of normalzed gradient field
-    EM_LNCC,                    ///< Normalized/Local cross-correlation
+    EM_NCC,                     ///< Normalized cross-correlation
+    EM_LNCC = EM_NCC,           ///< Local normalized cross-correlation
     EM_CoVar,                   ///< Covariance
     EM_PSNR,                    ///< Peak signal-to-noise ratio
 
@@ -130,7 +131,7 @@ inline string ToString(const EnergyMeasure &value, int w, char c, bool left)
     case EM_K:       str = "K"; break;
     case EM_ML:      str = "ML"; break;
     case EM_NGF_COS: str = "NGF_COS"; break;
-    case EM_LNCC:    str = "LNCC"; break;
+    case EM_NCC:     str = "NCC"; break;
     case EM_CoVar:   str = "CoVar"; break;
     case EM_PSNR:    str = "PSNR"; break;
 
@@ -191,7 +192,7 @@ inline string ToPrettyString(const EnergyMeasure &value, int w = 0, char c = ' '
     // ---------------------------------------------------------------------------
     // Image (dis-)similarity measures
     case EM_JE:      str = "Joint entropy"; break;
-    case EM_CC:      str = "Cross-correlation"; break;
+    case EM_CC:      str = "Normalized cross-correlation"; break;
     case EM_MI:      str = "Mutual information"; break;
     case EM_NMI:     str = "Normalized mutual information"; break;
     case EM_SSD:     str = "Sum of squared differences"; break;
@@ -201,7 +202,7 @@ inline string ToPrettyString(const EnergyMeasure &value, int w = 0, char c = ' '
     case EM_K:       str = "Kappa statistic"; break;
     case EM_ML:      str = "Maximum likelihood"; break;
     case EM_NGF_COS: str = "Cosine of normalized gradient field"; break;
-    case EM_LNCC:    str = "Local normalized cross-correlation"; break;
+    case EM_NCC:     str = "(Local) Normalized cross-correlation"; break;
     case EM_CoVar:   str = "Covariance"; break;
     case EM_PSNR:    str = "Peak signal-to-noise ratio"; break;
 
@@ -265,8 +266,8 @@ inline bool FromString(const char *str, EnergyMeasure &value)
   // ---------------------------------------------------------------------------
   // Alternative names for image (dis-)similarity measures
   if (value == EM_Unknown) {
-    if      (lstr == "ncc")   value = EM_LNCC;
-    else if (lstr == "lcc")   value = EM_LNCC;
+    if      (lstr == "lcc")   value = EM_NCC;
+    else if (lstr == "lncc")  value = EM_NCC;
     else if (lstr == "kappa") value = EM_K;
     else if (lstr == "correlation ratio xy" ||
              lstr == "correlationratioxy") value = EM_CR_XY;

--- a/Modules/Registration/include/mirtk/IntensityCrossCorrelation.h
+++ b/Modules/Registration/include/mirtk/IntensityCrossCorrelation.h
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2017 Imperial College London
+ * Copyright 2013-2017 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,16 +20,18 @@
 #ifndef MIRTK_IntensityCrossCorrelation_H
 #define MIRTK_IntensityCrossCorrelation_H
 
-#include "mirtk/ImageSimilarity.h"
+#include "mirtk/NormalizedIntensityCrossCorrelation.h"
 
 
 namespace mirtk {
 
 
 /**
- * Cross correlation image similarity measure
+ * Normalized cross correlation image similarity measure
+ *
+ * \deprecated Use NormalizedIntensityCrossCorrelation with (default) window size zero instead.
  */
-class IntensityCrossCorrelation : public ImageSimilarity
+class IntensityCrossCorrelation : public NormalizedIntensityCrossCorrelation
 {
   mirtkEnergyTermMacro(IntensityCrossCorrelation, EM_CC);
 
@@ -47,17 +49,7 @@ public:
   IntensityCrossCorrelation &operator =(const IntensityCrossCorrelation &);
 
   /// Destructor
-  ~IntensityCrossCorrelation();
-
-  // ---------------------------------------------------------------------------
-  // Evaluation
-protected:
-
-  /// Evaluate similarity of images
-  virtual double Evaluate();
-
-  /// Evaluate non-parametric similarity gradient w.r.t the given image
-  virtual bool NonParametricGradient(const RegisteredImage *, GradientImageType *);
+  virtual ~IntensityCrossCorrelation();
 
 };
 

--- a/Modules/Registration/include/mirtk/NormalizedIntensityCrossCorrelation.h
+++ b/Modules/Registration/include/mirtk/NormalizedIntensityCrossCorrelation.h
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2017 Imperial College London
+ * Copyright 2013-2017 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,11 +32,11 @@ namespace mirtk {
 
 
 /**
- * Normalized/Local cross correlation image similarity measure
+ * (Local) Normalized cross correlation image similarity measure
  */
 class NormalizedIntensityCrossCorrelation : public ImageSimilarity
 {
-  mirtkEnergyTermMacro(NormalizedIntensityCrossCorrelation, EM_LNCC);
+  mirtkEnergyTermMacro(NormalizedIntensityCrossCorrelation, EM_NCC);
 
   // ---------------------------------------------------------------------------
   // Types
@@ -87,18 +87,22 @@ private:
   /// Mean normalized target image
   mirtkComponentMacro(RealImage, T);
 
+  /// Global inner products computed over whole image domain
+  double _GlobalA, _GlobalB, _GlobalC, _GlobalS, _GlobalT;
+
   /// Temporary image used by ComputeWeightedAverage and WriteDataSets
   mutable RealImage _Temp;
 
   /// Size of box window or Full Width at Tenth Maximum (FWTM) of Gaussian kernel.
   /// A negative value indicates voxel units, while a positive value corresponds
-  /// to world units (i.e., mm).
+  /// to world units (i.e., mm). When 0, the global normalized cross correlation
+  /// is computed instead of local cross correlation within a neighborhood.
   mirtkPublicAttributeMacro(Vector3D<double>, NeighborhoodSize);
 
   /// Radius of local neighborhood window in number of voxels
   mirtkReadOnlyAttributeMacro(Vector3D<int>, NeighborhoodRadius);
 
-  /// Sum of local correlation coefficients
+  /// Sum of local correlation coefficients / global normalized cross correlation
   double _Sum;
 
   /// Size of overlap domain

--- a/Modules/Registration/include/mirtk/SimilarityMeasure.h
+++ b/Modules/Registration/include/mirtk/SimilarityMeasure.h
@@ -48,6 +48,7 @@ enum SimilarityMeasure
   SIM_K       = EM_K,       ///< Kappa statistic
   SIM_ML      = EM_ML,      ///< Maximum likelihood
   SIM_NGF_COS = EM_NGF_COS, ///< Cosine of normalzed gradient field
+  SIM_NCC     = EM_NCC,     ///< Normalized cross-correlation
   SIM_LNCC    = EM_LNCC,    ///< Local normalized cross-correlation
   SIM_CoVar   = EM_CoVar,   ///< Covariance
   SIM_PSNR    = EM_PSNR     ///< Peak signal-to-noise ratio

--- a/Modules/Registration/src/ImageSimilarity.cc
+++ b/Modules/Registration/src/ImageSimilarity.cc
@@ -27,7 +27,6 @@
 #include "mirtk/VoxelFunction.h"
 #include "mirtk/MultiLevelTransformation.h"
 
-#include "mirtk/NormalizedMutualImageInformation.h"
 
 namespace mirtk {
 

--- a/Modules/Registration/src/IntensityCrossCorrelation.cc
+++ b/Modules/Registration/src/IntensityCrossCorrelation.cc
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2017 Imperial College London
+ * Copyright 2013-2017 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 
 #include "mirtk/IntensityCrossCorrelation.h"
 
-#include "mirtk/Math.h"
 #include "mirtk/ObjectFactory.h"
 
 
@@ -38,7 +37,7 @@ mirtkAutoRegisterEnergyTermMacro(IntensityCrossCorrelation);
 IntensityCrossCorrelation
 ::IntensityCrossCorrelation(const char *name)
 :
-  ImageSimilarity(name)
+  NormalizedIntensityCrossCorrelation(name)
 {
 }
 
@@ -46,52 +45,13 @@ IntensityCrossCorrelation
 IntensityCrossCorrelation
 ::IntensityCrossCorrelation(const IntensityCrossCorrelation &other)
 :
-  ImageSimilarity(other)
+  NormalizedIntensityCrossCorrelation(other)
 {
 }
 
 // -----------------------------------------------------------------------------
 IntensityCrossCorrelation::~IntensityCrossCorrelation()
 {
-}
-
-// =============================================================================
-// Evaluation
-// =============================================================================
-
-// -----------------------------------------------------------------------------
-double IntensityCrossCorrelation::Evaluate()
-{
-  VoxelType *tgt = Target()->Data();
-  VoxelType *src = Source()->Data();
-
-  double x = .0, y = .0, xy = .0, x2 = .0, y2 = .0;
-  int    n =  0;
-  for (int idx = 0; idx < NumberOfVoxels(); ++idx, ++tgt, ++src) {
-    if (IsForeground(idx)) {
-      x  += *tgt;
-      y  += *src;
-      xy += (*tgt) * (*src);
-      x2 += (*tgt) * (*tgt);
-      y2 += (*tgt) * (*tgt);
-      ++n;
-    }
-  }
-
-  if (n == 0) return .0;
-  return (xy - (x * y) / n) / (sqrt(x2 - x * x / n) * sqrt(y2 - y *y / n));
-}
-
-// -----------------------------------------------------------------------------
-bool IntensityCrossCorrelation
-::NonParametricGradient(const RegisteredImage *image, GradientImageType *gradient)
-{
-  cerr << "IntensityCrossCorrelation::NonParametricGradient: Not implemented" << endl;
-  exit(1);
-
-  // Apply chain rule to obtain gradient w.r.t y = T(x)
-  MultiplyByImageGradient(image, gradient);
-  return true;
 }
 
 


### PR DESCRIPTION
Missing neighborhood iterator `SetChannel(0)` possibly after change of region iterator implementation. However, removed use of iterator all together as there is little benefit to using it. Implemented global NCC similarity measure for window size = 0.