### PR TITLE
fix: B-spline interpolators

### DIFF
--- a/Modules/Image/include/mirtk/BSplineInterpolateImageFunction.h
+++ b/Modules/Image/include/mirtk/BSplineInterpolateImageFunction.h
@@ -21,6 +21,7 @@
 #define MIRTK_BSplineInterpolateImageFunction_H
 
 #include "mirtk/InterpolateImageFunction.h"
+#include "mirtk/MirrorExtrapolateImageFunction.h"
 
 
 namespace mirtk {
@@ -51,8 +52,9 @@ class GenericBSplineInterpolateImageFunction
 
 public:
 
-  typedef GenericImage<RealType>                             CoefficientImage;
-  typedef GenericExtrapolateImageFunction<CoefficientImage>  CoefficientExtrapolator;
+  typedef GenericImage<RealType>                                   CoefficientImage;
+  typedef GenericExtrapolateImageFunction<CoefficientImage>        CoefficientExtrapolator;
+  typedef GenericMirrorExtrapolateImageFunction<CoefficientImage>  DefaultExtrapolator;
 
   // ---------------------------------------------------------------------------
   // Attributes

--- a/Modules/Image/include/mirtk/BaseImage.h
+++ b/Modules/Image/include/mirtk/BaseImage.h
@@ -558,6 +558,18 @@ public:
   /// Whether all voxels within a 4D bounding region are inside foreground region
   bool IsBoundingBoxInsideForeground(int, int, int, int, int, int, int, int) const;
 
+  /// Whether at least one neighboring voxel is outside the finite foreground region
+  bool IsNextToBackground(int) const;
+
+  /// Whether at least one neighboring voxel is outside the finite foreground region
+  bool IsNextToBackground(int, int, int = 0, int = 0) const;
+
+  /// Whether at least one neighboring voxel is inside the finite foreground region
+  bool IsNextToForeground(int) const;
+
+  /// Whether at least one neighboring voxel is inside the finite foreground region
+  bool IsNextToForeground(int, int, int = 0, int = 0) const;
+
   /// Whether any voxel is within background
   bool HasBackground() const;
 
@@ -1638,6 +1650,54 @@ inline bool BaseImage::IsBoundingBoxInsideForeground(int i1, int j1, int k1, int
     }
   }
   return true;
+}
+
+// -----------------------------------------------------------------------------
+inline bool BaseImage::IsNextToBackground(int i, int j, int k, int l) const
+{
+  for (int nl = l - 1; nl <= l + 1; ++nl)
+  for (int nk = k - 1; nk <= k + 1; ++nk)
+  for (int nj = j - 1; nj <= j + 1; ++nj)
+  for (int ni = i - 1; ni <= i + 1; ++ni) {
+    if (ni != 0 || nj != 0 || nk != 0 || nl != 0) {
+      if (IsOutsideForeground(ni, nj, nk, nl)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+// -----------------------------------------------------------------------------
+inline bool BaseImage::IsNextToBackground(int idx) const
+{
+  int i, j, k, l;
+  IndexToVoxel(idx, i, j, k, l);
+  return IsNextToBackground(i, j, k, l);
+}
+
+// -----------------------------------------------------------------------------
+inline bool BaseImage::IsNextToForeground(int i, int j, int k, int l) const
+{
+  for (int nl = l - 1; nl <= l + 1; ++nl)
+  for (int nk = k - 1; nk <= k + 1; ++nk)
+  for (int nj = j - 1; nj <= j + 1; ++nj)
+  for (int ni = i - 1; ni <= i + 1; ++ni) {
+    if (ni != 0 || nj != 0 || nk != 0 || nl != 0) {
+      if (IsInsideForeground(ni, nj, nk, nl)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+// -----------------------------------------------------------------------------
+inline bool BaseImage::IsNextToForeground(int idx) const
+{
+  int i, j, k, l;
+  IndexToVoxel(idx, i, j, k, l);
+  return IsNextToForeground(i, j, k, l);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Image/include/mirtk/CubicBSplineInterpolateImageFunction.h
+++ b/Modules/Image/include/mirtk/CubicBSplineInterpolateImageFunction.h
@@ -23,6 +23,7 @@
 #include "mirtk/BSpline.h"
 #include "mirtk/BaseImage.h"
 #include "mirtk/InterpolateImageFunction.h"
+#include "mirtk/MirrorExtrapolateImageFunction.h"
 
 
 namespace mirtk {
@@ -53,9 +54,10 @@ class GenericCubicBSplineInterpolateImageFunction
 
 public:
 
-  typedef GenericImage<RealType>                             CoefficientImage;
-  typedef GenericExtrapolateImageFunction<CoefficientImage>  CoefficientExtrapolator;
-  typedef BSpline<Real>                                      Kernel;
+  typedef GenericImage<RealType>                                   CoefficientImage;
+  typedef GenericExtrapolateImageFunction<CoefficientImage>        CoefficientExtrapolator;
+  typedef GenericMirrorExtrapolateImageFunction<CoefficientImage>  DefaultExtrapolator;
+  typedef BSpline<Real>                                            Kernel;
 
   // ---------------------------------------------------------------------------
   // Attributes

--- a/Modules/Image/include/mirtk/FastCubicBSplineInterpolateImageFunction.h
+++ b/Modules/Image/include/mirtk/FastCubicBSplineInterpolateImageFunction.h
@@ -22,6 +22,7 @@
 
 #include "mirtk/BaseImage.h"
 #include "mirtk/InterpolateImageFunction.h"
+#include "mirtk/MirrorExtrapolateImageFunction.h"
 
 
 namespace mirtk {
@@ -51,7 +52,7 @@ class GenericFastCubicBSplineInterpolateImageFunction
 {
   mirtkGenericInterpolatorMacro(
     GenericFastCubicBSplineInterpolateImageFunction,
-    Interpolation_CubicBSpline
+    Interpolation_FastCubicBSpline
   );
 
   // ---------------------------------------------------------------------------
@@ -59,9 +60,10 @@ class GenericFastCubicBSplineInterpolateImageFunction
 
 public:
 
-  typedef GenericImage<RealType>                             CoefficientImage;
-  typedef GenericExtrapolateImageFunction<CoefficientImage>  CoefficientExtrapolator;
-  typedef BSpline<Real>                                      Kernel;
+  typedef GenericImage<RealType>                                   CoefficientImage;
+  typedef GenericExtrapolateImageFunction<CoefficientImage>        CoefficientExtrapolator;
+  typedef GenericMirrorExtrapolateImageFunction<CoefficientImage>  DefaultExtrapolator;
+  typedef BSpline<Real>                                            Kernel;
 
   // ---------------------------------------------------------------------------
   // Attributes

--- a/Modules/Image/include/mirtk/GenericImage.h
+++ b/Modules/Image/include/mirtk/GenericImage.h
@@ -175,10 +175,6 @@ public:
   /// Number of vector components per voxel
   int N() const;
 
-  /// Function to convert pixel to index
-  /// more efficient than overwritten base class implementation
-  int VoxelToIndex(int, int, int = 0, int = 0) const;
-
   // ---------------------------------------------------------------------------
   // Image data access
 
@@ -524,13 +520,6 @@ template <class VoxelType>
 inline int GenericImage<VoxelType>::N() const
 {
   return voxel_info<VoxelType>::vector_size();
-}
-
-// -----------------------------------------------------------------------------
-template <class VoxelType>
-inline int GenericImage<VoxelType>::VoxelToIndex(int x, int y, int z, int t) const
-{
-  return static_cast<int>(&_matrix[t][z][y][x] - &_matrix[0][0][0][0]);
 }
 
 // =============================================================================

--- a/Modules/Image/include/mirtk/ImageToInterpolationCoefficients.h
+++ b/Modules/Image/include/mirtk/ImageToInterpolationCoefficients.h
@@ -25,6 +25,7 @@
 #include "mirtk/GenericImage.h"
 #include "mirtk/Parallel.h"
 #include "mirtk/Stream.h"
+#include "mirtk/Queue.h"
 
 
 namespace mirtk {
@@ -449,6 +450,51 @@ template <class TData>
 void ConvertToCubicBSplineCoefficients(GenericImage<TData> &image)
 {
   ConvertToSplineCoefficients(3, image);
+}
+
+// -----------------------------------------------------------------------------
+/// Fill background by front propagation of foreground
+template <class TData>
+void FillBackgroundBeforeConversionToSplineCoefficients(GenericImage<TData> &image)
+{
+  int idx, nbr, i, j, k, l;
+  Queue<int> active;
+  BinaryImage bg(image.Attributes());
+  for (idx = 0; idx < image.NumberOfVoxels(); ++idx) {
+    if (image.IsBackground(idx)) {
+      if (image.IsNextToForeground(idx)) {
+        active.push(idx);
+      }
+      bg(idx) = 1;
+    }
+  }
+  while (!active.empty()) {
+    idx = active.front();
+    active.pop();
+    if (bg(idx)) {
+      int   count = 0;
+      TData value = voxel_cast<TData>(0);
+      image.IndexToVoxel(idx, i, j, k, l);
+      for (int nl = l - 1; nl <= l + 1; ++nl)
+      for (int nk = k - 1; nk <= k + 1; ++nk)
+      for (int nj = j - 1; nj <= j + 1; ++nj)
+      for (int ni = i - 1; ni <= i + 1; ++ni) {
+        nbr = image.VoxelToIndex(ni, nj, nk, nl);
+        if (nbr != idx && image.IsInside(nbr)) {
+          if (bg(nbr)) {
+            active.push(nbr);
+          } else {
+            value += image(nbr);
+            count += 1;
+          }
+        }
+      }
+      value /= count;
+      image.Put(idx, value);
+      bg(idx) = 0;
+    }
+  }
+  image.ClearBackgroundValue();
 }
 
 


### PR DESCRIPTION
The default interpolation without extrapolator as well as the interpolation with padding value would produce incorrect results at the boundary. Also, filling in the background by propagating the foreground boundary values reduces large gradients in the coefficients at the boundary.

- [x] Speed up by limiting number of front propagation steps.