### PR TITLE
fix: Scalar operators of GenericImage [Image]

### DIFF
--- a/Modules/Image/src/GenericImage.cc
+++ b/Modules/Image/src/GenericImage.cc
@@ -772,7 +772,7 @@ GenericImage<VoxelType>& GenericImage<VoxelType>::operator+=(double scalar)
   VoxelType *ptr = this->Data();
   for (int idx = 0; idx < _NumberOfVoxels; ++idx) {
     if (IsForeground(idx)) {
-      ptr[idx] = voxel_cast<VoxelType>(voxel_cast<double>(ptr[idx]) + scalar);
+      ptr[idx] += scalar;
     }
   }
   return *this;
@@ -785,7 +785,7 @@ GenericImage<VoxelType>& GenericImage<VoxelType>::operator-=(double scalar)
   VoxelType *ptr = this->Data();
   for (int idx = 0; idx < _NumberOfVoxels; ++idx) {
     if (IsForeground(idx)) {
-      ptr[idx] = voxel_cast<VoxelType>(voxel_cast<double>(ptr[idx]) - scalar);
+      ptr[idx] -= scalar;
     }
   }
   return *this;
@@ -798,7 +798,7 @@ GenericImage<VoxelType>& GenericImage<VoxelType>::operator*=(double scalar)
   VoxelType *ptr = this->Data();
   for (int idx = 0; idx < _NumberOfVoxels; ++idx) {
     if (IsForeground(idx)) {
-      ptr[idx] = voxel_cast<VoxelType>(voxel_cast<double>(ptr[idx]) * scalar);
+      ptr[idx] *= scalar;
     }
   }
   return *this;
@@ -812,7 +812,7 @@ GenericImage<VoxelType>& GenericImage<VoxelType>::operator/=(double scalar)
     VoxelType *ptr = this->Data();
     for (int idx = 0; idx < _NumberOfVoxels; ++idx) {
       if (IsForeground(idx)) {
-        ptr[idx] = voxel_cast<VoxelType>(voxel_cast<double>(ptr[idx]) / scalar);
+        ptr[idx] /= scalar;
       }
     }
   } else {


### PR DESCRIPTION
Fix of `-=`, `+=`, `*=`, and `/=` operators of `GenericImage` class. Indirectly fixes inversion of SV FFD transformation which uses `_CPImage *= -1.0`, where `_CPImage` is a vector-valued image.

The voxel_cast to double only works for scalar images, but not vector-valued images. One fix would be to use voxel_cast<RealType>, but rather let the VoxelType implement the respective arithmetic operator with double scalar argument on the right-hand side.