### PR TITLE
enh: transform-image with composite transformation [Applications]

### DIFF
--- a/Modules/Transformation/include/mirtk/ImageTransformation.h
+++ b/Modules/Transformation/include/mirtk/ImageTransformation.h
@@ -47,6 +47,12 @@ public:
   /// Constructor
   ImageTransformationCache() : _Modified(true) {}
 
+  /// Constructor
+  explicit ImageTransformationCache(const ImageAttributes &attr)
+  :
+    RealImage(attr, 3), _Modified(true)
+  {}
+
   /// Destructor
   virtual ~ImageTransformationCache() {}
 };

--- a/Modules/Transformation/src/ImageTransformation.cc
+++ b/Modules/Transformation/src/ImageTransformation.cc
@@ -395,7 +395,7 @@ void ImageTransformation::Initialize()
     cerr << "ImageTransformation::Initialize: Filter has no output" << endl;
     exit(1);
   }
-  if (!_Transformation) {
+  if (!_Transformation && (!_Cache || _Cache->IsEmpty() || _Cache->Modified())) {
     cerr << "ImageTransformation::Initialize: Filter has no transformation" << endl;
     exit(1);
   }
@@ -414,7 +414,7 @@ void ImageTransformation::Initialize()
 
   _NumberOfSingularPoints = 0;
 
-  if (_Transformation->RequiresCachingOfDisplacements() && !_Cache) {
+  if (!_Cache && _Transformation->RequiresCachingOfDisplacements()) {
     _CacheOwner = true;
     _Cache      = new ImageTransformationCache();
     _Cache->Initialize(_Output->Attributes(), 3);


### PR DESCRIPTION
No need to compose transformations beforehand using `compose-dofs`. Instead, use `-dofin` or `-dofin_i/-invdof` options multiple times to compose the total transformation.