### PR TITLE
enh: average-images input/output normalization and output sharpening

### DIFF
--- a/Applications/src/average-images.cc
+++ b/Applications/src/average-images.cc
@@ -26,6 +26,7 @@
 #include "mirtk/GenericImage.h"
 #include "mirtk/VoxelFunction.h"
 #include "mirtk/InterpolateImageFunction.h"
+#include "mirtk/DataStatistics.h"
 
 #ifdef HAVE_MIRTK_Transformation
 #  include "mirtk/Transformation.h"
@@ -34,6 +35,7 @@
 #endif
 
 using namespace mirtk;
+using namespace mirtk::data::statistic;
 
 
 // =============================================================================
@@ -43,56 +45,93 @@ using namespace mirtk;
 /// Print program usage information
 void PrintHelp(const char* name)
 {
-  cout << endl;
+  cout << "\n";
 #ifdef HAVE_MIRTK_Transformation
-  cout << "Usage: " << name << " <output> -images <images.lst> [options]" << endl;
-  cout << "       " << name << " <output> -image <image1> [-dof <dof1>...] -image <image2> [-dof <dof2>...]... [options]" << endl;
-  cout << "       " << name << " <output> <image1> [<dof1>...] <image2> [<dof2>...]... [options]" << endl;
+  cout << "Usage: " << name << " <output> -images <images.lst> [options]\n";
+  cout << "       " << name << " <output> -image <image1> [-dof <dof1>...] -image <image2> [-dof <dof2>...]... [options]\n";
+  cout << "       " << name << " <output> <image1> [<dof1>...] <image2> [<dof2>...]... [options]\n";
 #else
-  cout << "Usage: " << name << " <output> -images <images.lst> [options]" << endl;
-  cout << "       " << name << " <output> -image <image1> -image <image2> ... [options]" << endl;
-  cout << "       " << name << " <output> <image1> <image2>... [options]" << endl;
+  cout << "Usage: " << name << " <output> -images <images.lst> [options]\n";
+  cout << "       " << name << " <output> -image <image1> -image <image2> ... [options]\n";
+  cout << "       " << name << " <output> <image1> <image2>... [options]\n";
 #endif
-  cout << "       " << name << " <output> <sequence> [options]" << endl;
-  cout << endl;
-  cout << "Description:" << endl;
-  cout << "  Computes voxelwise average image of the given (transformed) input images." << endl;
+  cout << "       " << name << " <output> <sequence> [options]\n";
+  cout << "\n";
+  cout << "Description:\n";
+  cout << "  Computes voxel-wise average image of the given (transformed) input images.\n";
 #ifdef HAVE_MIRTK_Transformation
-  cout << endl;
-  cout << "  The input images are optionally transformed by an image-to-average space transformation" << endl;
-  cout << "  (:option:`-dof`) or its inverse (:option:`-dof_i`)." << endl;
+  cout << "\n";
+  cout << "  The input images are optionally transformed by one or more image-to-average space\n";
+  cout << "  transformation (:option:`-dof`) or its inverse (:option:`-dof_i`), respectively.\n";
+  cout << "  When more than one transformation is given, these are concatenated via funtion\n";
+  cout << "  composition.\n";
 #endif
-  cout << endl;
-  cout << "Required arguments:" << endl;
-  cout << "  <output>                 Voxel-wise average image." << endl;
-  cout << "  -images <file>           Text file with N lines containing the file name of each input image," << endl;
-  cout << "                           optionally a transformation file name (see :option:`-dof` and :option:`-dof_i`)," << endl;
-  cout << "                           optionally followed by a weight for a weighted output average (default weight is 1)." << endl;
-  cout << "                           The first line of the text file must specify the common base directory" << endl;
-  cout << "                           of all relative image and transformation file paths occurring on the" << endl;
-  cout << "                           subsequent N lines. A path starting with './' must be relative to the" << endl;
-  cout << "                           directory containing the input text file itself." << endl;
-  cout << "  -delim, -delimiter <c>   Delimiter used in :option:`-images` file." << endl;
-  cout << "                           (default: ',' for .csv, '\\t' for .tsv, and ' ' otherwise)" << endl;
-  cout << "  -invert                  Invert transformations specified in :option:`-images` file." << endl;
-  cout << "  -image <file>            A single input image." << endl;
+  cout << "\n";
+  cout << "Required arguments:\n";
+  cout << "  <output>\n";
+  cout << "      Voxel-wise average image.\n";
+  cout << "\n";
+  cout << "Input options:\n";
+  cout << "  -image <file>\n";
+  cout << "      A single input image.\n";
+  cout << "  -images <file>\n";
+  cout << "      Text file with N lines containing the file name of each input image,\n";
+  cout << "      optionally a transformation file name (see :option:`-dof` and :option:`-dof_i`),\n";
+  cout << "      optionally followed by a weight for a weighted output average (default weight is 1).\n";
+  cout << "      The first line of the text file must specify the common base directory\n";
+  cout << "      of all relative image and transformation file paths occurring on the\n";
+  cout << "      subsequent N lines. A path starting with './' must be relative to the\n";
+  cout << "      directory containing the input text file itself.\n";
+  cout << "  -delim, -delimiter <c>\n";
+  cout << "      Delimiter used in :option:`-images` file.\n";
+  cout << "      (default: ',' for .csv, '\\t' for .tsv, and ' ' otherwise)\n";
 #ifdef HAVE_MIRTK_Transformation
-  cout << "  -dof <file>              Specifies a transformation to be applied to the preceeding image. (default: none)" << endl;
-  cout << "  -dof_i <file>            Specifies a transformation whose inverse is to be applied to the" << endl;
-  cout << "                           preceeding image similar to :option:`-dof`. (default: none)" << endl;
+  cout << "  -invert\n";
+  cout << "      Invert transformations specified in :option:`-images` file.\n";
+  cout << "  -dof <file>\n";
+  cout << "      Specifies a transformation to be applied to the preceeding image. (default: none)\n";
+  cout << "  -dof_i <file>\n";
+  cout << "      Specifies a transformation whose inverse is to be applied to the\n";
+  cout << "      preceeding image similar to :option:`-dof`. (default: none)\n";
 #endif
-  cout << endl;
-  cout << "Optional arguments:" << endl;
-  cout << "  -reference <file>          Reference image for output image attributes.\n";
-  cout << "  -size <dx> [<dy> [<dz>]]   Voxel size of intensity average image. (default: average of input images)" << endl;
-  cout << "  -padding <value>           Input padding and output background value. No input padding if not specified." << endl;
-  cout << "                             Output background value zero by default or minimum average intensity minus 1. (default: 0)" << endl;
-  cout << "  -interp <mode>             Interpolation mode, e.g., NN, Linear, BSpline, Cubic, Sinc. (default: Linear)" << endl;
-  cout << "  -label <value>             Segmentation label of which to create an average probability map." << endl;
-  cout << "  -datatype, -dtype, -type char|uchar|short|float|double" << endl;
-  cout << "      Data type of output image. The intermediate average image always has floating point data type." << endl;
-  cout << "      When this option is given, this average is cast to the respective output type before writing" << endl;
-  cout << "      the result to the output image file. (default: float)" << endl;
+  cout << "\n";
+  cout << "Optional arguments:\n";
+  cout << "  -reference, -target <file>|max-size|max-space|average\n";
+  cout << "      When <file> name specified, use the attributes of this reference image for average image.\n";
+  cout << "      When \"max-size\" is specified, the input image with the most number of voxels is used as\n";
+  cout << "      reference, whereas \"max-space\" selects the image which occupies the largest amount world space.\n";
+  cout << "      By default, an \"average\" voxel size and image orientation is computed from the input images\n";
+  cout << "      and the image size adjusted such that the image bounding boxes of all (affinely transformed)\n";
+  cout << "      input images are contained within the average image space. (default: average)\n";
+  cout << "  -voxel-size, -spacing, -size <dx> [<dy> [<dz>]]\n";
+  cout << "      Voxel size of intensity average image. (default: :option:`-reference`)\n";
+  cout << "  -padding <value>\n";
+  cout << "      Input padding and output background value. No input padding if not specified.\n";
+  cout << "      Output background value zero by default or minimum average intensity minus 1. (default: 0)\n";
+  cout << "  -normalize, -normalization <mode>\n";
+  cout << "      Input intensity normalization:\n";
+  cout << "      - ``none``:    Use input intensities unmodified. (default)\n";
+  cout << "      - ``mean``:    Divide by mean foreground value.\n";
+  cout << "      - ``median``:  Divide by median foreground value.\n";
+  cout << "      - ``z-score``: Subtract mean and divide by standard deviation.\n";
+  cout << "      - ``unit``:    Rescale input intensities to [0, 1].\n";
+  cout << "      - ``dist``:    Rescale input intensities to average mean and standard deviation of input images.\n";
+  cout << "  -rescale, -rescaling <mode>|<min> <max>\n";
+  cout << "      Linear rescaling of average intensity values:\n";
+  cout << "      - ``none``: No rescaling of averaged intensities. (default)\n";
+  cout << "      - ``unit``: Rescale average intensities to [0, 1].\n";
+  cout << "      - ``dist``: Rescale average intensities to average mean and standard deviation of input images.\n";
+  cout << "      - ``<min> <max>``: Rescale average intensities to specified output range.\n";
+  cout << "  -margin <n>\n";
+  cout << "      Crop/pad average image and ensure a margin of <n> voxels at each boundary. (default: -1/off)\n";
+  cout << "  -interpolation, -interp <mode>\n";
+  cout << "      Interpolation mode, e.g., NN, Linear, BSpline, Cubic, Sinc. (default: Linear)\n";
+  cout << "  -label <value>\n";
+  cout << "      Segmentation label of which to create an average probability map.\n";
+  cout << "  -datatype, -dtype, -type char|uchar|short|float|double\n";
+  cout << "      Data type of output image. The intermediate average image always has floating point data type.\n";
+  cout << "      When this option is given, this average is cast to the respective output type before writing\n";
+  cout << "      the result to the output image file. (default: float)\n";
   PrintCommonOptions(cout);
   cout << endl;
 }
@@ -108,6 +147,25 @@ typedef GenericInterpolateImageFunction<InputImage> InputImageFunction;
 
 // Type of average image
 typedef GenericImage<float>  AverageImage;
+
+// Type of intensity image normalization
+enum NormalizationMode
+{
+  Normalization_None,         ///< Use input intensity values unmodified
+  Normalization_Mean,         ///< Divide input image values by mean intensity
+  Normalization_Median,       ///< Divide input image values by median intensity
+  Normalization_ZScore,       ///< Subtract mean intensity and divide by standard deviation
+  Normalization_MeanStDev,    ///< Rescale input to average mean and standard deviation
+  Normalization_UnitRange     ///< Rescale input intensities to [0, 1]
+};
+
+// Type of average image rescaling functions
+enum RescalingMode
+{
+  Rescaling_None,        ///< No rescaling of average (normalized) input intensities
+  Rescaling_MeanStDev,   ///< Rescale output to input mean and standard deviation
+  Rescaling_Range        ///< Rescale output image to specified output range
+};
 
 // =============================================================================
 // Auxiliary functions
@@ -234,12 +292,27 @@ void Read(const string &image_name, const Array<string> &imdof_names, const Arra
 #endif // HAVE_MIRTK_Transformation
 
 // -----------------------------------------------------------------------------
+UniquePtr<bool[]> ForegroundMaskArray(const BaseImage *image)
+{
+  const int num = image->NumberOfSpatialVoxels();
+  UniquePtr<bool[]> mask(new bool[num]);
+  for (int idx = 0; idx < num; ++idx) {
+    mask[idx] = (!IsNaN(image->GetAsDouble(idx)) && image->IsForeground(idx));
+  }
+  return mask;
+}
+
+// -----------------------------------------------------------------------------
 struct AddVoxelValueToAverage : public VoxelFunction
 {
   AverageImage       *_Average;
   InputImageFunction *_Image;
   double              _Weight;
   int                 _Label;
+  double              _Scale;
+  double              _Intercept;
+  double              _Min;
+  double              _Max;
 
   #ifdef HAVE_MIRTK_Transformation
     const Array<UniquePtr<Transformation> > *_Transformation;
@@ -272,31 +345,86 @@ struct AddVoxelValueToAverage : public VoxelFunction
         *avg += static_cast<T>(_Weight);
       }
     } else {
-      const T bg = static_cast<T>(_Average->GetBackgroundValueAsDouble());
-      if ((IsNaN(bg) && IsNaN(*avg)) || (*avg == bg)) {
-        *avg = static_cast<T>(_Weight * _Image->Evaluate(x, y, z));
-      } else {
-        *avg += static_cast<T>(_Weight * _Image->Evaluate(x, y, z));
+      double value = _Image->Evaluate(x, y, z);
+      if (!IsNaN(value) && value != _Image->DefaultValue()) {
+        value = _Scale * clamp(value, _Min, _Max) + _Intercept;
+        if (IsNaN(*avg)) {
+          *avg = static_cast<T>(_Weight * value);
+        } else {
+          *avg += static_cast<T>(_Weight * value);
+        }
       }
     }
   }
 };
 
 // -----------------------------------------------------------------------------
-void Add(AverageImage &average, InputImage &image,
+bool Add(AverageImage &average, InputImage &image,
          #ifdef HAVE_MIRTK_Transformation
            const Array<UniquePtr<Transformation> > &dof,
            const Array<bool>                       &inv,
          #endif // HAVE_MIRTK_Transformation
-         double            weight        = 1.0,
-         int               label         = -1,
-         InterpolationMode interpolation = Interpolation_Linear)
+         double weight, int label,
+         InterpolationMode interpolation = Interpolation_Linear,
+         NormalizationMode normalization = Normalization_None,
+         double avg_mean = NaN, double avg_sigma = NaN)
 {
   AddVoxelValueToAverage add;
+  // Determine min/max intensity used to clamp interpolated values
+  const double bg = image.GetBackgroundValueAsDouble();
+  const InputType * const data = image.Data();
+  const int num = image.NumberOfSpatialVoxels();
+  UniquePtr<bool[]> mask = ForegroundMaskArray(&image);
+  Extrema::Calculate(add._Min, add._Max, num, data, mask.get());
+  if (IsNaN(add._Min) || IsNaN(add._Max)) return false;
+  // Compute normalization parameters
+  add._Scale = 1.;
+  add._Intercept = 0.;
+  if (normalization == Normalization_Mean) {
+    double mean = Mean::Calculate(num, data, mask.get());
+    if (!fequal(mean, 0.)) {
+      add._Scale = 1. / mean;
+    }
+  } else if (normalization == Normalization_Median) {
+    double median = Median::Calculate(num, data, mask.get());
+    if (!fequal(median, 0.)) {
+      add._Scale = 1. / median;
+    }
+  } else if (normalization == Normalization_ZScore) {
+    double mean, sigma;
+    NormalDistribution::Calculate(mean, sigma, num, data, mask.get());
+    if (fequal(sigma, 0.)) return false;
+    add._Scale = 1. / sigma;
+    add._Intercept = - mean / sigma;
+    double zscore_min = (add._Min - mean) / sigma;
+    double zscore_max = (add._Max - mean) / sigma;
+    double output_min = ((IsNaN(bg) || bg <= 0.) ? 0. : bg + .01);
+    double output_max = output_min + (zscore_max - zscore_min);
+    double zscore_mul = (output_max - output_min) / (zscore_max - zscore_min);
+    double zscore_add = output_min - zscore_mul * zscore_min;
+    add._Scale     = zscore_mul * add._Scale;
+    add._Intercept = zscore_mul * add._Intercept + zscore_add;
+  } else if (normalization == Normalization_MeanStDev) {
+    double mean, sigma;
+    NormalDistribution::Calculate(mean, sigma, num, data, mask.get());
+    if (fequal(avg_sigma, 0.) || fequal(sigma, 0.)) return false;
+    add._Scale = avg_sigma / sigma;
+    add._Intercept = avg_mean - add._Scale / sigma;
+  } else if (normalization == Normalization_UnitRange) {
+    double range = add._Max - add._Min;
+    if (fequal(range, 0.)) return false;
+    add._Scale = 1. / (add._Max - add._Min);
+    add._Intercept = - add._Scale * add._Min;
+  }
+  // Mask array no longer needed
+  mask.reset();
+  // Set interpolation function
   if (label > 0) interpolation = Interpolation_NN;
   UniquePtr<InputImageFunction> interp;
   interp.reset(InputImageFunction::New(interpolation, &image));
+  interp->DefaultValue(bg);
   interp->Initialize();
+  // Precompute displacement vector field
   #ifdef HAVE_MIRTK_Transformation
     bool cache = false;
     GenericImage<double> disp;
@@ -324,11 +452,106 @@ void Add(AverageImage &average, InputImage &image,
     add._Invert         = &inv;
     add._Displacement   = (cache ? &disp : nullptr);
   #endif // HAVE_MIRTK_Transformation
+  // Transform, normalize, and add image values
   add._Average = &average;
   add._Weight  = weight;
   add._Label   = label;
   add._Image   = interp.get();
   ParallelForEachVoxel(average.Attributes(), average, add);
+  return true;
+}
+
+// -----------------------------------------------------------------------------
+/// Voxel function for parallel convolution of 2D image with discrete Laplace operator
+class LaplaceOperator2D : public VoxelFunction
+{
+  const AverageImage *_Image;
+  const double2       _NeighborWeight;
+  const double        _CenterWeight;
+
+public:
+
+  LaplaceOperator2D(const AverageImage *image)
+  :
+    _Image(image),
+    _NeighborWeight(make_double2(_Image->XSize() * _Image->XSize(),
+                                 _Image->YSize() * _Image->YSize())),
+    _CenterWeight(2. * _NeighborWeight.x + 2. * _NeighborWeight.y)
+  {}
+
+  void operator ()(int i, int j, int, int, AverageImage::VoxelType *out) const
+  {
+    const AverageImage &f = *_Image;
+    if (f.IsInsideForeground(i, j)) {
+      double invalue  = f(i, j);
+      double outvalue = 0.;
+      if (f.IsInsideForeground(i-1, j)) outvalue += f(i-1, j) * _NeighborWeight.x;
+      else                              outvalue += invalue   * _NeighborWeight.x;
+      if (f.IsInsideForeground(i+1, j)) outvalue += f(i+1, j) * _NeighborWeight.x;
+      else                              outvalue += invalue   * _NeighborWeight.x;
+      if (f.IsInsideForeground(i, j-1)) outvalue += f(i, j-1) * _NeighborWeight.y;
+      else                              outvalue += invalue   * _NeighborWeight.y;
+      if (f.IsInsideForeground(i, j+1)) outvalue += f(i, j+1) * _NeighborWeight.y;
+      else                              outvalue += invalue   * _NeighborWeight.y;
+      *out = voxel_cast<AverageImage::VoxelType>(outvalue - invalue * _CenterWeight);
+    }
+  }
+};
+
+// -----------------------------------------------------------------------------
+/// Voxel function for parallel convolution of 3D image with discrete Laplace operator
+class LaplaceOperator3D : public VoxelFunction
+{
+  const AverageImage *_Image;
+  const double3       _NeighborWeight;
+  const double        _CenterWeight;
+
+public:
+
+  LaplaceOperator3D(const AverageImage *image)
+  :
+    _Image(image),
+    _NeighborWeight(make_double3(_Image->XSize() * _Image->XSize(),
+                                 _Image->YSize() * _Image->YSize(),
+                                 _Image->ZSize() * _Image->ZSize())),
+    _CenterWeight(2. * _NeighborWeight.x + 2. * _NeighborWeight.y + 2. * _NeighborWeight.z)
+  {}
+
+  void operator ()(int i, int j, int k, int, AverageImage::VoxelType *out) const
+  {
+    const AverageImage &f = *_Image;
+    if (f.IsInsideForeground(i, j, k)) {
+      double invalue  = f(i, j, k);
+      double outvalue = 0.;
+      if (f.IsInsideForeground(i-1, j, k)) outvalue += f(i-1, j, k) * _NeighborWeight.x;
+      else                                 outvalue += invalue      * _NeighborWeight.x;
+      if (f.IsInsideForeground(i+1, j, k)) outvalue += f(i+1, j, k) * _NeighborWeight.x;
+      else                                 outvalue += invalue      * _NeighborWeight.x;
+      if (f.IsInsideForeground(i, j-1, k)) outvalue += f(i, j-1, k) * _NeighborWeight.y;
+      else                                 outvalue += invalue      * _NeighborWeight.y;
+      if (f.IsInsideForeground(i, j+1, k)) outvalue += f(i, j+1, k) * _NeighborWeight.y;
+      else                                 outvalue += invalue      * _NeighborWeight.y;
+      if (f.IsInsideForeground(i, j, k-1)) outvalue += f(i, j, k-1) * _NeighborWeight.z;
+      else                                 outvalue += invalue      * _NeighborWeight.z;
+      if (f.IsInsideForeground(i, j, k+1)) outvalue += f(i, j, k+1) * _NeighborWeight.z;
+      else                                 outvalue += invalue      * _NeighborWeight.z;
+      *out = voxel_cast<AverageImage::VoxelType>(outvalue - invalue * _CenterWeight);
+    }
+  }
+};
+
+// -----------------------------------------------------------------------------
+/// Convolve intensity image by the finite difference Laplacian kernel
+AverageImage ApplyLaplaceOperator(const AverageImage &image)
+{
+  AverageImage output(image);
+  output.ClearBackgroundValue();
+  if (output.Z() == 1 || output.ZSize() == 0.) {
+    ParallelForEachVoxel(LaplaceOperator2D(&image), output.Attributes(), output);
+  } else {
+    ParallelForEachVoxel(LaplaceOperator3D(&image), output.Attributes(), output);
+  }
+  return output;
 }
 
 // =============================================================================
@@ -403,13 +626,18 @@ int main(int argc, char **argv)
   // Parse arguments
   const char        *image_list_name  = nullptr;
   const char        *image_list_delim = nullptr;
-  const char        *reference_name   = nullptr;
+  string             reference_name;
   double             padding          = numeric_limits<double>::quiet_NaN();
   InterpolationMode  interpolation    = Interpolation_Linear;
+  NormalizationMode  normalization    = Normalization_None;
+  RescalingMode      rescaling        = Rescaling_None;
+  double             output_min       = -inf;
+  double             output_max       = +inf;
   bool               invert_dofs      = false;
   int                label            = -1;
   ImageDataType      dtype            = MIRTK_VOXEL_FLOAT;
   int                margin           = -1;
+  bool               sharpen          = false;
   double             dx = .0, dy = .0, dz = .0;
 
   for (ARGUMENTS_AFTER(nposarg)) {
@@ -419,10 +647,19 @@ int main(int argc, char **argv)
     else if (OPTION("-delim") || OPTION("-delimiter")) {
       image_list_delim = ARGUMENT;
     }
-    else if (OPTION("-reference")) {
-      reference_name = ARGUMENT;
+    else if (OPTION("-reference") || OPTION("-target")) {
+      const string farg = ARGUMENT;
+      const string larg = ToLower(farg);
+      if (larg == "maxsize" || larg == "max-size") {
+        reference_name = "max-size";
+      } else if (larg == "maxvol" || larg == "maxvolume" || larg == "max-vol" || larg == "max-volume" ||
+                 larg == "maxarea" || larg == "max-area" || larg == "maxspace" || larg == "max-space") {
+        reference_name = "max-space";
+      } else {
+        reference_name = farg;
+      }
     }
-    else if (OPTION("-size")) {
+    else if (OPTION("-spacing") || OPTION("-voxel-size") || OPTION("-size")) {
       PARSE_ARGUMENT(dx);
       dy = dz = dx;
       if (HAS_ARGUMENT) {
@@ -431,11 +668,69 @@ int main(int argc, char **argv)
         else              dz = .0;
       }
     }
-    else if (OPTION("-padding"))   PARSE_ARGUMENT(padding);
-    else if (OPTION("-invert"))    invert_dofs = true;
-    else if (OPTION("-margin"))    PARSE_ARGUMENT(margin);
-    else if (OPTION("-label"))     PARSE_ARGUMENT(label);
-    else if (OPTION("-interp"))    PARSE_ARGUMENT(interpolation);
+    else if (OPTION("-normalization") || OPTION("-normalize")) {
+      if (HAS_ARGUMENT) {
+        const string arg = ToLower(ARGUMENT);
+        bool bval;
+        if (FromString(arg, bval)) {
+          normalization = (bval ? Normalization_Mean : Normalization_None);
+        } else if (arg == "none") {
+          normalization = Normalization_None;
+        } else if (arg == "mean") {
+          normalization = Normalization_Mean;
+        } else if (arg == "median") {
+          normalization = Normalization_Median;
+        } else if (arg == "zscore" || arg == "z-score") {
+          normalization = Normalization_ZScore;
+        } else if (arg == "unit") {
+          normalization = Normalization_UnitRange;
+        } else if (arg == "dist") {
+          normalization = Normalization_MeanStDev;
+        } else {
+          FatalError("Invalid -normalization mode: " << arg);
+        }
+      } else {
+        normalization = Normalization_Mean;
+      }
+    }
+    else if (OPTION("-rescaling") || OPTION("-rescale")) {
+      if (HAS_ARGUMENT) {
+        const string arg = ToLower(ARGUMENT);
+        if (HAS_ARGUMENT) {
+          if (!FromString(arg, output_min)) {
+            FatalError("Option -resaling must either have one string argument or two floating point numbers as arguments");
+          }
+          PARSE_ARGUMENT(output_max);
+          rescaling = Rescaling_Range;
+        } else {
+          bool bval;
+          if (FromString(arg, bval)) {
+            rescaling = (bval ? Rescaling_MeanStDev : Rescaling_None);
+          } else {
+            const string larg = ToLower(arg);
+            if (larg == "none") {
+              rescaling = Rescaling_None;
+            } else if (arg == "unit") {
+              output_min = 0.;
+              output_max = 1.;
+              rescaling = Rescaling_Range;
+            } else if (arg == "dist") {
+              rescaling = Rescaling_MeanStDev;
+            } else {
+              FatalError("Invalid -rescaling mode: " << arg);
+            }
+          }
+        }
+      } else {
+        rescaling = Rescaling_MeanStDev;
+      }
+    }
+    else HANDLE_BOOL_OPTION(sharpen);
+    else HANDLE_BOOLEAN_OPTION("invert", invert_dofs);
+    else if (OPTION("-padding")) PARSE_ARGUMENT(padding);
+    else if (OPTION("-margin")) PARSE_ARGUMENT(margin);
+    else if (OPTION("-label")) PARSE_ARGUMENT(label);
+    else if (OPTION("-interpolation") || OPTION("-interp")) PARSE_ARGUMENT(interpolation);
     else if (OPTION("-datatype") || OPTION("-dtype") || OPTION("-type")) {
       PARSE_ARGUMENT(dtype);
     }
@@ -493,44 +788,113 @@ int main(int argc, char **argv)
     FatalError("No input image(s) specified!");
   }
 
-  // Compute sum of weights
-  double wsum = .0;
+  // Normalize weights
+  double wsum = 0.;
   for (int n = 0; n < nimages; ++n) {
     wsum += image_weight[n];
   }
+  if (wsum == 0.) {
+    FatalError("Sum of image weights is zero!");
+  }
+  for (int n = 0; n < nimages; ++n) {
+    image_weight[n] /= wsum;
+  }
 
-  // Compute voxel-wise average of (interpolated) input intensities on
-  // common (mapped) image domain of all input images; for example,
-  // used for anatomical intensity atlas construction
-
-  // Compute field-of-view which contains all images
-  if (verbose) cout << "Determine field-of-view which contains all images...", cout.flush();
-  ImageAttributes fov;
-  if (reference_name) {
-    GreyImage reference(reference_name);
-    fov = reference.Attributes();
-  } else if (sequence.IsEmpty()) {
-    Array<ImageAttributes> attr;
+  // ---------------------------------------------------------------------------
+  // Collect input properties if needed
+  double min_input = -inf, max_input = +inf;
+  double sum_of_means  = 0.;
+  double sum_of_sigmas = 0.;
+  Array<ImageAttributes> attrs;
+  bool calc_input_distribution = false;
+  bool collect_attrs           = false;
+  if (reference_name.empty() || reference_name == "max-size" || reference_name == "max-space") {
+    collect_attrs = sequence.IsEmpty();
+  }
+  if (normalization == Normalization_MeanStDev || rescaling == Rescaling_MeanStDev) {
+    calc_input_distribution = true;
+  }
+  if (collect_attrs || calc_input_distribution) {
+    if (verbose) {
+      cout << "Determine";
+      if (collect_attrs) {
+        if (reference_name == "max-size" || reference_name == "max-space") {
+          cout << " image with " << reference_name;
+        } else {
+          cout << " common field-of-view";
+        }
+      }
+      if (calc_input_distribution) {
+        if (collect_attrs) cout << ", and";
+        cout << " average intensity distribution";
+      }
+      cout << "...";
+      cout.flush();
+    }
     for (int n = 0; n < nimages; ++n) {
       #ifdef HAVE_MIRTK_Transformation
         Read(image_name[n], imdof_name[n], imdof_invert[n], image, dofs, invert);
-        dofs.clear(); // unused here
-        invert.clear();
+        dofs.clear(), invert.clear(); // unused here
       #else // HAVE_MIRTK_Transformation
         image.Read(image_name[n].c_str());
       #endif // HAVE_MIRTK_Transformation
       if (image.T() > 1) {
         if (verbose) cout << " failed" << endl;
-        FatalError("Image " << (n+1) << " has four dimensions!");
+        FatalError("Image " << (n + 1) << " has four dimensions!");
       }
-      attr.push_back(OrthogonalFieldOfView(image.Attributes()));
+      if (collect_attrs) {
+        attrs.push_back(OrthogonalFieldOfView(image.Attributes()));
+      }
+      image.PutBackgroundValueAsDouble(padding);
+      if (calc_input_distribution) {
+        double mean, sigma, min_value, max_value;
+        const int num = image.NumberOfSpatialVoxels();
+        UniquePtr<bool[]> mask = ForegroundMaskArray(&image);
+        NormalDistribution::Calculate(mean, sigma, num, image.Data(), mask.get());
+        Extrema::Calculate(min_value, max_value, num, image.Data(), mask.get());
+        if (min_value < min_input) min_input = min_value;
+        if (max_value > max_input) max_input = max_value;
+        sum_of_means  += mean;
+        sum_of_sigmas += sigma;
+      }
     }
-    fov = OverallFieldOfView(attr);
+    if (verbose) cout << " done" << endl;
+  }
+
+  const double avg_mean  = sum_of_means  / nimages;
+  const double avg_sigma = sum_of_sigmas / nimages;
+
+  // ---------------------------------------------------------------------------
+  // Average image attributes (field-of-view)
+  ImageAttributes fov;
+  if (!reference_name.empty() && reference_name != "max-size" && reference_name != "max-space") {
+    if (verbose) cout << "Using attributes of reference image" << endl;
+    BinaryImage reference(reference_name.c_str());
+    fov = reference.Attributes();
+  } else if (sequence.IsEmpty()) {
+    if (reference_name == "max-size") {
+      int vox = 0;
+      for (const auto &attr : attrs) {
+        if (attr.NumberOfSpatialPoints() > vox) {
+          vox = attr.NumberOfSpatialPoints();
+          fov = attr;
+        }
+      }
+    } else if (reference_name == "max-space") {
+      double vol = 0.;
+      for (const auto &attr : attrs) {
+        if (attr.Space() > vol) {
+          vol = attr.Space();
+          fov = attr;
+        }
+      }
+    } else {
+      fov = OverallFieldOfView(attrs);
+    }
   } else {
     fov = sequence.Attributes();
     fov._t = 1, fov._dt *= nimages;
   }
-  if (verbose) cout << " done" << endl;
 
   // Set desired output voxel size
   if (dx > .0) {
@@ -546,10 +910,11 @@ int main(int argc, char **argv)
     fov._dz = dz;
   }
 
+  // ---------------------------------------------------------------------------
   // Compute average image
   AverageImage average(fov);
-  average = padding;
-  average.PutBackgroundValueAsDouble(padding);
+  average = NaN;
+  average.PutBackgroundValueAsDouble(NaN);
   for (int n = 0; n < nimages; ++n) {
     if (sequence.IsEmpty()) {
       if (verbose) {
@@ -572,37 +937,155 @@ int main(int argc, char **argv)
         invert.clear();
       #endif
     }
+    image.PutBackgroundValueAsDouble(padding, true);
 
+    bool ok;
     #ifdef HAVE_MIRTK_Transformation
-      Add(average, image, dofs, invert, image_weight[n], label, interpolation);
-      dofs.clear();
-      invert.clear();
+      ok = Add(average, image, dofs, invert, image_weight[n], label, interpolation, normalization, avg_mean, avg_sigma);
+      dofs.clear(), invert.clear();
     #else
-      Add(average, image, image_weight[n], label, interpolation);
+      ok = Add(average, image, image_weight[n], label, interpolation, normalization, avg_mean, avg_sigma);
     #endif
-
-    if (verbose) cout << " done" << endl;
+    if (ok) {
+      if (verbose) cout << " done" << endl;
+    } else {
+      if (verbose) cout << " skip" << endl;
+      if (normalization == Normalization_UnitRange || normalization == Normalization_ZScore || normalization == Normalization_MeanStDev) {
+        Warning("Input image " << image_name[n] << " either contains no or constant foreground values!");
+      } else {
+        Warning("Input image " << image_name[n] << " contains no foreground values!");
+      }
+    }
   }
-  if (wsum > .0) average /= wsum;
 
+  // ---------------------------------------------------------------------------
+  // Replace NaN values by suitable background value
+  AverageImage::VoxelType min_value, max_value;
+  average.GetMinMax(min_value, max_value);
+  AverageImage::VoxelType bg = min_value - 1.;
+  if (bg > 0.) bg = 0.;
+  for (int idx = 0; idx < average.NumberOfVoxels(); ++idx) {
+    if (IsNaN(average(idx))) {
+      average(idx) = bg;
+    }
+  }
+  average.PutBackgroundValueAsDouble(bg);
+
+  // ---------------------------------------------------------------------------
   // Crop/pad average image
   if (margin >= 0) {
+    if (verbose) {
+      cout << "Cropping average image adding margin of " << margin << " background layers...";
+      cout.flush();
+    }
     average.CropPad(margin);
+    if (verbose) cout << " done" << endl;
   }
 
-  // Replace NaN background values
-  if (IsNaN(average.GetBackgroundValueAsDouble())) {
-    AverageImage::VoxelType min_value, max_value;
+  // ---------------------------------------------------------------------------
+  // Sharpen average image (cf. itkLaplacianSharpeningImageFilter, ANTs AverageImages)
+  if (sharpen) {
+    // TODO: Implement this as reusable MIRTK image filter
+    if (verbose) {
+      cout << "Sharpening average image using Laplacian operator...";
+      cout.flush();
+    }
+    const int num = average.NumberOfSpatialVoxels();
+    UniquePtr<bool[]> mask = ForegroundMaskArray(&average);
+    typedef AverageImage::VoxelType Real;
+    AverageImage laplace = ApplyLaplaceOperator(average);
+    Real mean = Mean::Calculate(num, average.Data(), mask.get());
+    Real min_value, max_value;
     average.GetMinMax(min_value, max_value);
-    padding = min(.0, double(min_value) - 1.0);
-    for (int idx = 0; idx < average.NumberOfVoxels(); ++idx) {
-      if (IsNaN(average(idx))) {
-        average(idx) = voxel_cast<AverageImage::VoxelType>(padding);
+    laplace.PutMinMax(min_value, max_value);
+    if (debug) {
+      average.Write("debug_average_intensity.nii.gz");
+      laplace.Write("debug_average_laplacian.nii.gz");
+    }
+    for (int idx = 0; idx < num; ++idx) {
+      if (mask[idx]) average(idx) -= laplace(idx);
+    }
+    if (debug) {
+      average.Write("debug_average_sharpened.nii.gz");
+    }
+    Real shift = mean - Mean::Calculate(num, average.Data(), mask.get());
+    for (int idx = 0; idx < num; ++idx) {
+      if (mask[idx]) {
+        average(idx) = clamp(average(idx) + shift, min_value, max_value);
       }
+    }
+    if (verbose) cout << " done" << endl;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Replace background value by specified padding value
+  if (!IsNaN(padding)) {
+    AverageImage::VoxelType bg;
+    bg = voxel_cast<AverageImage::VoxelType>(padding);
+    for (int idx = 0; idx < average.NumberOfVoxels(); ++idx) {
+      if (average.IsBackground(idx)) average(idx) = bg;
     }
     average.PutBackgroundValueAsDouble(padding);
   }
 
+  // ---------------------------------------------------------------------------
+  // Rescale to input mean and standard deviation
+  if (rescaling != Rescaling_None) {
+    double scale = 1., shift = 0.;
+    const int num = average.NumberOfSpatialVoxels();
+    UniquePtr<bool[]> mask = ForegroundMaskArray(&average);
+    if (rescaling == Rescaling_MeanStDev) {
+      if (verbose) {
+        cout << "Rescaling average to input mean and standard deviation...";
+        cout.flush();
+      }
+      double mean, sigma;
+      NormalDistribution::Calculate(mean, sigma, num, average.Data(), mask.get());
+      if (!fequal(avg_sigma, 0.) && !fequal(sigma, 0.)) {
+        scale = avg_sigma / sigma;
+      }
+      shift = avg_mean - scale * mean;
+    } else if (rescaling == Rescaling_Range) {
+      if (verbose) {
+        cout << "Rescaling average to output range [" << output_min << ", " << output_max << "]...";
+        cout.flush();
+      }
+      double min_value, max_value;
+      Extrema::Calculate(min_value, max_value, num, average.Data(), mask.get());
+      if (!fequal(max_value, min_value)) {
+        scale = (output_max - output_min) / (max_value - min_value);
+      }
+      shift = output_min - scale * min_value;
+    }
+    double min_value = +inf;
+    if (!fequal(scale, 1.) || !fequal(shift, 0.)) {
+      double value;
+      for (int idx = 0; idx < num; ++idx) {
+        if (mask[idx]) {
+          value = clamp(scale * double(average(idx)) + shift, min_input, max_input);
+          if (value < min_value) min_value = value;
+          average(idx) = voxel_cast<AverageImage::VoxelType>(value);
+        }
+      }
+    }
+    if (verbose) {
+      cout << " done" << endl;
+    }
+    double bg = average.GetBackgroundValueAsDouble();
+    if (min_value < bg) {
+      bg = min(0., min_value - 1.);
+      AverageImage::VoxelType padding = static_cast<AverageImage::VoxelType>(bg);
+      if (verbose) {
+        cout << "Input -padding value larger than rescaled minimum, pad output with: " << padding << endl;
+      }
+      for (int idx = 0; idx < num; ++idx) {
+        if (!mask[idx]) average(idx) = padding;
+      }
+      average.PutBackgroundValueAsDouble(bg);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
   // Write average image
   if (average.GetDataType() != dtype) {
     UniquePtr<BaseImage> output(BaseImage::New(dtype));

--- a/Modules/Image/include/mirtk/GenericImage.h
+++ b/Modules/Image/include/mirtk/GenericImage.h
@@ -396,7 +396,13 @@ public:
   /// Linearly rescale intensities
   void PutMinMax(VoxelType, VoxelType);
 
+  /// Mean pixel value
+  ///
+  /// \param[in] fg Calculate mean of foreground only.
+  RealType Mean(bool fg = true) const;
+
   /// Average pixel values get accessor
+  /// \deprecated Use Mean instead.
   RealType GetAverage(int = 1) const;
 
   /// Standard Deviation of the pixels

--- a/Modules/Image/include/mirtk/ImageAttributes.h
+++ b/Modules/Image/include/mirtk/ImageAttributes.h
@@ -242,6 +242,15 @@ struct ImageAttributes
   // ---------------------------------------------------------------------------
   // Output
 
+  /// Image slice area in world space
+  double Area() const;
+
+  /// Image volume in world space
+  double Volume() const;
+
+  /// Amount of space occupied by the image in n-D world space (excluding time dimension)
+  double Space() const;
+
   /// Print attributes
   void Print(ostream &, Indent = 0) const;
 

--- a/Modules/Image/src/GenericImage.cc
+++ b/Modules/Image/src/GenericImage.cc
@@ -1123,39 +1123,39 @@ template <> void GenericImage<double3x3>::PutMinMax(VoxelType, VoxelType)
 // -----------------------------------------------------------------------------
 template <class VoxelType>
 typename GenericImage<VoxelType>::RealType
+GenericImage<VoxelType>::Mean(bool fg) const
+{
+  int num = 0;
+  RealType sum = voxel_cast<RealType >(0);
+  const VoxelType *ptr = this->Data();
+  for (int idx = 0; idx < _NumberOfVoxels; ++idx) {
+    if (!fg || IsForeground(idx)) {
+      sum += voxel_cast<RealType>(*ptr);
+      num += 1;
+    }
+    ++ptr;
+  }
+  return (num > 0 ? sum / num : sum);
+}
+
+template <> typename GenericImage<float3x3 >::RealType GenericImage<float3x3 >::Mean(bool) const
+{
+  cerr << "GenericImage<float3x3>::Mean: Not implemented" << endl;
+  exit(1);
+}
+
+template <> typename GenericImage<double3x3>::RealType GenericImage<double3x3>::Mean(bool) const
+{
+  cerr << "GenericImage<double3x3>::Mean: Not implemented" << endl;
+  exit(1);
+}
+
+// -----------------------------------------------------------------------------
+template <class VoxelType>
+typename GenericImage<VoxelType>::RealType
 GenericImage<VoxelType>::GetAverage(int toggle) const
 {
-  const VoxelType  zero = voxel_cast<VoxelType>(0);
-  RealType         avg  = voxel_cast<RealType >(0);
-  const VoxelType *ptr;
-
-  if (toggle) {
-    int n = 0;
-    ptr = this->Data();
-    for (int i = 0; i < _NumberOfVoxels; i++) {
-      if (IsForeground(i) && (*ptr) > zero) n++;
-      ++ptr;
-    }
-    const RealType norm = voxel_cast<RealType>(1.0 / n);
-    ptr = this->Data();
-    for (int i = 0; i < _NumberOfVoxels; i++) {
-      if (IsForeground(i) && (*ptr) > zero) {
-        avg += norm * voxel_cast<RealType>(*ptr);
-      }
-      ++ptr;
-    }
-  } else {
-    const RealType norm = voxel_cast<RealType>(1.0 / _NumberOfVoxels);
-    ptr = this->Data();
-    for (int i = 0; i < _NumberOfVoxels; i++) {
-      if (IsForeground(i)) {
-        avg += norm * voxel_cast<RealType>(*ptr);
-      }
-      ++ptr;
-    }
-  }
-
-  return avg;
+  return Mean(toggle == 0 ? false : true);
 }
 
 template <> typename GenericImage<float3x3 >::RealType GenericImage<float3x3 >::GetAverage(int) const

--- a/Modules/Image/src/ImageAttributes.cc
+++ b/Modules/Image/src/ImageAttributes.cc
@@ -363,6 +363,29 @@ bool ImageAttributes::EqualInTime(const ImageAttributes &attr) const
 }
 
 // -----------------------------------------------------------------------------
+double ImageAttributes::Area() const
+{
+  return _x * _dx * _y * _dy;
+}
+
+// -----------------------------------------------------------------------------
+double ImageAttributes::Volume() const
+{
+  return _x * _dx * _y * _dy * _z * _dz;
+}
+
+// -----------------------------------------------------------------------------
+double ImageAttributes::Space() const
+{
+  if (static_cast<bool>(*this)) {
+    if (_dz > 0.) return Volume();
+    else          return Area();
+  } else {
+    return 0.;
+  }
+}
+
+// -----------------------------------------------------------------------------
 void ImageAttributes::Print(ostream &os, Indent indent) const
 {
   // Change output stream settings


### PR DESCRIPTION
The Laplacian based average image sharpening is done by the ANTs AverageImages tool used for atlas construction.