### PR TITLE
enh: Registered image cache interpolators

### DIFF
--- a/Modules/Image/include/mirtk/ImageGradientFunction.h
+++ b/Modules/Image/include/mirtk/ImageGradientFunction.h
@@ -20,6 +20,7 @@
 #ifndef MIRTK_ImageGradientFunction_H
 #define MIRTK_ImageGradientFunction_H
 
+#include "mirtk/Object.h"
 #include "mirtk/Matrix.h"
 #include "mirtk/Vector3D.h"
 #include "mirtk/BaseImage.h"
@@ -40,7 +41,7 @@ namespace mirtk {
  * image derivatives instead of the image intensity value. Note that it
  * cannot be applied to multi-channel or vector-valued images.
  */
-class ImageGradientFunction
+class ImageGradientFunction : public Object
 {
   mirtkAbstractMacro(ImageGradientFunction);
 

--- a/Modules/Registration/include/mirtk/GenericRegistrationFilter.h
+++ b/Modules/Registration/include/mirtk/GenericRegistrationFilter.h
@@ -242,7 +242,7 @@ public:
   mirtkPublicAttributeMacro(enum ExtrapolationMode, ExtrapolationMode);
 
   /// Whether to precompute image derivatives or compute them on the fly
-  mirtkPublicAttributeMacro(bool, PrecomputeDerivatives);
+  mirtkPublicAttributeMacro(int, PrecomputeDerivatives);
 
   /// Default similarity measure
   mirtkPublicAttributeMacro(enum SimilarityMeasure, SimilarityMeasure);

--- a/Modules/Registration/src/GenericRegistrationFilter.cc
+++ b/Modules/Registration/src/GenericRegistrationFilter.cc
@@ -703,7 +703,7 @@ void GenericRegistrationFilter::Reset()
   _MergeGlobalAndLocalTransformation   = false;
   _InterpolationMode                   = Interpolation_FastLinear;
   _ExtrapolationMode                   = Extrapolation_Default;
-  _PrecomputeDerivatives               = false;
+  _PrecomputeDerivatives               = -1;
   _SimilarityMeasure                   = SIM_NMI;
   _PointSetDistanceMeasure             = PDM_FRE;
   _OptimizationMethod                  = OM_ConjugateGradientDescent;
@@ -1156,7 +1156,10 @@ bool GenericRegistrationFilter::Set(const char *param, const char *value, int le
   } else if (name == "Extrapolation mode") {
     return FromString(value, _ExtrapolationMode);
   } else if (name == "Precompute image derivatives") {
-    return FromString(value, _PrecomputeDerivatives);
+    bool bval;
+    if (!FromString(value, bval)) return false;
+    _PrecomputeDerivatives = (bval ? 1 : 0);
+    return true;
 
   // (Default) Similarity measure
   } else if (name == "Image (dis-)similarity measure" ||
@@ -1627,7 +1630,7 @@ ParameterList GenericRegistrationFilter::Parameter(int level) const
     Insert(params, "No. of resolution levels",              _NumberOfLevels);
     Insert(params, "Interpolation mode",                    _InterpolationMode);
     Insert(params, "Extrapolation mode",                    _ExtrapolationMode);
-    Insert(params, "Precompute image derivatives",          _PrecomputeDerivatives);
+    Insert(params, "Precompute image derivatives",          _PrecomputeDerivatives == 0 ? false : true);
     Insert(params, "Normalize weights of energy terms",     _NormalizeWeights);
     Insert(params, "Downsample images with padding",        _DownsampleWithPadding);
     Insert(params, "Crop/pad images",                       _CropPadImages);
@@ -1930,6 +1933,21 @@ void GenericRegistrationFilter::GuessParameter()
   if (!IsNaN(_DefaultPadding)) {
     for (int n = 0; n < _NumberOfImages; ++n) {
       if (IsNaN(_Padding[n])) _Padding[n] = _DefaultPadding;
+    }
+  }
+
+  // Whether to precompute image derivatives
+  if (_PrecomputeDerivatives == -1) {
+    enum InterpolationMode mode = InterpolationWithoutPadding(_InterpolationMode);
+    if (mode == Interpolation_Linear || mode == Interpolation_FastLinear) {
+      _PrecomputeDerivatives = 1;
+    } else {
+      _PrecomputeDerivatives = 0;
+    }
+  } else {
+    enum InterpolationMode mode = InterpolationWithoutPadding(_InterpolationMode);
+    if (_PrecomputeDerivatives == 0 && mode != Interpolation_Linear && mode != Interpolation_FastLinear) {
+      Throw(ERR_InvalidArgument, __FUNCTION__, "Precomputation of image derivatives currently required for non-linear interpolation modes");
     }
   }
 
@@ -3646,7 +3664,7 @@ void GenericRegistrationFilter::SetInputOf(RegisteredImage *output, const struct
   output->InputImage           (&_Image[_CurrentLevel][n]);
   output->InterpolationMode    (_InterpolationMode);
   output->ExtrapolationMode    (_ExtrapolationMode);
-  output->PrecomputeDerivatives(_PrecomputeDerivatives);
+  output->PrecomputeDerivatives(_PrecomputeDerivatives == 0 ? false : true);
   output->Transformation       (this->OutputTransformation(ti));
 
   // Add/Amend displacement cache entry

--- a/Modules/Transformation/include/mirtk/RegisteredImage.h
+++ b/Modules/Transformation/include/mirtk/RegisteredImage.h
@@ -181,6 +181,11 @@ protected:
   /// \param[in] sigma Standard deviation of Gaussian smoothing filter in voxels.
   void ComputeInputHessian(double sigma);
 
+private:
+
+  /// Internal voxel-wise update functor object
+  SharedPtr<Object> _Evaluator;
+
   // ---------------------------------------------------------------------------
   // Construction/Destruction
 public:


### PR DESCRIPTION
When using a B-spline interpolator, the coefficients were recomputed upon each update of the transformed image which slows down the registration quite a lot and is unnecessary. Instead, keep the interpolators alive between update calls to avoid unnecessary re-computations.

This PR also includes a small change of evaluating values outside the domain for which no boundary condition has to be applied to avoid sharp boundaries in the transformed image.

Further, the pre-computation of source image gradients is automatically enabled when the interpolation mode is not Linear, which is the only one for which there exists an on-the-fly ImageGradientFunction subclass at the moment. Still need to provide ones for the B-spline interpolation modes.