### PR TITLE
fix: Number of components argument handling in BaseImage constructor [Image]

### DIFF
--- a/Modules/Image/include/mirtk/BaseImage.h
+++ b/Modules/Image/include/mirtk/BaseImage.h
@@ -132,7 +132,7 @@ protected:
   BaseImage();
 
   /// Constructor
-  BaseImage(const ImageAttributes &, int = 1);
+  BaseImage(const ImageAttributes &, int = -1);
 
   /// Copy constructor
   BaseImage(const BaseImage &);

--- a/Modules/Image/include/mirtk/HashImage.h
+++ b/Modules/Image/include/mirtk/HashImage.h
@@ -97,10 +97,7 @@ public:
   explicit HashImage(int, int, int, int, int);
 
   /// Constructor for given image attributes
-  explicit HashImage(const ImageAttributes &);
-
-  /// Constructor for given image attributes
-  explicit HashImage(const ImageAttributes &, int);
+  explicit HashImage(const ImageAttributes &, int = -1);
 
   /// Copy constructor for image
   explicit HashImage(const BaseImage &);

--- a/Modules/Image/include/mirtk/HashImage.hxx
+++ b/Modules/Image/include/mirtk/HashImage.hxx
@@ -107,15 +107,6 @@ HashImage<VoxelType>::HashImage(int x, int y, int z, int t, int n)
 
 // -----------------------------------------------------------------------------
 template <class VoxelType>
-HashImage<VoxelType>::HashImage(const ImageAttributes &attr)
-:
-  BaseImage(attr)
-{
-  AllocateImage();
-}
-
-// -----------------------------------------------------------------------------
-template <class VoxelType>
 HashImage<VoxelType>::HashImage(const ImageAttributes &attr, int n)
 :
   BaseImage(attr, n)
@@ -205,7 +196,10 @@ void HashImage<VoxelType>::Initialize(const ImageAttributes &a, int n)
 {
   // Initialize attributes
   ImageAttributes attr(a);
-  if (n >= 1) attr._t = n, attr._dt = .0; // i.e., vector image with n components
+  if (n >= 1) {
+    attr._t  = n;
+    attr._dt = 0.;  // i.e., vector image with n components
+  }
   // Initialize memory
   if (_attr._x != attr._x || _attr._y != attr._y || _attr._z != attr._z || _attr._t != attr._t) {
     PutAttributes(attr);

--- a/Modules/Image/src/BaseImage.cc
+++ b/Modules/Image/src/BaseImage.cc
@@ -66,7 +66,10 @@ BaseImage::BaseImage(const ImageAttributes &attr, int n)
   _bgSet(false)
 {
   _attr = attr;
-  if (n > 1) _attr._t = n, _attr._dt = .0; // i.e., vector image with n components
+  if (n >= 1) {
+    _attr._t  = n;
+    _attr._dt = 0.;  // i.e., vector image with n components
+  }
   PutAttributes(_attr);
 }
 

--- a/Modules/Image/src/GenericImage.cc
+++ b/Modules/Image/src/GenericImage.cc
@@ -243,7 +243,10 @@ void GenericImage<VoxelType>::Initialize(const ImageAttributes &a, int n, VoxelT
 {
   // Initialize attributes
   ImageAttributes attr(a);
-  if (n >= 1) attr._t = n, attr._dt = .0; // i.e., vector image with n components
+  if (n >= 1) {
+    attr._t  = n;
+    attr._dt = 0;  // i.e., vector image with n components
+  }
   // Initialize memory
   if (_attr._x != attr._x || _attr._y != attr._y || _attr._z != attr._z || _attr._t != attr._t) {
     PutAttributes(attr);


### PR DESCRIPTION
`BaseImage(attr, 1)` should result in a scalar valued image regardless of the `attr._t` value.