### PR TITLE
fix: Symmetry with symmetric SV FFD energy

### DIFF
--- a/Modules/Registration/src/GenericRegistrationFilter.cc
+++ b/Modules/Registration/src/GenericRegistrationFilter.cc
@@ -2219,7 +2219,10 @@ void GenericRegistrationFilter::GuessParameter()
   }
 
   // By default, crop/pad FFD lattice only if domain not explicitly specified
-  if (_CropPadFFD == -1) _CropPadFFD = (_Domain == NULL);
+  // and none of the transformation models is parameterised by velocities
+  if (_CropPadFFD == -1) {
+    _CropPadFFD = (_Domain == nullptr && !IsDiffeo(_TransformationModel));
+  }
 
   // Optimization parameters
   double value;

--- a/Modules/Registration/src/GenericRegistrationFilter.cc
+++ b/Modules/Registration/src/GenericRegistrationFilter.cc
@@ -2652,58 +2652,64 @@ void GenericRegistrationFilter::InitializeStatus(HomogeneousTransformation *lin)
 // -----------------------------------------------------------------------------
 void GenericRegistrationFilter::InitializeStatus(FreeFormTransformation *ffd)
 {
-  // Determine target data sets
-  Array<bool> is_target_image(NumberOfImages());
-  for (int n = 0; n < NumberOfImages(); ++n) {
-    is_target_image[n] = IsTargetImage(n);
-  }
-  #if MIRTK_Registration_WITH_PointSet
-    Array<bool> is_moving_pointset(NumberOfPointSets());
-    for (int n = 0; n < NumberOfPointSets(); ++n) {
-      is_moving_pointset[n] = IsMovingPointSet(n);
-    }
-  #endif // MIRTK_Registration_WITH_PointSet
-  // In case of fluid multi-level transformation, apply the global transformation
-  // to the target images because the FFDs are defined on this transformed lattice
-  Matrix             *smat = NULL;
-  ResampledImageType *image;
-  const FluidFreeFormTransformation *fluid;
-  if ((fluid = dynamic_cast<const FluidFreeFormTransformation *>(_Transformation))) {
-    smat = new Matrix[NumberOfImages()];
-    for (int n = 0; n < NumberOfImages(); ++n) {
-      if (is_target_image[n]) {
-        image   = const_cast<ResampledImageType *>(&_Image[_CurrentLevel][n]);
-        smat[n] = image->GetAffineMatrix();
-        image->PutAffineMatrix(fluid->GetGlobalTransformation()->GetMatrix());
-      }
-    }
-  }
-  // Initialize status of control points
-  InitializeCPStatus init_status(_Mask [_CurrentLevel],
-                                 _Image[_CurrentLevel], is_target_image,
-                                 _Transformation, ffd,
-                                 #if MIRTK_Registration_WITH_PointSet
-                                   _PointSet[_CurrentLevel], is_moving_pointset,
-                                 #endif // MIRTK_Registration_WITH_PointSet
-                                 _RegisterX, _RegisterY, _RegisterZ);
-  blocked_range<int> cps(0, ffd->NumberOfCPs());
-  parallel_for(cps, init_status);
-  // Restore affine transformation matrices of input images
-  if (smat) {
-    for (int n = 0; n < NumberOfImages(); ++n) {
-      if (is_target_image[n]) {
-        image = const_cast<ResampledImageType *>(&_Image[_CurrentLevel][n]);
-        image->PutAffineMatrix(smat[n]);
-      }
-    }
-    delete[] smat;
-  }
+  if (!IsDiffeo(_CurrentModel) || _CropPadFFD) {
 
-  // Discard passive DoFs to reduce memory/disk use
-  if (_CropPadFFD) {
-    ffd->CropPadPassiveCPs(ffd->KernelSize(),
-                           ffd->KernelSize(),
-                           ffd->KernelSize(), 0, true);
+    // Determine target data sets
+    Array<bool> is_target_image(NumberOfImages());
+    for (int n = 0; n < NumberOfImages(); ++n) {
+      is_target_image[n] = !IsMovingImage(n);
+    }
+    #if MIRTK_Registration_WITH_PointSet
+      Array<bool> is_moving_pointset(NumberOfPointSets());
+      for (int n = 0; n < NumberOfPointSets(); ++n) {
+        is_moving_pointset[n] = IsMovingPointSet(n);
+      }
+    #endif // MIRTK_Registration_WITH_PointSet
+
+    // In case of fluid multi-level transformation, apply the global transformation
+    // to the target images because the FFDs are defined on this transformed lattice
+    Matrix             *smat = NULL;
+    ResampledImageType *image;
+    const FluidFreeFormTransformation *fluid;
+    if ((fluid = dynamic_cast<const FluidFreeFormTransformation *>(_Transformation))) {
+      smat = new Matrix[NumberOfImages()];
+      for (int n = 0; n < NumberOfImages(); ++n) {
+        if (is_target_image[n]) {
+          image   = const_cast<ResampledImageType *>(&_Image[_CurrentLevel][n]);
+          smat[n] = image->GetAffineMatrix();
+          image->PutAffineMatrix(fluid->GetGlobalTransformation()->GetMatrix());
+        }
+      }
+    }
+
+    // Initialize status of control points
+    InitializeCPStatus init_status(_Mask [_CurrentLevel],
+                                   _Image[_CurrentLevel], is_target_image,
+                                   _Transformation, ffd,
+                                   #if MIRTK_Registration_WITH_PointSet
+                                     _PointSet[_CurrentLevel], is_moving_pointset,
+                                   #endif // MIRTK_Registration_WITH_PointSet
+                                   _RegisterX, _RegisterY, _RegisterZ);
+    blocked_range<int> cps(0, ffd->NumberOfCPs());
+    parallel_for(cps, init_status);
+
+    // Restore affine transformation matrices of input images
+    if (smat) {
+      for (int n = 0; n < NumberOfImages(); ++n) {
+        if (is_target_image[n]) {
+          image = const_cast<ResampledImageType *>(&_Image[_CurrentLevel][n]);
+          image->PutAffineMatrix(smat[n]);
+        }
+      }
+      delete[] smat;
+    }
+
+    // Discard passive DoFs to reduce memory/disk use
+    if (_CropPadFFD) {
+      ffd->CropPadPassiveCPs(ffd->KernelSize(),
+                             ffd->KernelSize(),
+                             ffd->KernelSize(), 0, true);
+    }
   }
 
   // In case of a transformation parameterized by a (stationary) velocity

--- a/Modules/Registration/src/GenericRegistrationFilter.cc
+++ b/Modules/Registration/src/GenericRegistrationFilter.cc
@@ -3786,7 +3786,8 @@ void GenericRegistrationFilter::AddImageSimilarityTerm()
       if (sim->IsSymmetric() || sim->_SourceTransformation.IsIdentity()) {
         attrs.push_back(OrthogonalFieldOfView(this->ImageAttributes(sim->_SourceIndex)));
       }
-      attr = OverallFieldOfView(attrs);
+      if (attrs.empty()) attr = this->RegistrationDomain();
+      else               attr = OverallFieldOfView(attrs);
     }
     // Instantiate new similarity measure term
     similarity = ImageSimilarity::New(sim->_Measure);

--- a/Modules/Registration/src/GenericRegistrationFilter.cc
+++ b/Modules/Registration/src/GenericRegistrationFilter.cc
@@ -2855,24 +2855,26 @@ void GenericRegistrationFilter::InitializeTransformation()
   // Compute domain on which free-form deformation must be defined
   struct ImageAttributes domain = _RegistrationDomain;
 
-  const HomogeneousTransformation        *ilin = NULL;
-  const MultiLevelFreeFormTransformation *iffd = NULL;
-
-  (ilin = dynamic_cast<const HomogeneousTransformation        *>(_InitialGuess)) ||
-  (iffd = dynamic_cast<const MultiLevelFreeFormTransformation *>(_InitialGuess));
-  if (iffd) ilin = iffd->GetGlobalTransformation();
-
-  if (ilin) {
-    // In case the global transformation is to be merged into the local one,
-    // make sure that the domain on which the local transformation is defined
-    // is large enough to avoid unpleasant boundary effects
-    if (_MergeGlobalAndLocalTransformation) {
-      domain = ffd->ApproximationDomain(domain, _InitialGuess);
-    // In case of fluid composition of global and local transformation,
-    // i.e., T = T_local o T_global, linearly transform attributes such that
-    // local transformation is defined for the mapped image region
-    } else if (_MultiLevelMode == MFFD_Fluid) {
-      domain.PutAffineMatrix(ilin->GetMatrix());
+  if (_InitialGuess && !_InitialGuess->IsIdentity()) {
+    const HomogeneousTransformation *ilin;
+    ilin = dynamic_cast<const HomogeneousTransformation *>(_InitialGuess);
+    if (!ilin) {
+      const MultiLevelFreeFormTransformation *iffd;
+      iffd = dynamic_cast<const MultiLevelFreeFormTransformation *>(_InitialGuess);
+      if (iffd) ilin = iffd->GetGlobalTransformation();
+    }
+    if (ilin) {
+      // In case the global transformation is to be merged into the local one,
+      // make sure that the domain on which the local transformation is defined
+      // is large enough to avoid unpleasant boundary effects
+      if (_MergeGlobalAndLocalTransformation) {
+        domain = ffd->ApproximationDomain(domain, _InitialGuess);
+      // In case of fluid composition of global and local transformation,
+      // i.e., T = T_local o T_global, linearly transform attributes such that
+      // local transformation is defined for the mapped image region
+      } else if (_MultiLevelMode == MFFD_Fluid) {
+        domain.PutAffineMatrix(ilin->GetMatrix());
+      }
     }
   }
 

--- a/Modules/Transformation/src/BSplineFreeFormTransformationSV.cc
+++ b/Modules/Transformation/src/BSplineFreeFormTransformationSV.cc
@@ -554,6 +554,15 @@ ImageAttributes BSplineFreeFormTransformationSV
     if (z >= grid._z - 1 && z - grid._z - 1 > margin_back)   margin_back   = z - grid._z - 1;
   }
 
+  // Disregard small precision errors
+  const double eps = 1e-6;
+  margin_left   = round(margin_left   / eps) * eps;
+  margin_right  = round(margin_right  / eps) * eps;
+  margin_bottom = round(margin_bottom / eps) * eps;
+  margin_top    = round(margin_top    / eps) * eps;
+  margin_front  = round(margin_front  / eps) * eps;
+  margin_back   = round(margin_back   / eps) * eps;
+
   // Account for inter-/extrapolation error on boundary of FFD lattice and
   // therefore make lattice a bit bigger than otherwise needed
   const double margin_safety = 1.5;
@@ -566,14 +575,14 @@ ImageAttributes BSplineFreeFormTransformationSV
 
   // Compute of offsets by which lattice origin must be moved such that
   // the lattice origin is the center of the extended lattice again
-  const double ox = (margin_right - margin_left)   * grid._dx / 2.0;
+  const double ox = (margin_right - margin_left  )  * grid._dx / 2.0;
   const double oy = (margin_top   - margin_bottom) * grid._dy / 2.0;
-  const double oz = (margin_back  - margin_front)  * grid._dz / 2.0;
+  const double oz = (margin_back  - margin_front ) * grid._dz / 2.0;
 
   // Initialize free-form deformation (for extended image grid)
-  grid._x       += static_cast<int>(margin_left + margin_right);
-  grid._y       += static_cast<int>(margin_bottom + margin_top);
-  grid._z       += static_cast<int>(margin_front + margin_back);
+  grid._x       += static_cast<int>(margin_left   + margin_right);
+  grid._y       += static_cast<int>(margin_bottom + margin_top  );
+  grid._z       += static_cast<int>(margin_front  + margin_back );
   grid._xorigin += grid._xaxis[0] * ox + grid._yaxis[0] * oy + grid._zaxis[0] * oz;
   grid._yorigin += grid._xaxis[1] * ox + grid._yaxis[1] * oy + grid._zaxis[1] * oz;
   grid._zorigin += grid._xaxis[2] * ox + grid._yaxis[2] * oy + grid._zaxis[2] * oz;


### PR DESCRIPTION
The result of the registration with energy function `SIM(I(1) o T^-0.5, I(2) o T^0.5)` for the reversed order of input images, e.g., `-image a.nii.gz b.nii.gz` vs. `-image b.nii.gz a.nii.gz`, should be the exact inverse (i.e., `v_{ba} = - v_{ab}`) of each other. Due to minor bugs in the setup of the registration filter, this was not the case when cropping of the SV FFD lattice was enabled. This has been fixed and moreover the cropping is disabled for SV/TD FFD models by default.