### PR TITLE
enh: calculate-element-wise [Applications]

### DIFF
--- a/Applications/src/calculate-element-wise.cc
+++ b/Applications/src/calculate-element-wise.cc
@@ -467,7 +467,7 @@ int main(int argc, char **argv)
               }
             #endif
           }
-          UniquePtr<Mask> op(new Mask(fname));
+          UniquePtr<Mask> op(new Mask(fname, c));
           if (aname) {
             #if MIRTK_Image_WITH_VTK
               op->ArrayName(aname);

--- a/Applications/src/calculate-element-wise.cc
+++ b/Applications/src/calculate-element-wise.cc
@@ -276,6 +276,9 @@ void PrintHelp(const char *name)
   cout << "      Print mean intensity of values less than or equal to the n-th percentile. (default: off)\n";
   cout << "  -upper-percentile-mean, -upctavg <n>\n";
   cout << "      Print mean intensity of values greater than or equal to the n-th percentile. (default: off)\n";
+  cout << "  -sum\n";
+  cout << "      Print sum of values. Can be used to count values within a certain range using a thresholding\n";
+  cout << "      followed by :option:`-set` 1 before summing these values. (default: off)\n";
   PrintCommonOptions(cout);
   cout << "\n";
   cout << "Examples:\n";
@@ -941,6 +944,8 @@ int main(int argc, char **argv)
           exit(1);
         }
       } while (HAS_ARGUMENT);
+    } else if (OPTION("-sum")) {
+      ops.push_back(UniquePtr<Op>(new Sum()));
     } else if (OPTION("-delimiter") || OPTION("-delim") || OPTION("-d") || OPTION("-sep")) {
       delimiter = ARGUMENT;
     } else if (OPTION("-precision") || OPTION("-digits")) {

--- a/Modules/Image/include/mirtk/DataStatistics.h
+++ b/Modules/Image/include/mirtk/DataStatistics.h
@@ -178,6 +178,47 @@ namespace statistic {
 
 
 // -----------------------------------------------------------------------------
+/// Get sum of values
+class Sum : public Statistic
+{
+public:
+
+  Sum(const char *desc = "Sum", const Array<string> *names = nullptr)
+  :
+    Statistic(1, desc, names)
+  {
+    if (!names) _Names[0] = "Sum";
+  }
+
+  template <class T>
+  static double Calculate(int n, const T *data, const bool *mask = nullptr)
+  {
+    double sum = 0.;
+    if (mask) {
+      for (int i = 0; i < n; ++i) {
+        if (mask[i]) {
+          sum += static_cast<double>(data[i]);
+        }
+      }
+    } else {
+      for (int i = 0; i < n; ++i) {
+        sum += static_cast<double>(data[i]);
+      }
+    }
+    return sum;
+  }
+
+  void Evaluate(Array<double> &values, int n, const double *data, const bool *mask = nullptr) const
+  {
+    values.resize(1);
+    values[0] = Calculate(n, data, mask);
+  }
+
+  // Add support for vtkDataArray argument
+  mirtkCalculateVtkDataArray1();
+};
+
+// -----------------------------------------------------------------------------
 /// Get minimum value
 class Min : public Statistic
 {

--- a/Modules/Image/include/mirtk/DataStatistics.h
+++ b/Modules/Image/include/mirtk/DataStatistics.h
@@ -109,15 +109,14 @@ public:
     if (data->GetDataType() == VTK_DOUBLE) {
       this->Process(n, reinterpret_cast<double *>(data->GetVoidPointer(0)), mask);
     } else {
-      double *d = new double[n];
-      double *tuple = d;
+      UniquePtr<double[]> _data(new double[n]);
+      double *tuple = _data.get();
       for (vtkIdType i = 0; i < data->GetNumberOfTuples(); ++i) {
         data->GetTuple(i, tuple);
         tuple += data->GetNumberOfComponents();
       }
-      this->Process(n, d, mask);
+      this->Process(n, _data.get(), mask);
       // Unlike base class, no need to copy data back to input array
-      delete[] d;
     }
   }
 


### PR DESCRIPTION
- Use smart pointers to avoid memory leaks.
- Fix `-mask` option arguments.
- Add `-sum` option.