### PR TITLE
fix: Registration logger

### DIFF
--- a/Modules/Image/include/mirtk/ImageAttributes.h
+++ b/Modules/Image/include/mirtk/ImageAttributes.h
@@ -243,6 +243,9 @@ struct ImageAttributes
   // Output
 
   /// Print attributes
+  void Print(ostream &, Indent = 0) const;
+
+  /// Print attributes
   void Print(Indent = 0) const;
 
 };

--- a/Modules/Image/src/ImageAttributes.cc
+++ b/Modules/Image/src/ImageAttributes.cc
@@ -363,49 +363,55 @@ bool ImageAttributes::EqualInTime(const ImageAttributes &attr) const
 }
 
 // -----------------------------------------------------------------------------
-void ImageAttributes::Print(Indent indent) const
+void ImageAttributes::Print(ostream &os, Indent indent) const
 {
   // Change output stream settings
-  const streamsize    w = cout.width    (0);
-  const streamsize    p = cout.precision(5);
-  const ios::fmtflags f = cout.flags    ();
+  const streamsize    w = os.width    (0);
+  const streamsize    p = os.precision(5);
+  const ios::fmtflags f = os.flags    ();
   // Print attributes of lattice
   bool sz = (_z > 1 && _dz);
   bool st = (_t > 1 && _dt);
   bool dz = (_dz && (_dz != 1.0 || _z > 1));
   bool dt = (_dt && (_dt != 1.0 || _t > 1));
-  if (_t > 1 && !_dt) cout << indent << "Channels: " << setw(10) << _t << "\n";
-  cout << indent << "Size:     "     << setw(10) << _x
-                            << " x " << setw(10) << _y;
-  if (sz || st) cout        << " x " << setw(10) << _z;
-  if (      st) cout        << " x " << setw(10) << _t;
-  cout << "\n";
-  cout << indent << "Spacing:  "       << fixed << setw(10) << _dx
-                              << " x " << fixed << setw(10) << _dy;
-  if (dz || dt) cout     << " x " << fixed << setw(10) << _dz;
-  if (      dt) cout     << " x " << fixed << setw(10) << _dt;
-  cout << "\n";
-  cout << indent << "Origin:  [" << fixed << setw(10) << _xorigin
-                        << " , " << fixed << setw(10) << _yorigin
-                        << " , " << fixed << setw(10) << _zorigin
-                        << " , " << fixed << setw(10) << _torigin
-                        <<   "]\n";
-  cout << indent << "X-axis:  [" << fixed << setw(10) << _xaxis[0]
-                        << " , " << fixed << setw(10) << _xaxis[1]
-                        << " , " << fixed << setw(10) << _xaxis[2]
-                        <<   "]\n";
-  cout << indent << "Y-axis:  [" << fixed << setw(10) << _yaxis[0]
-                        << " , " << fixed << setw(10) << _yaxis[1]
-                        << " , " << fixed << setw(10) << _yaxis[2]
-                        <<   "]\n";
-  cout << indent << "Z-axis:  [" << fixed << setw(10) << _zaxis[0]
-                        << " , " << fixed << setw(10) << _zaxis[1]
-                        << " , " << fixed << setw(10) << _zaxis[2]
-                        <<   "]\n";
+  if (_t > 1 && !_dt) os << indent << "Channels: " << setw(10) << _t << "\n";
+  os << indent << "Size:     "     << setw(10) << _x
+                          << " x " << setw(10) << _y;
+  if (sz || st) os        << " x " << setw(10) << _z;
+  if (      st) os        << " x " << setw(10) << _t;
+  os << "\n";
+  os << indent << "Spacing:  "       << fixed << setw(10) << _dx
+                            << " x " << fixed << setw(10) << _dy;
+  if (dz || dt) os     << " x " << fixed << setw(10) << _dz;
+  if (      dt) os     << " x " << fixed << setw(10) << _dt;
+  os << "\n";
+  os << indent << "Origin:  [" << fixed << setw(10) << _xorigin
+                      << " , " << fixed << setw(10) << _yorigin
+                      << " , " << fixed << setw(10) << _zorigin
+                      << " , " << fixed << setw(10) << _torigin
+                      <<   "]\n";
+  os << indent << "X-axis:  [" << fixed << setw(10) << _xaxis[0]
+                      << " , " << fixed << setw(10) << _xaxis[1]
+                      << " , " << fixed << setw(10) << _xaxis[2]
+                      <<   "]\n";
+  os << indent << "Y-axis:  [" << fixed << setw(10) << _yaxis[0]
+                      << " , " << fixed << setw(10) << _yaxis[1]
+                      << " , " << fixed << setw(10) << _yaxis[2]
+                      <<   "]\n";
+  os << indent << "Z-axis:  [" << fixed << setw(10) << _zaxis[0]
+                      << " , " << fixed << setw(10) << _zaxis[1]
+                      << " , " << fixed << setw(10) << _zaxis[2]
+                      <<   "]\n";
   // Restore output stream settings
-  cout.width    (w);
-  cout.precision(p);
-  cout.flags    (f);
+  os.width    (w);
+  os.precision(p);
+  os.flags    (f);
+}
+
+// -----------------------------------------------------------------------------
+void ImageAttributes::Print(Indent indent) const
+{
+  Print(cout, indent);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Numerics/include/mirtk/Matrix.h
+++ b/Modules/Numerics/include/mirtk/Matrix.h
@@ -460,6 +460,9 @@ public:
   /// Print matrix
   void Print(Indent = 0) const;
 
+  /// Print matrix
+  void Print(ostream &, Indent = 0) const;
+
   /// Read matrix from file
   void Read(const char *);
 

--- a/Modules/Numerics/src/Matrix.cc
+++ b/Modules/Numerics/src/Matrix.cc
@@ -1098,21 +1098,27 @@ Cifstream& operator >>(Cifstream &from, Matrix &m)
 // -----------------------------------------------------------------------------
 void Matrix::Print(Indent indent) const
 {
-  cout << indent << "Matrix " << _rows << " x " << _cols << endl;
+  Print(cout, indent);
+}
+
+// -----------------------------------------------------------------------------
+void Matrix::Print(ostream &os, Indent indent) const
+{
+  os << indent << "Matrix " << _rows << " x " << _cols << endl;
   ++indent;
-  cout.setf(ios::right);
-  cout.setf(ios::fixed);
-  cout.precision(4);
+  os.setf(ios::right);
+  os.setf(ios::fixed);
+  os.precision(4);
   for (int i = 0; i < _rows; i++) {
-    cout << indent;
+    os << indent;
     for (int j = 0; j < _cols; j++) {
-      cout << setw(15) << _matrix[j][i] << " ";
+      os << setw(15) << _matrix[j][i] << " ";
     }
-    cout << endl;
+    os << endl;
   }
-  cout.precision(6);
-  cout.unsetf(ios::right);
-  cout.unsetf(ios::fixed);
+  os.precision(6);
+  os.unsetf(ios::right);
+  os.unsetf(ios::fixed);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Registration/src/GenericRegistrationLogger.cc
+++ b/Modules/Registration/src/GenericRegistrationLogger.cc
@@ -26,6 +26,7 @@
 #include "mirtk/EnergyTerm.h"
 #include "mirtk/HomogeneousTransformation.h"
 #include "mirtk/GenericRegistrationFilter.h"
+#include "mirtk/ImageSimilarity.h"
 
 #include "mirtk/CommonExport.h"
 
@@ -134,10 +135,21 @@ void GenericRegistrationLogger::HandleEvent(Observable *obj, Event event, const 
     case StartEvent: {
       if (_Verbosity > 1) {
         os << "\nRegistration domain:\n\n";
-        reg->_RegistrationDomain.Print(2);
+        reg->_RegistrationDomain.Print(os, 2);
         if (reg->NumberOfImages() > 0) {
-          os << "\nAttributes of registered images:\n\n";
-          reg->_Image[reg->_CurrentLevel][0].Attributes().Print(2);
+          os << "\nAttributes of downsampled images:\n";
+          for (int n = 0; n < reg->NumberOfImages(); ++n) {
+            os << "\n";
+            reg->_Image[reg->_CurrentLevel][n].Attributes().Print(os, 2);
+          }
+          const int nterms = reg->_Energy.NumberOfTerms();
+          for (int t = 0; t < nterms; ++t) {
+            const ImageSimilarity * const sim = dynamic_cast<ImageSimilarity *>(reg->_Energy.Term(t));
+            if (sim) {
+              os << "\nAttributes of registered images (" << sim->Name() << "):\n\n";
+              sim->Domain().Print(os, 2);
+            }
+          }
         }
         os << "\nInitial transformation:\n\n";
         HomogeneousTransformation *lin = dynamic_cast<HomogeneousTransformation *>(reg->_Transformation);
@@ -154,10 +166,10 @@ void GenericRegistrationLogger::HandleEvent(Observable *obj, Event event, const 
           post(1, 3) = + reg->_SourceOffset._y;
           post(2, 3) = + reg->_SourceOffset._z;
           lin->PutMatrix(post * mat * pre);
-          lin->Print(Indent(2, 2));
+          lin->Print(os, Indent(2, 2));
           lin->PutMatrix(mat);
         } else {
-          reg->_Transformation->Print(Indent(2, 2));
+          reg->_Transformation->Print(os, Indent(2, 2));
         }
       }
       if (_Verbosity == 0) {
@@ -406,7 +418,7 @@ void GenericRegistrationLogger::HandleEvent(Observable *obj, Event event, const 
           post(1, 3) = + reg->_SourceOffset._y;
           post(2, 3) = + reg->_SourceOffset._z;
           lin->PutMatrix(post * mat * pre);
-          lin->Print(Indent(2, 2));
+          lin->Print(os, Indent(2, 2));
           lin->PutMatrix(mat);
         }
       }

--- a/Modules/Transformation/include/mirtk/AffineTransformation.h
+++ b/Modules/Transformation/include/mirtk/AffineTransformation.h
@@ -216,10 +216,13 @@ public:
 
   // ---------------------------------------------------------------------------
   // I/O
-  using RigidTransformation::Write;
+
+  // Do not hide methods of base class
+  using SimilarityTransformation::Print;
+  using SimilarityTransformation::Write;
 
   /// Prints the parameters of the transformation
-  virtual void Print(Indent = 0) const;
+  virtual void Print(ostream &, Indent = 0) const;
 
   /// Whether this transformation can read a file of specified type (i.e. format)
   virtual bool CanRead(TransformationType) const;

--- a/Modules/Transformation/include/mirtk/BSplineFreeFormTransformation3D.h
+++ b/Modules/Transformation/include/mirtk/BSplineFreeFormTransformation3D.h
@@ -306,8 +306,11 @@ public:
   // ---------------------------------------------------------------------------
   // I/O
 
+  // Do not hide methods of base class
+  using FreeFormTransformation3D::Print;
+
   /// Prints the parameters of the transformation
-  virtual void Print(Indent = 0) const;
+  virtual void Print(ostream &, Indent = 0) const;
 
   /// Whether this transformation can read a file of specified type (i.e. format)
   virtual bool CanRead(TransformationType) const;

--- a/Modules/Transformation/include/mirtk/BSplineFreeFormTransformation4D.h
+++ b/Modules/Transformation/include/mirtk/BSplineFreeFormTransformation4D.h
@@ -266,8 +266,11 @@ public:
   // ---------------------------------------------------------------------------
   // I/O
 
+  // Do not hide methods of base class
+  using FreeFormTransformation4D::Print;
+
   /// Prints the parameters of the transformation
-  virtual void Print(Indent = 0) const;
+  virtual void Print(ostream &, Indent = 0) const;
 
   /// Whether this transformation can read a file of specified type (i.e. format)
   virtual bool CanRead(TransformationType) const;

--- a/Modules/Transformation/include/mirtk/BSplineFreeFormTransformationSV.h
+++ b/Modules/Transformation/include/mirtk/BSplineFreeFormTransformationSV.h
@@ -432,11 +432,11 @@ public:
   // ---------------------------------------------------------------------------
   // I/O
 
-  // Do not overwrite other base class overloads
-  using BSplineFreeFormTransformation3D::Read;
+  // Do not hide methods of base class
+  using BSplineFreeFormTransformation3D::Print;
 
   /// Prints the parameters of the transformation
-  virtual void Print(Indent = 0) const;
+  virtual void Print(ostream &, Indent = 0) const;
 
   /// Whether this transformation can read a file of specified type (i.e. format)
   virtual bool CanRead(TransformationType) const;

--- a/Modules/Transformation/include/mirtk/BSplineFreeFormTransformationStatistical.h
+++ b/Modules/Transformation/include/mirtk/BSplineFreeFormTransformationStatistical.h
@@ -161,10 +161,12 @@ public:
   // ---------------------------------------------------------------------------
   // I/O
 
+  // Do not hide methods of base class
+  using BSplineFreeFormTransformation3D::Print;
   using BSplineFreeFormTransformation3D::Write;
 
   /// Prints the parameters of the transformation
-  virtual void Print(Indent = 0) const;
+  virtual void Print(ostream &, Indent = 0) const;
 
   /// Writes a transformation to a file stream
   virtual Cofstream &Write(Cofstream &) const;

--- a/Modules/Transformation/include/mirtk/BSplineFreeFormTransformationTD.h
+++ b/Modules/Transformation/include/mirtk/BSplineFreeFormTransformationTD.h
@@ -192,10 +192,11 @@ public:
   // ---------------------------------------------------------------------------
   // I/O
 
-  using BSplineFreeFormTransformation4D::Read;
+  // Do not hide methods of base class
+  using BSplineFreeFormTransformation4D::Print;
 
   /// Prints the parameters of the transformation
-  virtual void Print(Indent = 0) const;
+  virtual void Print(ostream &, Indent = 0) const;
 
   /// Whether this transformation can read a file of specified type (i.e. format)
   virtual bool CanRead(TransformationType) const;

--- a/Modules/Transformation/include/mirtk/FluidFreeFormTransformation.h
+++ b/Modules/Transformation/include/mirtk/FluidFreeFormTransformation.h
@@ -292,8 +292,11 @@ public:
   // ---------------------------------------------------------------------------
   // I/O
 
+  // Do not hide methods of base class
+  using MultiLevelTransformation::Print;
+
   /// Prints the parameters of the transformation
-  virtual void Print(Indent = 0) const;
+  virtual void Print(ostream &, Indent = 0) const;
 
   /// Whether this transformation can read a file of specified type (i.e. format)
   virtual bool CanRead(TransformationType) const;

--- a/Modules/Transformation/include/mirtk/FreeFormTransformation.h
+++ b/Modules/Transformation/include/mirtk/FreeFormTransformation.h
@@ -701,8 +701,11 @@ public:
   // ---------------------------------------------------------------------------
   // I/O
 
+  // Do not hide methods of base class
+  using Transformation::Print;
+
   /// Prints the parameters of the transformation
-  virtual void Print(Indent = 0) const;
+  virtual void Print(ostream &, Indent = 0) const;
 
 protected:
 

--- a/Modules/Transformation/include/mirtk/HomogeneousTransformation.h
+++ b/Modules/Transformation/include/mirtk/HomogeneousTransformation.h
@@ -238,8 +238,11 @@ public:
   // ---------------------------------------------------------------------------
   // I/O
 
+  // Do not hide methods of base class
+  using Transformation::Print;
+
   /// Prints the parameters of the transformation
-  virtual void Print(Indent = 0) const;
+  virtual void Print(ostream &, Indent = 0) const;
 
 protected:
   

--- a/Modules/Transformation/include/mirtk/LinearFreeFormTransformation3D.h
+++ b/Modules/Transformation/include/mirtk/LinearFreeFormTransformation3D.h
@@ -175,8 +175,11 @@ public:
   // ---------------------------------------------------------------------------
   // I/O
 
+  // Do not hide methods of base class
+  using FreeFormTransformation3D::Print;
+
   /// Prints the parameters of the transformation
-  virtual void Print(Indent = 0) const;
+  virtual void Print(ostream &, Indent = 0) const;
 
   /// Whether this transformation can read a file of specified type (i.e. format)
   virtual bool CanRead(TransformationType) const;

--- a/Modules/Transformation/include/mirtk/LinearFreeFormTransformation4D.h
+++ b/Modules/Transformation/include/mirtk/LinearFreeFormTransformation4D.h
@@ -187,8 +187,11 @@ public:
   // ---------------------------------------------------------------------------
   // I/O
 
+  // Do not hide methods of base class
+  using FreeFormTransformation4D::Print;
+
   /// Prints the parameters of the transformation
-  virtual void Print(Indent = 0) const;
+  virtual void Print(ostream &, Indent = 0) const;
 
   /// Whether this transformation can read a file of specified type (i.e. format)
   virtual bool CanRead(TransformationType) const;

--- a/Modules/Transformation/include/mirtk/LinearFreeFormTransformationTD.h
+++ b/Modules/Transformation/include/mirtk/LinearFreeFormTransformationTD.h
@@ -136,8 +136,11 @@ public:
   // ---------------------------------------------------------------------------
   // I/O
 
+  // Do not hide methods of base class
+  using LinearFreeFormTransformation4D::Print;
+
   /// Prints the parameters of the transformation
-  virtual void Print(Indent = 0) const;
+  virtual void Print(ostream &, Indent = 0) const;
 
   /// Whether this transformation can read a file of specified type (i.e. format)
   virtual bool CanRead(TransformationType) const;

--- a/Modules/Transformation/include/mirtk/MultiLevelFreeFormTransformation.h
+++ b/Modules/Transformation/include/mirtk/MultiLevelFreeFormTransformation.h
@@ -275,8 +275,11 @@ public:
   // ---------------------------------------------------------------------------
   // I/O
 
+  // Do not hide methods of base class
+  using MultiLevelTransformation::Print;
+
   /// Prints the parameters of the transformation
-  virtual void Print(Indent = 0) const;
+  virtual void Print(ostream &, Indent = 0) const;
 
   // ---------------------------------------------------------------------------
   // Backwards compatibility

--- a/Modules/Transformation/include/mirtk/MultiLevelStationaryVelocityTransformation.h
+++ b/Modules/Transformation/include/mirtk/MultiLevelStationaryVelocityTransformation.h
@@ -274,7 +274,7 @@ public:
   // I/O
 
   /// Prints the parameters of the transformation
-  virtual void Print(Indent = 0) const;
+  virtual void Print(ostream &, Indent = 0) const;
 
   // ---------------------------------------------------------------------------
   // Others

--- a/Modules/Transformation/include/mirtk/MultiLevelTransformation.h
+++ b/Modules/Transformation/include/mirtk/MultiLevelTransformation.h
@@ -609,8 +609,11 @@ public:
   // ---------------------------------------------------------------------------
   // I/O
 
+  // Do not hide methods of base class
+  using Transformation::Print;
+
   /// Prints the parameters of the transformation
-  virtual void Print(Indent = 0) const;
+  virtual void Print(ostream &, Indent = 0) const;
 
 protected:
 

--- a/Modules/Transformation/include/mirtk/PartialBSplineFreeFormTransformationSV.h
+++ b/Modules/Transformation/include/mirtk/PartialBSplineFreeFormTransformationSV.h
@@ -241,11 +241,14 @@ public:
 
   // ---------------------------------------------------------------------------
   // I/O
+
+  // Do not hide methods of base class
+  using Transformation::Print;
   using Transformation::Read;
   using Transformation::Write;
 
   /// Prints information about the transformation
-  virtual void Print(Indent = 0) const;
+  virtual void Print(ostream &, Indent = 0) const;
 
   /// Reads transformation from a file stream
   virtual Cifstream &Read(Cifstream &);

--- a/Modules/Transformation/include/mirtk/PartialMultiLevelStationaryVelocityTransformation.h
+++ b/Modules/Transformation/include/mirtk/PartialMultiLevelStationaryVelocityTransformation.h
@@ -253,11 +253,14 @@ public:
 
   // ---------------------------------------------------------------------------
   // I/O
+
+  // Do not hide methods of base class
+  using MultiLevelTransformation::Print;
   using MultiLevelTransformation::Read;
   using MultiLevelTransformation::Write;
 
   /// Prints information about the transformation
-  virtual void Print(Indent = 0) const;
+  virtual void Print(ostream &, Indent = 0) const;
 
   /// Reads a transformation from a file stream
   virtual Cifstream &Read(Cifstream &);

--- a/Modules/Transformation/include/mirtk/RigidTransformation.h
+++ b/Modules/Transformation/include/mirtk/RigidTransformation.h
@@ -175,8 +175,11 @@ public:
   // ---------------------------------------------------------------------------
   // I/O
 
+  // Do not hide methods of base class
+  using HomogeneousTransformation::Print;
+
   /// Prints the parameters of the transformation
-  virtual void Print(Indent = 0) const;
+  virtual void Print(ostream &, Indent = 0) const;
 
 public:
 

--- a/Modules/Transformation/include/mirtk/SimilarityTransformation.h
+++ b/Modules/Transformation/include/mirtk/SimilarityTransformation.h
@@ -111,10 +111,13 @@ public:
 
   // ---------------------------------------------------------------------------
   // I/O
+
+  // Do not hide methods of base class
+  using RigidTransformation::Print;
   using RigidTransformation::Write;
 
   /// Prints the parameters of the transformation
-  virtual void Print(Indent = 0) const;
+  virtual void Print(ostream &, Indent = 0) const;
 
   /// Whether this transformation can read a file of specified type (i.e. format)
   virtual bool CanRead(TransformationType) const;

--- a/Modules/Transformation/include/mirtk/Transformation.h
+++ b/Modules/Transformation/include/mirtk/Transformation.h
@@ -577,7 +577,10 @@ public:
   // I/O
 
   /// Prints information about the transformation
-  virtual void Print(Indent = 0) const = 0;
+  void Print(Indent = 0) const;
+
+  /// Prints information about the transformation
+  virtual void Print(ostream &os, Indent = 0) const = 0;
 
   /// Reads a transformation from a file
   virtual void Read(const char *);
@@ -1036,6 +1039,12 @@ inline void Transformation
 // =============================================================================
 // Others
 // =============================================================================
+
+// -----------------------------------------------------------------------------
+inline void Transformation::Print(Indent indent) const
+{
+  this->Print(cout, indent);
+}
 
 // -----------------------------------------------------------------------------
 inline TransformationType Transformation::TypeOfClass() const

--- a/Modules/Transformation/src/AffineTransformation.cc
+++ b/Modules/Transformation/src/AffineTransformation.cc
@@ -626,36 +626,36 @@ void AffineTransformation::DeriveJacobianWrtDOF(Matrix &dJdp, int dof, double x,
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-void AffineTransformation::Print(Indent indent) const
+void AffineTransformation::Print(ostream &os, Indent indent) const
 {
-  RigidTransformation::Print(indent);
+  RigidTransformation::Print(os, indent);
 
-  cout.setf(ios::right);
-  cout.setf(ios::fixed);
-  streamsize previous_precision = cout.precision(4);
+  os.setf(ios::right);
+  os.setf(ios::fixed);
+  streamsize previous_precision = os.precision(4);
 
   if (_Status[SX] == Active || !fequal(_Param[SX], 100.0, 1e-4) ||
       _Status[SY] == Active || !fequal(_Param[SY], 100.0, 1e-4) ||
       _Status[SZ] == Active || !fequal(_Param[SZ], 100.0, 1e-4)) {
-    cout << indent;
-    if (_Status[SX]  == Active) cout << "sx  = "  << setw(8) << _Param[SX]  << "  ";
-    if (_Status[SY]  == Active) cout << "sy  = "  << setw(8) << _Param[SY]  << "  ";
-    if (_Status[SZ]  == Active) cout << "sz  = "  << setw(8) << _Param[SZ]  << "  ";
-    cout << endl;
+    os << indent;
+    if (_Status[SX]  == Active) os << "sx  = "  << setw(8) << _Param[SX]  << "  ";
+    if (_Status[SY]  == Active) os << "sy  = "  << setw(8) << _Param[SY]  << "  ";
+    if (_Status[SZ]  == Active) os << "sz  = "  << setw(8) << _Param[SZ]  << "  ";
+    os << endl;
   }
   if (_Status[SXY] == Active || !fequal(_Param[SXY], .0, 1e-4) ||
       _Status[SXZ] == Active || !fequal(_Param[SXZ], .0, 1e-4) ||
       _Status[SYZ] == Active || !fequal(_Param[SYZ], .0, 1e-4)) {
-    cout << indent;
-    if (_Status[SXY] == Active) cout << "sxy = " << setw(8) << _Param[SXY] << "  ";
-    if (_Status[SYZ] == Active) cout << "syz = " << setw(8) << _Param[SYZ] << "  ";
-    if (_Status[SXZ] == Active) cout << "sxz = " << setw(8) << _Param[SXZ] << "  ";
-    cout << endl;
+    os << indent;
+    if (_Status[SXY] == Active) os << "sxy = " << setw(8) << _Param[SXY] << "  ";
+    if (_Status[SYZ] == Active) os << "syz = " << setw(8) << _Param[SYZ] << "  ";
+    if (_Status[SXZ] == Active) os << "sxz = " << setw(8) << _Param[SXZ] << "  ";
+    os << endl;
   }
 
-  cout.precision(previous_precision);
-  cout.unsetf(ios::right);
-  cout.unsetf(ios::fixed);
+  os.precision(previous_precision);
+  os.unsetf(ios::right);
+  os.unsetf(ios::fixed);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Transformation/src/BSplineFreeFormTransformation3D.cc
+++ b/Modules/Transformation/src/BSplineFreeFormTransformation3D.cc
@@ -1572,10 +1572,10 @@ void BSplineFreeFormTransformation3D::BendingEnergyGradient(double *gradient, do
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-void BSplineFreeFormTransformation3D::Print(Indent indent) const
+void BSplineFreeFormTransformation3D::Print(ostream &os, Indent indent) const
 {
-  cout << indent << "3D B-spline FFD:" << endl;
-  FreeFormTransformation3D::Print(indent + 1);
+  os << indent << "3D B-spline FFD:" << endl;
+  FreeFormTransformation3D::Print(os, indent + 1);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Transformation/src/BSplineFreeFormTransformation4D.cc
+++ b/Modules/Transformation/src/BSplineFreeFormTransformation4D.cc
@@ -1390,10 +1390,10 @@ void BSplineFreeFormTransformation4D::BendingEnergyGradient(double *gradient, do
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-void BSplineFreeFormTransformation4D::Print(Indent indent) const
+void BSplineFreeFormTransformation4D::Print(ostream &os, Indent indent) const
 {
-  cout << indent << "4D B-spline FFD:" << endl;
-  FreeFormTransformation4D::Print(indent + 1);
+  os << indent << "4D B-spline FFD:" << endl;
+  FreeFormTransformation4D::Print(os, indent + 1);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Transformation/src/BSplineFreeFormTransformationSV.cc
+++ b/Modules/Transformation/src/BSplineFreeFormTransformationSV.cc
@@ -1624,30 +1624,30 @@ void BSplineFreeFormTransformationSV
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-void BSplineFreeFormTransformationSV::Print(Indent indent) const
+void BSplineFreeFormTransformationSV::Print(ostream &os, Indent indent) const
 {
-  cout << indent << "B-spline SV FFD:" << endl;
+  os << indent << "B-spline SV FFD:" << endl;
   indent++;
   // Print FFD attributes
-  FreeFormTransformation3D::Print(indent);
+  FreeFormTransformation3D::Print(os, indent);
   // Change output stream settings
-  const streamsize    w = cout.width    (0);
-  const streamsize    p = cout.precision(2);
-  const ios::fmtflags f = cout.flags();
+  const streamsize    w = os.width    (0);
+  const streamsize    p = os.precision(2);
+  const ios::fmtflags f = os.flags();
   cout.unsetf(ios::floatfield);
   // Print SV FFD parameters
-  cout << indent << "Integration method:                " << setw(6) << ToString(_IntegrationMethod) << endl;
-  cout << indent << "Cross-sectional time interval:     " << setw(6) << _T << endl;
-  cout << indent << "Time unit of integration interval: " << setw(6) << _TimeUnit << endl;
-  cout << indent << "Maximum scaled velocity:           " << setw(6) << _MaxScaledVelocity << endl;
-  cout << indent << "No. of integration steps per unit: " << setw(6) << _NumberOfSteps << endl;
-  cout << indent << "No. of cross-sectional steps:      " << setw(6) << NumberOfStepsForIntervalLength(_T) << endl;
-  cout << indent << "No. of BCH terms:                  " << setw(6) << _NumberOfBCHTerms << endl;
-  cout << indent << "Use Lie derivative:                " << setw(6) << ToString(_LieDerivative) << endl;
+  os << indent << "Integration method:                " << setw(6) << ToString(_IntegrationMethod) << endl;
+  os << indent << "Cross-sectional time interval:     " << setw(6) << _T << endl;
+  os << indent << "Time unit of integration interval: " << setw(6) << _TimeUnit << endl;
+  os << indent << "Maximum scaled velocity:           " << setw(6) << _MaxScaledVelocity << endl;
+  os << indent << "No. of integration steps per unit: " << setw(6) << _NumberOfSteps << endl;
+  os << indent << "No. of cross-sectional steps:      " << setw(6) << NumberOfStepsForIntervalLength(_T) << endl;
+  os << indent << "No. of BCH terms:                  " << setw(6) << _NumberOfBCHTerms << endl;
+  os << indent << "Use Lie derivative:                " << setw(6) << ToString(_LieDerivative) << endl;
   // Restore output stream settings
-  cout.width    (w);
-  cout.precision(p);
-  cout.flags    (f);
+  os.width    (w);
+  os.precision(p);
+  os.flags    (f);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Transformation/src/BSplineFreeFormTransformationStatistical.cc
+++ b/Modules/Transformation/src/BSplineFreeFormTransformationStatistical.cc
@@ -337,10 +337,10 @@ void BSplineFreeFormTransformationStatistical
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-void BSplineFreeFormTransformationStatistical::Print(Indent indent) const
+void BSplineFreeFormTransformationStatistical::Print(ostream &os, Indent indent) const
 {
-  cout << indent << "3D Statistical B-spline FFD:" << endl;
-  FreeFormTransformation3D::Print(indent + 1);
+  os << indent << "3D Statistical B-spline FFD:" << endl;
+  FreeFormTransformation3D::Print(os, indent + 1);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Transformation/src/BSplineFreeFormTransformationTD.cc
+++ b/Modules/Transformation/src/BSplineFreeFormTransformationTD.cc
@@ -419,19 +419,19 @@ void BSplineFreeFormTransformationTD
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-void BSplineFreeFormTransformationTD::Print(Indent indent) const
+void BSplineFreeFormTransformationTD::Print(ostream &os, Indent indent) const
 {
-  cout << indent << "B-spline TD FFD:" << endl;
+  os << indent << "B-spline TD FFD:" << endl;
   ++indent;
-  FreeFormTransformation4D::Print(indent);
-  cout << indent << "Numerical integration:" << endl;
+  FreeFormTransformation4D::Print(os, indent);
+  os << indent << "Numerical integration:" << endl;
   ++indent;
-  cout << indent << "Method:      " << ToString(_IntegrationMethod) << endl;
+  os << indent << "Method:      " << ToString(_IntegrationMethod) << endl;
   if (_MinTimeStep < _MaxTimeStep && _IntegrationMethod >= FFDIM_RKEH12) {
-    cout << indent << "Step size:   [" << _MinTimeStep << ", " << _MaxTimeStep << "]" << endl;
-    cout << indent << "Local error: " << _Tolerance << endl;
+    os << indent << "Step size:   [" << _MinTimeStep << ", " << _MaxTimeStep << "]" << endl;
+    os << indent << "Local error: " << _Tolerance << endl;
   } else {
-    cout << indent << "Step size:   " << _MinTimeStep << endl;  
+    os << indent << "Step size:   " << _MinTimeStep << endl;
   }
 }
 

--- a/Modules/Transformation/src/FluidFreeFormTransformation.cc
+++ b/Modules/Transformation/src/FluidFreeFormTransformation.cc
@@ -977,12 +977,12 @@ ParametricGradient(const PointSet &pos, const Vector3D<double> *in,
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-void FluidFreeFormTransformation::Print(Indent indent) const
+void FluidFreeFormTransformation::Print(ostream &os, Indent indent) const
 {
-  cout << indent << "Fluid FFD:" << endl;
-  MultiLevelTransformation::Print(indent + 1);
-  cout << (indent + 1) << "Affine post-transformation:" << endl;
-  _AffineTransformation.Print(indent + 2);
+  os << indent << "Fluid FFD:" << endl;
+  MultiLevelTransformation::Print(os, indent + 1);
+  os << (indent + 1) << "Affine post-transformation:" << endl;
+  _AffineTransformation.Print(os, indent + 2);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Transformation/src/FreeFormTransformation.cc
+++ b/Modules/Transformation/src/FreeFormTransformation.cc
@@ -1312,16 +1312,16 @@ void FreeFormTransformation::BendingEnergyGradient(double *, double, bool, bool)
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-void FreeFormTransformation::Print(Indent indent) const
+void FreeFormTransformation::Print(ostream &os, Indent indent) const
 {
   // Print no. of transformation parameters
-  cout << indent << "Number of DOFs:          " << this->NumberOfDOFs() << endl;
-  cout << indent << "Number of CPs (active):  " << this->NumberOfActiveCPs()<< endl;
-  cout << indent << "Number of CPs (passive): " << this->NumberOfPassiveCPs()<< endl;
-  cout << indent << "Extrapolation mode:      " << ToString(_ExtrapolationMode) << endl;
+  os << indent << "Number of DOFs:          " << this->NumberOfDOFs() << endl;
+  os << indent << "Number of CPs (active):  " << this->NumberOfActiveCPs()<< endl;
+  os << indent << "Number of CPs (passive): " << this->NumberOfPassiveCPs()<< endl;
+  os << indent << "Extrapolation mode:      " << ToString(_ExtrapolationMode) << endl;
   // Print lattice attributes
-  cout << indent << "Control point lattice:" << endl;
-  _attr.Print(indent + 1);
+  os << indent << "Control point lattice:" << endl;
+  _attr.Print(os, indent + 1);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Transformation/src/HomogeneousTransformation.cc
+++ b/Modules/Transformation/src/HomogeneousTransformation.cc
@@ -528,9 +528,9 @@ bool HomogeneousTransformation::IsIdentity() const
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-void HomogeneousTransformation::Print(Indent indent) const
+void HomogeneousTransformation::Print(ostream &os, Indent indent) const
 {
-  _matrix.Print(indent);
+  _matrix.Print(os, indent);
 }
 
 // ---------------------------------------------------------------------------

--- a/Modules/Transformation/src/LinearFreeFormTransformation3D.cc
+++ b/Modules/Transformation/src/LinearFreeFormTransformation3D.cc
@@ -450,10 +450,10 @@ void LinearFreeFormTransformation3D::BendingEnergyGradient(double *gradient, dou
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-void LinearFreeFormTransformation3D::Print(Indent indent) const
+void LinearFreeFormTransformation3D::Print(ostream &os, Indent indent) const
 {
-  cout << indent << "3D Linear FFD:" << endl;
-  FreeFormTransformation3D::Print(indent + 1);
+  os << indent << "3D Linear FFD:" << endl;
+  FreeFormTransformation3D::Print(os, indent + 1);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Transformation/src/LinearFreeFormTransformation4D.cc
+++ b/Modules/Transformation/src/LinearFreeFormTransformation4D.cc
@@ -524,10 +524,10 @@ void LinearFreeFormTransformation4D
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-void LinearFreeFormTransformation4D::Print(Indent indent) const
+void LinearFreeFormTransformation4D::Print(ostream &os, Indent indent) const
 {
-  cout << indent << "4D Linear FFD:" << endl;
-  FreeFormTransformation4D::Print(indent + 1);
+  os << indent << "4D Linear FFD:" << endl;
+  FreeFormTransformation4D::Print(os, indent + 1);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Transformation/src/LinearFreeFormTransformationTD.cc
+++ b/Modules/Transformation/src/LinearFreeFormTransformationTD.cc
@@ -245,13 +245,13 @@ void LinearFreeFormTransformationTD::Interpolate(const double *, const double *,
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-void LinearFreeFormTransformationTD::Print(Indent indent) const
+void LinearFreeFormTransformationTD::Print(ostream &os, Indent indent) const
 {
-  cout << indent << "Linear TD FFD:" << endl;
+  os << indent << "Linear TD FFD:" << endl;
   ++indent;
-  FreeFormTransformation4D::Print(indent);
-  cout << indent << "Minimum length of steps: " << _MinTimeStep << endl;
-  cout << indent << "Maximum length of steps: " << _MaxTimeStep << endl;
+  FreeFormTransformation4D::Print(os, indent);
+  os << indent << "Minimum length of steps: " << _MinTimeStep << endl;
+  os << indent << "Maximum length of steps: " << _MaxTimeStep << endl;
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Transformation/src/MultiLevelFreeFormTransformation.cc
+++ b/Modules/Transformation/src/MultiLevelFreeFormTransformation.cc
@@ -769,10 +769,10 @@ void MultiLevelFreeFormTransformation
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-void MultiLevelFreeFormTransformation::Print(Indent indent) const
+void MultiLevelFreeFormTransformation::Print(ostream &os, Indent indent) const
 {
-  cout << indent << "Multi-level FFD:" << endl;
-  MultiLevelTransformation::Print(indent + 1);
+  os << indent << "Multi-level FFD:" << endl;
+  MultiLevelTransformation::Print(os, indent + 1);
 }
 
 

--- a/Modules/Transformation/src/MultiLevelStationaryVelocityTransformation.cc
+++ b/Modules/Transformation/src/MultiLevelStationaryVelocityTransformation.cc
@@ -373,10 +373,10 @@ void MultiLevelStationaryVelocityTransformation::Invert()
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-void MultiLevelStationaryVelocityTransformation::Print(Indent indent) const
+void MultiLevelStationaryVelocityTransformation::Print(ostream &os, Indent indent) const
 {
-  cout << indent << "Multi-level SV FFD:" << endl;
-  MultiLevelTransformation::Print(indent + 1);
+  os << indent << "Multi-level SV FFD:" << endl;
+  MultiLevelTransformation::Print(os, indent + 1);
 }
 
 

--- a/Modules/Transformation/src/MultiLevelTransformation.cc
+++ b/Modules/Transformation/src/MultiLevelTransformation.cc
@@ -951,20 +951,20 @@ void MultiLevelTransformation
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-void MultiLevelTransformation::Print(Indent indent) const
+void MultiLevelTransformation::Print(ostream &os, Indent indent) const
 {
   Indent subindent(indent + 1);
 
   // Print global transformation
-  cout << indent << "Global transformation:" << endl;
-  this->GetGlobalTransformation()->Print(subindent);
+  os << indent << "Global transformation:" << endl;
+  this->GetGlobalTransformation()->Print(os, subindent);
 
   // Print local transformations
   for (int l = 0; l < _NumberOfLevels; ++l) {
-    cout << indent << "Local transformation";
-    cout << (this->LocalTransformationIsActive(l) ? " (active)" : " (passive)");
-    cout << ":" << endl;
-    this->GetLocalTransformation(l)->Print(subindent);
+    os << indent << "Local transformation";
+    os << (this->LocalTransformationIsActive(l) ? " (active)" : " (passive)");
+    os << ":" << endl;
+    this->GetLocalTransformation(l)->Print(os, subindent);
   }
 }
 

--- a/Modules/Transformation/src/PartialBSplineFreeFormTransformationSV.cc
+++ b/Modules/Transformation/src/PartialBSplineFreeFormTransformationSV.cc
@@ -308,11 +308,11 @@ void PartialBSplineFreeFormTransformationSV
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-void PartialBSplineFreeFormTransformationSV::Print(Indent indent) const
+void PartialBSplineFreeFormTransformationSV::Print(ostream &os, Indent indent) const
 {
-  cout << indent << "Partial B-spline SV FFD" << endl;
-  _Transformation->Print(indent+1);
-  cout << indent << "Fraction of transformation applied: " << _Fraction << endl;
+  os << indent << "Partial B-spline SV FFD" << endl;
+  _Transformation->Print(os, indent + 1);
+  os << indent << "Fraction of transformation applied: " << _Fraction << endl;
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Transformation/src/PartialMultiLevelStationaryVelocityTransformation.cc
+++ b/Modules/Transformation/src/PartialMultiLevelStationaryVelocityTransformation.cc
@@ -339,11 +339,11 @@ void PartialMultiLevelStationaryVelocityTransformation
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-void PartialMultiLevelStationaryVelocityTransformation::Print(Indent indent) const
+void PartialMultiLevelStationaryVelocityTransformation::Print(ostream &os, Indent indent) const
 {
-  cout << indent << "Partial Multi-level B-spline SV FFD" << endl;
-  _Transformation->Print(indent+1);
-  cout << indent << "Fraction of transformation applied: " << _Fraction << endl;
+  os << indent << "Partial Multi-level B-spline SV FFD" << endl;
+  _Transformation->Print(os, indent + 1);
+  os << indent << "Fraction of transformation applied: " << _Fraction << endl;
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Transformation/src/RigidTransformation.cc
+++ b/Modules/Transformation/src/RigidTransformation.cc
@@ -373,34 +373,34 @@ void RigidTransformation::DeriveJacobianWrtDOF(Matrix &dJdp, int dof, double, do
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-void RigidTransformation::Print(Indent indent) const
+void RigidTransformation::Print(ostream &os, Indent indent) const
 {
-  cout.setf(ios::right);
-  cout.setf(ios::fixed);
-  streamsize previous_precision = cout.precision(4);
+  os.setf(ios::right);
+  os.setf(ios::fixed);
+  streamsize previous_precision = os.precision(4);
 
   if (_Status[TX] == Active || !fequal(_Param[TX], .0, 1e-4) ||
       _Status[TY] == Active || !fequal(_Param[TY], .0, 1e-4) ||
       _Status[TZ] == Active || !fequal(_Param[TZ], .0, 1e-4)) {
-    cout << indent;
-    if (_Status[TX] == Active) cout << "tx  = " << setw(8) << _Param[TX] << "  ";
-    if (_Status[TY] == Active) cout << "ty  = " << setw(8) << _Param[TY] << "  ";
-    if (_Status[TZ] == Active) cout << "tz  = " << setw(8) << _Param[TZ];
-    cout << endl;
+    os << indent;
+    if (_Status[TX] == Active) os << "tx  = " << setw(8) << _Param[TX] << "  ";
+    if (_Status[TY] == Active) os << "ty  = " << setw(8) << _Param[TY] << "  ";
+    if (_Status[TZ] == Active) os << "tz  = " << setw(8) << _Param[TZ];
+    os << endl;
   }
   if (_Status[RX] == Active || !fequal(_Param[RX], .0, 1e-4) ||
       _Status[RY] == Active || !fequal(_Param[RY], .0, 1e-4) ||
       _Status[RZ] == Active || !fequal(_Param[RZ], .0, 1e-4)) {
-    cout << indent;
-    if (_Status[RX] == Active) cout << "rx  = " << setw(8) << _Param[RX] << "  ";
-    if (_Status[RY] == Active) cout << "ry  = " << setw(8) << _Param[RY] << "  ";
-    if (_Status[RZ] == Active) cout << "rz  = " << setw(8) << _Param[RZ];
-    cout << endl;
+    os << indent;
+    if (_Status[RX] == Active) os << "rx  = " << setw(8) << _Param[RX] << "  ";
+    if (_Status[RY] == Active) os << "ry  = " << setw(8) << _Param[RY] << "  ";
+    if (_Status[RZ] == Active) os << "rz  = " << setw(8) << _Param[RZ];
+    os << endl;
   }
 
-  cout.precision(previous_precision);
-  cout.unsetf(ios::right);
-  cout.unsetf(ios::fixed);
+  os.precision(previous_precision);
+  os.unsetf(ios::right);
+  os.unsetf(ios::fixed);
 }
 
 

--- a/Modules/Transformation/src/SimilarityTransformation.cc
+++ b/Modules/Transformation/src/SimilarityTransformation.cc
@@ -288,21 +288,21 @@ void SimilarityTransformation::DeriveJacobianWrtDOF(Matrix &dJdp, int dof, doubl
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-void SimilarityTransformation::Print(Indent indent) const
+void SimilarityTransformation::Print(ostream &os, Indent indent) const
 {
-  RigidTransformation::Print(indent);
+  RigidTransformation::Print(os, indent);
 
-  cout.setf(ios::right);
-  cout.setf(ios::fixed);
-  streamsize previous_precision = cout.precision(4);
+  os.setf(ios::right);
+  os.setf(ios::fixed);
+  streamsize previous_precision = os.precision(4);
 
   if (_Status[SX] == Active || !fequal(_Param[SX], 100.0, 1e-4)) {
-    cout << indent << "s   = " << setw(8) << _Param[SG] << endl;
+    os << indent << "s   = " << setw(8) << _Param[SG] << endl;
   }
 
-  cout.precision(previous_precision);
-  cout.unsetf(ios::right);
-  cout.unsetf(ios::fixed);
+  os.precision(previous_precision);
+  os.unsetf(ios::right);
+  os.unsetf(ios::fixed);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
- Output of "registered image attributes" confusing/mislabelled.
- Always print to specified output stream, not some to `cout` (unless that's the set `ostream`).