### PR TITLE
enh: Improvements and additional register options [Registration,Applications]

### DIFF
--- a/Applications/src/evaluate-similarity.cc
+++ b/Applications/src/evaluate-similarity.cc
@@ -252,8 +252,8 @@ int main(int argc, char **argv)
   InitializeIOLibrary();
 
   // Input and (transformed) image instances
-  GenericImage<double> target_image, source_image;
-  RegisteredImage      target,       source;
+  RegisteredImage::InputImageType target_image, source_image;
+  RegisteredImage target, source;
 
   target.InputImage(&target_image);
   source.InputImage(&source_image);

--- a/Applications/src/register.cc
+++ b/Applications/src/register.cc
@@ -990,6 +990,16 @@ int main(int argc, char **argv)
   // Set input images
   for (int n = 0; n < nimages; ++n) {
     images[n]->PutTOrigin(image_times[n]);
+    #if 1  // TODO: Fix the actual issue so this is not needed!
+      images[n]->PutAffineMatrix(images[n]->GetAffineMatrix(), true);
+      if (!images[n]->GetAffineMatrix().IsIdentity()) {
+        if (verbose > 0) cout << endl;
+        Warning("Input image has shearing component in affine matrix (NIfTI sform)!"
+                "\nThis may potentially result in a suboptimal output transformation!"
+                "\nConsider pre-transforming the image with the given affine transformation."
+                "\nThis issue has yet to be fixed properly within the Registration module.");
+      }
+    #endif
     registration.AddInput(images[n].get());
   }
 

--- a/Applications/src/register.cc
+++ b/Applications/src/register.cc
@@ -1081,26 +1081,21 @@ int main(int argc, char **argv)
     registration.Write(parout_name);
   }
 
+  const clock_t start_cpu_time = clock();
 #ifdef HAVE_TBB
-  tbb::tick_count start_time = tbb::tick_count::now();
-#else
-  clock_t start_time = clock();
+  tbb::tick_count start_wall_time = tbb::tick_count::now();
 #endif
 
   registration.Run();
 
   if (verbose) {
-    double elapsed_time;
-#ifdef HAVE_TBB
-    elapsed_time = (tbb::tick_count::now() - start_time).seconds();
-#else
-    elapsed_time = static_cast<double>(clock() - start_time)
-                 / static_cast<double>(CLOCKS_PER_SEC);
-#endif
-    int m = ifloor(elapsed_time / 60.0);
-    int s = iround(elapsed_time - m * 60);
-    if (s == 60) m += 1, s = 0;
-    cout << "\nFinished in " << m << " min " << s << " sec" << endl;
+    cout << "\n";
+    double sec = static_cast<double>(clock() - start_cpu_time) / static_cast<double>(CLOCKS_PER_SEC);
+    #ifdef HAVE_TBB
+      cout << "CPU time is " << ElapsedTimeToString(sec, TIME_IN_SECONDS, TIME_FORMAT_H_MIN_SEC, 2) << "\n";
+      sec = (tbb::tick_count::now() - start_wall_time).seconds();
+    #endif
+    cout << "Finished in " << ElapsedTimeToString(sec, TIME_IN_SECONDS, TIME_FORMAT_H_MIN_SEC, 2) << endl;
   }
 
   // Write final transformation

--- a/Applications/src/register.cc
+++ b/Applications/src/register.cc
@@ -87,6 +87,7 @@ void PrintUsage(const char* name)
   cout << "  -dof_i  <file>          Apply inverse of pre-computed affine transformation instead (cf. -dof).\n";
   cout << "  -mask   <file>          Reference mask which defines the domain within which to evaluate the\n";
   cout << "                          energy function (i.e. data fidelity terms). (default: none)\n";
+  cout << "  -reset-mask [yes|no]    Set value of all :option:`-mask` voxels to active (1). (default: no)\n";
   cout << "  -dofin  <file>          Initial transformation estimate. (default: align centroids)\n";
   cout << "  -par <name> <value>     Specify parameter value directly as command argument.\n";
   cout << "  -parin  <file>          Read parameters from configuration file. If \"stdin\" or \"cin\",\n";
@@ -657,6 +658,7 @@ int main(int argc, char **argv)
   const char *parin_name         = NULL;
   const char *parout_name        = NULL;
   const char *mask_name          = NULL;
+  bool        reset_mask         = false;
   ParameterList params;
 
   enum {
@@ -731,6 +733,7 @@ int main(int argc, char **argv)
     else if (OPTION("-dofin" )) dofin_name      = ARGUMENT;
     else if (OPTION("-dofout")) dofout_name     = ARGUMENT;
     else if (OPTION("-mask"))   mask_name       = ARGUMENT;
+    else HANDLE_BOOLEAN_OPTION("reset-mask", reset_mask);
     else if (OPTION("-nodebug-level-prefix")) {
       debug_output_level_prefix = false;
     }
@@ -1050,6 +1053,7 @@ int main(int argc, char **argv)
   UniquePtr<BinaryImage> mask;
   if (mask_name) {
     mask.reset(new BinaryImage(mask_name));
+    if (reset_mask) *mask = 1;
     registration.Domain(mask.get());
   }
 

--- a/Applications/src/resample-image.cc
+++ b/Applications/src/resample-image.cc
@@ -160,10 +160,10 @@ int main(int argc, char *argv[])
   double            interpolation_sigma = 1.0; // Interpolation_Gaussian parameter
   double            outside_value       = 0.0; // Extrapolation_Const parameter
   double            isotropic           = .0;
-  double            padding_value       = numeric_limits<double>::quiet_NaN();
-  double            dx                  = image->GetXSize();
-  double            dy                  = image->GetYSize();
-  double            dz                  = image->GetZSize();
+  double            padding_value       = NaN;
+  double            dx                  = image->XSize();
+  double            dy                  = image->YSize();
+  double            dz                  = image->ZSize();
 
   int nx, ny, nz;
   nx = ny = nz = 0;
@@ -202,14 +202,11 @@ int main(int argc, char *argv[])
     }
     else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
- 
-  if (!IsNaN(padding_value) && interpolation_mode != Interpolation_Linear) {
-    FatalError("Resampling with -padding always uses linear interpolation!");
-  }
 
   // Create interpolator
   UniquePtr<InterpolateImageFunction> interpolator;
   interpolator.reset(InterpolateImageFunction::New(interpolation_mode, extrapolation_mode, image.get()));
+  interpolator->DefaultValue(outside_value);
 
   // TODO: The actual type of the templated GenericGaussianInterpolateImageFunction's is not known.
   //       Add virtual parameter setters which take string arguments to InterpolateImageFunction.

--- a/Applications/src/transform-image.cc
+++ b/Applications/src/transform-image.cc
@@ -626,6 +626,9 @@ int main(int argc, char **argv)
     // Instantiate image interpolator
     UniquePtr<InterpolateImageFunction> interpolator;
     interpolator.reset(InterpolateImageFunction::New(interpolation));
+    if (!IsNaN(target_padding)) {
+      interpolator->DefaultValue(target_padding);
+    }
 
     // Initialize output image
     // Note: Always use floating point for intermediate interpolated image values!
@@ -677,6 +680,7 @@ int main(int argc, char **argv)
           ResamplingWithPadding<RealPixel> resampler(dx, dy, dz, target_padding);
           resampler.Input(target.get());
           resampler.Output(target.get());
+          resampler.Interpolator(interpolator.get());
           resampler.Run();
         }
       }
@@ -711,6 +715,8 @@ int main(int argc, char **argv)
     } else if (!target_name && srcdof_name) {
       target->PutAffineMatrix(source->GetAffineMatrix(), affdof_apply);
     }
+
+    interpolator->DefaultValue(source_padding);
 
     if (dofs.size() == 1) {
 

--- a/Modules/Common/include/mirtk/Event.h
+++ b/Modules/Common/include/mirtk/Event.h
@@ -153,12 +153,14 @@ struct LineSearchStep
   double      _MaxLength;   ///< Maximum allowed step length
   double      _Unit;        ///< Step length unit
   double      _Delta;       ///< Maximum change of parameters (DoFs)
+  double      _TotalDelta;  ///< Accumulated change of parameters (DoFs)
 
   LineSearchStep()
   :
     _Info(NULL), _Direction(NULL),
     _Current(.0), _Value(.0), _Length(.0), _TotalLength(.0),
-    _MinLength(.0), _MaxLength(.0), _Unit(.0), _Delta(.0)
+    _MinLength(.0), _MaxLength(.0), _Unit(.0),
+    _Delta(.0), _TotalDelta(.0)
   {}
 };
 

--- a/Modules/Common/include/mirtk/Math.h
+++ b/Modules/Common/include/mirtk/Math.h
@@ -112,9 +112,25 @@ MIRTKCU_API inline bool IsInf(double x)
 
 // -----------------------------------------------------------------------------
 /// Determine equality of two floating point numbers
-MIRTKCU_API inline bool fequal(double a, double b, double tol = 1e-12)
+MIRTKCU_API inline bool AreEqual(double a, double b, double tol = 1e-12)
 {
   return abs(a - b) < tol;
+}
+
+// -----------------------------------------------------------------------------
+/// Determine equality of two floating point numbers including check if both are NaN
+MIRTKCU_API inline bool AreEqualOrNaN(double a, double b, double tol = 1e-12)
+{
+  if (IsNaN(a)) return IsNaN(b);
+  if (IsNaN(b)) return IsNaN(a);
+  return AreEqual(a, b, tol);
+}
+
+// -----------------------------------------------------------------------------
+/// \deprecated Use AreEqual instead.
+MIRTKCU_API inline bool fequal(double a, double b, double tol = 1e-12)
+{
+  return AreEqual(a, b, tol);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Common/include/mirtk/Profiling.h
+++ b/Modules/Common/include/mirtk/Profiling.h
@@ -23,6 +23,7 @@
 #include "mirtk/CommonExport.h"
 
 #include "mirtk/Stream.h"
+#include "mirtk/String.h"
 
 #include <ctime>
 #ifdef HAVE_TBB
@@ -43,7 +44,20 @@ namespace mirtk {
 
 
 // -----------------------------------------------------------------------------
-enum TimeUnit {TIME_IN_DEFAULT_UNIT, TIME_IN_MILLISECONDS, TIME_IN_SECONDS};
+enum TimeUnit
+{
+  TIME_IN_DEFAULT_UNIT,
+  TIME_IN_MILLISECONDS,
+  TIME_IN_SECONDS
+};
+
+enum TimeFormat
+{
+  TIME_FORMAT_UNITS,       ///< Print elapsed time using time units
+  TIME_FORMAT_HHMMSS,      ///< Print elapsed time with format "HH:MM:SS"
+  TIME_FORMAT_H_MIN_SEC,   ///< Print elapsed time with format "[H h] [M min] [S sec]"
+  TIME_FORMAT_MIN_SEC      ///< Print elapsed time with format "[M min] [S sec]"
+};
 
 // =============================================================================
 // Global profiling options
@@ -78,9 +92,20 @@ void PrintProfilingOptions(ostream &);
 // CPU Profiling
 // =============================================================================
 
-// -----------------------------------------------------------------------------
-/// Print elapsed time for given section
+/// Print elapsed time for profiled section
 void PrintElapsedTime(const char *, double, TimeUnit = TIME_IN_SECONDS);
+
+/// Convert elapsed time given in the specified units to string of given format
+///
+/// \param[in] t      Elapsed time in specified \p units.
+/// \param[in] units  Units of time measurement.
+/// \param[in] fmt    Time string format.
+/// \param[in] w      Width of time field when \p fmt is not TIME_FORMAT_HHMMSS.
+/// \param[in] c      Character used to fill time field.
+/// \param[in] left   Whether to print time value left justified.
+string ElapsedTimeToString(double t, TimeUnit units = TIME_IN_SECONDS,
+                           TimeFormat fmt = TIME_FORMAT_HHMMSS,
+                           int w = 0, char c = ' ', bool left = false);
 
 // -----------------------------------------------------------------------------
 /// Start measurement of execution time of current code block

--- a/Modules/Common/include/mirtk/Queue.h
+++ b/Modules/Common/include/mirtk/Queue.h
@@ -21,12 +21,16 @@
 #define MIRTK_Queue_H
 
 #include <queue>
+#include <deque>
 
 namespace mirtk {
 
 
 template <class T>
 using Queue = std::queue<T>;
+
+template <class T>
+using Deque = std::deque<T>;
 
 
 } // namespace mirtk

--- a/Modules/Common/include/mirtk/String.h
+++ b/Modules/Common/include/mirtk/String.h
@@ -221,19 +221,37 @@ inline string ToString(const bool &value, int w, char c, bool left)
 }
 
 /// Write "<name> = <value>" configuration entry to output stream
-template <class TValue>
-inline void PrintParameter(std::ostream &os, const char *name, const TValue &value)
+inline void PrintParameter(std::ostream &os, const char *name, const char *value)
 {
   const std::streamsize w = os.width(40);
-  os << std::left << name << std::setw(0) << " = " << ToString(value) << std::endl;
+  os << std::left << name << std::setw(0) << " = " << value << "\n";
   os.width(w);
 }
 
 /// Write "<name> = <value>" configuration entry to output stream
-template <class TValue>
-inline void PrintParameter(std::ostream &os, const std::string &name, const TValue &value)
+inline void PrintParameter(std::ostream &os, const char *name, const string &value)
 {
-  PrintParameter(os, name.c_str(), value);
+  PrintParameter(os, name, value.c_str());
+}
+
+/// Write "<name> = <value>" configuration entry to output stream
+inline void PrintParameter(std::ostream &os, const string &name, const string &value)
+{
+  PrintParameter(os, name.c_str(), value.c_str());
+}
+
+/// Write "<name> = <value>" configuration entry to output stream
+template <class TValue>
+inline void PrintParameter(std::ostream &os, const char *name, const TValue &value)
+{
+  PrintParameter(os, name, ToString(value));
+}
+
+/// Write "<name> = <value>" configuration entry to output stream
+template <class TValue>
+inline void PrintParameter(std::ostream &os, const string &name, const TValue &value)
+{
+  PrintParameter(os, name, ToString(value));
 }
 
 /// Print single argument to output stream

--- a/Modules/Common/src/Profiling.cc
+++ b/Modules/Common/src/Profiling.cc
@@ -21,6 +21,7 @@
 
 #include "mirtk/Options.h"
 #include "mirtk/Stream.h"
+#include "mirtk/Math.h"
 
 
 namespace mirtk {
@@ -114,11 +115,62 @@ void PrintElapsedTime(const char *section, double t, TimeUnit unit)
     }
     unit = debug_time_unit;
   }
-  if      (unit == TIME_IN_MILLISECONDS) snprintf(unit_buffer, 6, "msecs");
-  else if (unit == TIME_IN_SECONDS)      snprintf(unit_buffer, 6, "secs");
+  if      (unit == TIME_IN_MILLISECONDS) snprintf(unit_buffer, 6, "msec");
+  else if (unit == TIME_IN_SECONDS)      snprintf(unit_buffer, 6, "sec");
   else                                   snprintf(unit_buffer, 6, "undef");
   printf("Time for %-*s %10.3f %s\n", section_width, section_buffer, t, unit_buffer);
   fflush(stdout);
+}
+
+// -----------------------------------------------------------------------------
+string ElapsedTimeToString(double t, TimeUnit unit, TimeFormat fmt, int w, char c, bool left)
+{
+  string str;
+  if (fmt == TIME_FORMAT_UNITS) {
+    if (unit == TIME_IN_DEFAULT_UNIT) {
+      if (debug_time_unit == TIME_IN_MILLISECONDS) {
+        if (unit == TIME_IN_SECONDS)      t *= 1.e+3;
+      } else if (debug_time_unit == TIME_IN_SECONDS) {
+        if (unit == TIME_IN_MILLISECONDS) t *= 1.e-3;
+      }
+      unit = debug_time_unit;
+    }
+    str = ToString(t, w, c, left);
+    if      (unit == TIME_IN_MILLISECONDS) str += " msec";
+    else if (unit == TIME_IN_SECONDS)      str += " sec";
+    else                                   str += " undef";
+  } else {
+    int h, m, s;
+    if (unit == TIME_IN_DEFAULT_UNIT) unit = debug_time_unit;
+    if (unit == TIME_IN_MILLISECONDS) t *= 1.e-3;
+    s = iround(t);
+    m = s / 60;
+    s = s % 60;
+    if (fmt == TIME_FORMAT_MIN_SEC) {
+      str  = ToString(m, w, c, left);
+      str += " min ";
+      str += ToString(s, w, c, left);
+      str += " sec";
+    } else {
+      h = m / 60;
+      m = m % 60;
+      if (fmt == TIME_FORMAT_H_MIN_SEC) {
+        str  = ToString(h, w, c, left);
+        str += " h ";
+        str += ToString(m, w, c, left);
+        str += " min ";
+        str += ToString(s, w, c, left);
+        str += " sec";
+      } else {
+        str  = ToString(h, 2, '0');
+        str += ":";
+        str += ToString(m, 2, '0');
+        str += ":";
+        str += ToString(s, 2, '0');
+      }
+    }
+  }
+  return str;
 }
 
 

--- a/Modules/Image/include/mirtk/BSplineInterpolateImageFunction.hxx
+++ b/Modules/Image/include/mirtk/BSplineInterpolateImageFunction.hxx
@@ -210,8 +210,8 @@ GenericBSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (bgw > fgw) {
-    val  = voxel_cast<RealType>(this->DefaultValue());
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    val = voxel_cast<RealType>(this->DefaultValue());
   }
   return voxel_cast<VoxelType>(val);
 }
@@ -278,8 +278,8 @@ typename TCoefficient::VoxelType GenericBSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (bgw > fgw) {
-    val  = voxel_cast<RealType>(this->DefaultValue());
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    val = voxel_cast<RealType>(this->DefaultValue());
   }
   return voxel_cast<VoxelType>(val);
 }
@@ -364,8 +364,8 @@ GenericBSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (bgw > fgw) {
-    val  = voxel_cast<RealType>(this->DefaultValue());
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    val = voxel_cast<RealType>(this->DefaultValue());
   }
   return voxel_cast<VoxelType>(val);
 }
@@ -437,8 +437,8 @@ typename TCoefficient::VoxelType GenericBSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (bgw > fgw) {
-    val  = voxel_cast<RealType>(this->DefaultValue());
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    val = voxel_cast<RealType>(this->DefaultValue());
   }
   return voxel_cast<typename TCoefficient::VoxelType>(val);
 }
@@ -520,8 +520,8 @@ GenericBSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (bgw > fgw) {
-    val  = voxel_cast<RealType>(this->DefaultValue());
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    val = voxel_cast<RealType>(this->DefaultValue());
   }
   return voxel_cast<VoxelType>(val);
 }
@@ -596,8 +596,8 @@ typename TCoefficient::VoxelType GenericBSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (bgw > fgw) {
-    val  = voxel_cast<RealType>(this->DefaultValue());
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    val = voxel_cast<RealType>(this->DefaultValue());
   }
   return voxel_cast<VoxelType>(val);
 }

--- a/Modules/Image/include/mirtk/CSplineInterpolateImageFunction.hxx
+++ b/Modules/Image/include/mirtk/CSplineInterpolateImageFunction.hxx
@@ -141,8 +141,8 @@ GenericCSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (nrm) val /= nrm;
-  else     val  = voxel_cast<RealType>(this->DefaultValue());
+  if (nrm > 1e-3) val /= nrm;
+  else val = voxel_cast<RealType>(this->DefaultValue());
 
   return voxel_cast<VoxelType>(val);
 }
@@ -184,10 +184,10 @@ GenericCSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (fgw > bgw) val /= fgw;
-  else           val  = voxel_cast<RealType>(this->DefaultValue());
-
-  return voxel_cast<VoxelType>(val);
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    return voxel_cast<VoxelType>(this->DefaultValue());
+  }
+  return voxel_cast<VoxelType>(val / fgw);
 }
 
 // -----------------------------------------------------------------------------
@@ -221,8 +221,8 @@ GenericCSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (nrm) val /= nrm;
-  else     val  = voxel_cast<RealType>(this->DefaultValue());
+  if (nrm > 1e-3) val /= nrm;
+  else val = voxel_cast<RealType>(this->DefaultValue());
 
   return voxel_cast<VoxelType>(val);
 }
@@ -262,10 +262,10 @@ GenericCSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (fgw > bgw) val /= fgw;
-  else           val  = voxel_cast<RealType>(this->DefaultValue());
-
-  return voxel_cast<VoxelType>(val);
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    return voxel_cast<VoxelType>(this->DefaultValue());
+  }
+  return voxel_cast<VoxelType>(val / fgw);
 }
 
 // -----------------------------------------------------------------------------
@@ -311,8 +311,8 @@ GenericCSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (nrm) val /= nrm;
-  else     val  = voxel_cast<RealType>(this->DefaultValue());
+  if (nrm > 1e-3) val /= nrm;
+  else val = voxel_cast<RealType>(this->DefaultValue());
 
   return voxel_cast<VoxelType>(val);
 }
@@ -358,10 +358,10 @@ GenericCSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (fgw > bgw) val /= fgw;
-  else           val  = voxel_cast<RealType>(this->DefaultValue());
-
-  return voxel_cast<VoxelType>(val);
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    return voxel_cast<VoxelType>(this->DefaultValue());
+  }
+  return voxel_cast<VoxelType>(val / fgw);
 }
 
 // -----------------------------------------------------------------------------
@@ -400,8 +400,8 @@ GenericCSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (nrm) val /= nrm;
-  else     val  = voxel_cast<RealType>(this->DefaultValue());
+  if (nrm > 1e-3) val /= nrm;
+  else val = voxel_cast<RealType>(this->DefaultValue());
 
   return voxel_cast<VoxelType>(val);
 }
@@ -446,10 +446,10 @@ GenericCSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (fgw > bgw) val /= fgw;
-  else           val  = voxel_cast<RealType>(this->DefaultValue());
-
-  return voxel_cast<VoxelType>(val);
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    return voxel_cast<VoxelType>(this->DefaultValue());
+  }
+  return voxel_cast<VoxelType>(val / fgw);
 }
 
 // -----------------------------------------------------------------------------
@@ -498,8 +498,8 @@ GenericCSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (nrm) val /= nrm;
-  else     val  = voxel_cast<RealType>(this->DefaultValue());
+  if (nrm > 1e-3) val /= nrm;
+  else val = voxel_cast<RealType>(this->DefaultValue());
 
   return voxel_cast<VoxelType>(val);
 }
@@ -546,10 +546,10 @@ GenericCSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (fgw > bgw) val /= fgw;
-  else           val  = voxel_cast<RealType>(this->DefaultValue());
-
-  return voxel_cast<VoxelType>(val);
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    return voxel_cast<VoxelType>(this->DefaultValue());
+  }
+  return voxel_cast<VoxelType>(val / fgw);
 }
 
 // -----------------------------------------------------------------------------
@@ -593,8 +593,8 @@ GenericCSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (nrm) val /= nrm;
-  else     val  = voxel_cast<RealType>(this->DefaultValue());
+  if (nrm > 1e-3) val /= nrm;
+  else val = voxel_cast<RealType>(this->DefaultValue());
 
   return voxel_cast<VoxelType>(val);
 }
@@ -644,10 +644,10 @@ GenericCSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (fgw > bgw) val /= fgw;
-  else           val  = voxel_cast<RealType>(this->DefaultValue());
-
-  return voxel_cast<VoxelType>(val);
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    return voxel_cast<VoxelType>(this->DefaultValue());
+  }
+  return voxel_cast<VoxelType>(val / fgw);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Image/include/mirtk/ConvolutionFunction.h
+++ b/Modules/Image/include/mirtk/ConvolutionFunction.h
@@ -617,16 +617,21 @@ protected:
   /// Constructor
   TruncatedForegroundConvolution1D(const BaseImage *image, const TKernel *kernel, int size, bool norm = true)
   :
-    _Kernel(kernel), _Size(size), _Radius((size - 1) / 2), _Normalize(norm),
-    _Background(image->GetBackgroundValueAsDouble())
-  {}
+    _Kernel(kernel), _Size(size), _Radius((size - 1) / 2), _Normalize(norm)
+  {
+    if (image->HasBackgroundValue()) {
+      _Background = image->GetBackgroundValueAsDouble();
+    } else {
+      _Background = NaN;
+    }
+  }
 
   // ---------------------------------------------------------------------------
   /// Apply kernel initially at center voxel
   template <class T>
   bool ConvolveCenterVoxel(const T *in, double &acc, double &sum) const
   {
-    if (*in == _Background) {
+    if (AreEqualOrNaN(static_cast<double>(*in), _Background, 1e-6)) {
       acc = _Background;
       sum = .0;
       return false;
@@ -648,7 +653,7 @@ protected:
       i  += di;
       in -= s;
       // Stop if outside image/foreground
-      if (i < 0 || i >= n || *in == _Background) break;
+      if (i < 0 || i >= n || AreEqualOrNaN(static_cast<double>(*in), _Background, 1e-6)) break;
       // Multiply with kernel weight
       acc += static_cast<double>(_Kernel[k]) * static_cast<double>(*in);
       sum += static_cast<double>(_Kernel[k]);
@@ -666,7 +671,7 @@ protected:
       i  += di;
       in += s;
       // Stop if outside image/foreground
-      if (i < 0 || i >= n || *in == _Background) break;
+      if (i < 0 || i >= n || AreEqualOrNaN(static_cast<double>(*in), _Background, 1e-6)) break;
       // Multiply with kernel weight
       acc += static_cast<double>(_Kernel[k]) * static_cast<double>(*in);
       sum += static_cast<double>(_Kernel[k]);
@@ -890,14 +895,20 @@ protected:
   :
     _Kernel(kernel), _Size(size), _Radius((size - 1) / 2), _Norm(norm),
     _Background(image->GetBackgroundValueAsDouble())
-  {}
+  {
+    if (image->HasBackgroundValue()) {
+      _Background = image->GetBackgroundValueAsDouble();
+    } else {
+      _Background = NaN;
+    }
+  }
 
   // ---------------------------------------------------------------------------
   /// Apply kernel initially at center voxel
   template <class T>
   bool ConvolveCenterVoxel(const T *in, double &acc) const
   {
-    if (*in == _Background) {
+    if (AreEqualOrNaN(static_cast<double>(*in), _Background, 1e-6)) {
       acc = _Background / _Norm;
       return false;
     } else {
@@ -917,7 +928,7 @@ protected:
       i  += di;
       in -= s;
       // Reverse if outside image/foreground
-      if (i < 0 || i >= n || *in == _Background) {
+      if (i < 0 || i >= n || AreEqualOrNaN(static_cast<double>(*in), _Background, 1e-6)) {
         di  = -di;
         s   = -s;
         i  += di;
@@ -939,7 +950,7 @@ protected:
       i  += di;
       in += s;
       // Reverse if outside image/foreground
-      if (i < 0 || i >= n || *in == _Background) {
+      if (i < 0 || i >= n || AreEqualOrNaN(static_cast<double>(*in), _Background, 1e-6)) {
         di  = -di;
         s   = -s;
         i  += di;
@@ -1114,16 +1125,21 @@ protected:
   /// Constructor
   ExtendedForegroundConvolution1D(const BaseImage *image, const TKernel *kernel, int size, double norm = 1.0)
   :
-    _Kernel(kernel), _Size(size), _Radius((size - 1) / 2), _Norm(norm),
-    _Background(image->GetBackgroundValueAsDouble())
-  {}
+    _Kernel(kernel), _Size(size), _Radius((size - 1) / 2), _Norm(norm)
+  {
+    if (image->HasBackgroundValue()) {
+      _Background = image->GetBackgroundValueAsDouble();
+    } else {
+      _Background = NaN;
+    }
+  }
 
   // ---------------------------------------------------------------------------
   /// Apply kernel initially at center voxel
   template <class T>
   bool ConvolveCenterVoxel(const T *in, double &acc) const
   {
-    if (*in == _Background) {
+    if (AreEqualOrNaN(static_cast<double>(*in), _Background, 1e-6)) {
       acc = _Background / _Norm;
       return false;
     } else {
@@ -1141,7 +1157,7 @@ protected:
     for (int k = _Radius + 1; k < _Size; ++k) {
       i  -= di;
       in -= s;
-      if (i < 0 || *in == _Background) {
+      if (i < 0 || AreEqualOrNaN(static_cast<double>(*in), _Background, 1e-6)) {
         i  += di;
         in += s;
         di = s = 0;
@@ -1160,7 +1176,7 @@ protected:
     for (int k = _Radius - 1; k >= 0; --k) {
       i  += di;
       in += s;
-      if (n <= i || *in == _Background) {
+      if (n <= i || AreEqualOrNaN(static_cast<double>(*in), _Background, 1e-6)) {
         i  -= di;
         in -= s;
         di = s = 0;

--- a/Modules/Image/include/mirtk/ConvolutionFunction.h
+++ b/Modules/Image/include/mirtk/ConvolutionFunction.h
@@ -32,6 +32,13 @@ namespace mirtk {
 namespace ConvolutionFunction {
 
 
+/// Tolerance used for floating point comparisons
+inline double Epsilon()
+{
+  return 1e-6;
+}
+
+
 // =============================================================================
 // Boundary conditions for image domain
 // =============================================================================
@@ -112,7 +119,7 @@ struct ConvolveInX : public VoxelFunction
       ++i, ++in, --n;
     }
     // Output result of convolution
-    if (_Normalize && sum != .0) acc /= sum;
+    if (_Normalize && !AreEqual(sum, 0., Epsilon())) acc /= sum;
     *out = static_cast<T2>(acc);
   }
 };
@@ -154,7 +161,7 @@ struct ConvolveInY : public VoxelFunction
       ++j, in += _X, --n;
     }
     // Output result of convolution
-    if (_Normalize && sum != .0) acc /= sum;
+    if (_Normalize && !AreEqual(sum, 0., Epsilon())) acc /= sum;
     *out = static_cast<T2>(acc);
   }
 };
@@ -196,7 +203,7 @@ struct ConvolveInZ : public VoxelFunction
       ++k, in += _XY, --n;
     }
     // Output result of convolution
-    if (_Normalize && sum != .0) acc /= sum;
+    if (_Normalize && !AreEqual(sum, 0., Epsilon())) acc /= sum;
     *out = static_cast<T2>(acc);
   }
 };
@@ -235,7 +242,7 @@ struct ConvolveInT : public VoxelFunction
       ++l, in += _XYZ, --n;
     }
     // Output result of convolution
-    if (_Normalize && sum != .0) acc /= sum;
+    if (_Normalize && !AreEqual(sum, 0., Epsilon())) acc /= sum;
     *out = static_cast<T2>(acc);
   }
 };
@@ -283,7 +290,7 @@ struct ConvolveForegroundInX : public VoxelFunction
       ++i, ++in, --n;
     }
     // Output result of convolution
-    if (_Normalize && sum != .0) acc /= sum;
+    if (_Normalize && !AreEqual(sum, 0., Epsilon())) acc /= sum;
     *out = static_cast<T2>(acc);
   }
 };
@@ -328,7 +335,7 @@ struct ConvolveForegroundInY : public VoxelFunction
       ++j, in += _X, --n;
     }
     // Output result of convolution
-    if (_Normalize && sum != .0) acc /= sum;
+    if (_Normalize && !AreEqual(sum, 0., Epsilon())) acc /= sum;
     *out = static_cast<T2>(acc);
   }
 };
@@ -373,7 +380,7 @@ struct ConvolveForegroundInZ : public VoxelFunction
       ++k, in += _XY, --n;
     }
     // Output result of convolution
-    if (_Normalize && sum != .0) acc /= sum;
+    if (_Normalize && !AreEqual(sum, 0., Epsilon())) acc /= sum;
     *out = static_cast<T2>(acc);
   }
 };
@@ -415,7 +422,7 @@ struct ConvolveForegroundInT : public VoxelFunction
       ++l, in += _XYZ, --n;
     }
     // Output result of convolution
-    if (_Normalize && sum != .0) acc /= sum;
+    if (_Normalize && !AreEqual(sum, 0., Epsilon())) acc /= sum;
     *out = static_cast<T2>(acc);
   }
 };
@@ -465,7 +472,7 @@ struct ConvolveWeightedImageInX : public VoxelFunction
       ++i, ++in, ++win, --n;
     }
     // Output result of convolution
-    acc = (sum > .0 ? acc / sum : .0);
+    acc = (sum > Epsilon() ? acc / sum : 0.);
     *out = static_cast<T3>(acc);
   }
 };
@@ -511,7 +518,7 @@ struct ConvolveWeightedImageInY : public VoxelFunction
       ++j, in += _X, win += _X, --n;
     }
     // Output result of convolution
-    acc = (sum > .0 ? acc / sum : .0);
+    acc = (sum > Epsilon() ? acc / sum : 0.);
     *out = static_cast<T3>(acc);
   }
 };
@@ -557,7 +564,7 @@ struct ConvolveWeightedImageInZ : public VoxelFunction
       ++k, in += _XY, win += _XY, --n;
     }
     // Output result of convolution
-    acc = (sum > .0 ? acc / sum : .0);
+    acc = (sum > Epsilon() ? acc / sum : 0.);
     *out = static_cast<T3>(acc);
   }
 };
@@ -597,7 +604,7 @@ struct ConvolveWeightedImageInT : public VoxelFunction
       ++l, in += _XYZ, win += _XYZ, --n;
     }
     // Output result of convolution
-    acc = (sum > .0 ? acc / sum : .0);
+    acc = (sum > Epsilon() ? acc / sum : 0.);
     *out = static_cast<T3>(acc);
   }
 };
@@ -631,7 +638,7 @@ protected:
   template <class T>
   bool ConvolveCenterVoxel(const T *in, double &acc, double &sum) const
   {
-    if (AreEqualOrNaN(static_cast<double>(*in), _Background, 1e-6)) {
+    if (AreEqualOrNaN(static_cast<double>(*in), _Background, Epsilon())) {
       acc = _Background;
       sum = .0;
       return false;
@@ -653,7 +660,7 @@ protected:
       i  += di;
       in -= s;
       // Stop if outside image/foreground
-      if (i < 0 || i >= n || AreEqualOrNaN(static_cast<double>(*in), _Background, 1e-6)) break;
+      if (i < 0 || i >= n || AreEqualOrNaN(static_cast<double>(*in), _Background, Epsilon())) break;
       // Multiply with kernel weight
       acc += static_cast<double>(_Kernel[k]) * static_cast<double>(*in);
       sum += static_cast<double>(_Kernel[k]);
@@ -671,7 +678,7 @@ protected:
       i  += di;
       in += s;
       // Stop if outside image/foreground
-      if (i < 0 || i >= n || AreEqualOrNaN(static_cast<double>(*in), _Background, 1e-6)) break;
+      if (i < 0 || i >= n || AreEqualOrNaN(static_cast<double>(*in), _Background, Epsilon())) break;
       // Multiply with kernel weight
       acc += static_cast<double>(_Kernel[k]) * static_cast<double>(*in);
       sum += static_cast<double>(_Kernel[k]);
@@ -682,7 +689,7 @@ protected:
   template <class T>
   void Put(T *out, double acc, double sum) const
   {
-    if (_Normalize && sum != .0) acc /= sum;
+    if (_Normalize && !AreEqual(sum, 0., Epsilon())) acc /= sum;
     (*out) = static_cast<T>(acc);
   }
 
@@ -706,21 +713,21 @@ struct ConvolveTruncatedForegroundInX : public TruncatedForegroundConvolution1D<
   ConvolveTruncatedForegroundInX(const BaseImage *image, const TKernel *kernel, int size, bool norm = true, int l = 0)
   :
     TruncatedForegroundConvolution1D<TKernel>(image, kernel, size, norm),
-    _Offset(l * image->NumberOfSpatialVoxels()), _X(image->GetX())
+    _Offset(l * image->NumberOfSpatialVoxels()), _X(image->X())
   {}
 
   ConvolveTruncatedForegroundInX(const BaseImage *image, double bg, const TKernel *kernel, int size, bool norm = true, int l = 0)
   :
     TruncatedForegroundConvolution1D<TKernel>(image, kernel, size, norm),
-    _Offset(l * image->NumberOfSpatialVoxels()), _X(image->GetX())
+    _Offset(l * image->NumberOfSpatialVoxels()), _X(image->X())
   {
     this->_Background = bg;
   }
 
   ConvolveTruncatedForegroundInX(const BaseImage *image, const GenericImage<TKernel> *kernel, bool norm = true, int l = 0)
   :
-    TruncatedForegroundConvolution1D<TKernel>(image, kernel->GetPointerToVoxels(), kernel->GetNumberOfVoxels(), norm),
-    _Offset(l * image->NumberOfSpatialVoxels()), _X(image->GetX())
+    TruncatedForegroundConvolution1D<TKernel>(image, kernel->Data(), kernel->NumberOfVoxels(), norm),
+    _Offset(l * image->NumberOfSpatialVoxels()), _X(image->X())
   {}
 
   template <class T1, class T2>
@@ -748,26 +755,26 @@ struct ConvolveTruncatedForegroundInY : public TruncatedForegroundConvolution1D<
   :
     TruncatedForegroundConvolution1D<TKernel>(image, kernel, size, norm),
     _Offset(l * image->NumberOfSpatialVoxels()),
-    _X(image->GetX()),
-    _Y(image->GetY())
+    _X(image->X()),
+    _Y(image->Y())
   {}
 
   ConvolveTruncatedForegroundInY(const BaseImage *image, double bg, const TKernel *kernel, int size, bool norm = true, int l = 0)
   :
     TruncatedForegroundConvolution1D<TKernel>(image, kernel, size, norm),
     _Offset(l * image->NumberOfSpatialVoxels()),
-    _X(image->GetX()),
-    _Y(image->GetY())
+    _X(image->X()),
+    _Y(image->Y())
   {
     this->_Background = bg;
   }
 
   ConvolveTruncatedForegroundInY(const BaseImage *image, const GenericImage<TKernel> *kernel, bool norm = true, int l = 0)
   :
-    TruncatedForegroundConvolution1D<TKernel>(image, kernel->GetPointerToVoxels(), kernel->GetNumberOfVoxels(), norm),
+    TruncatedForegroundConvolution1D<TKernel>(image, kernel->Data(), kernel->NumberOfVoxels(), norm),
     _Offset(l * image->NumberOfSpatialVoxels()),
-    _X(image->GetX()),
-    _Y(image->GetY())
+    _X(image->X()),
+    _Y(image->Y())
   {}
 
   template <class T1, class T2>
@@ -796,26 +803,26 @@ struct ConvolveTruncatedForegroundInZ : public TruncatedForegroundConvolution1D<
   :
     TruncatedForegroundConvolution1D<TKernel>(image, kernel, size, norm),
     _Offset(l * image->NumberOfSpatialVoxels()),
-    _XY(image->GetX() * image->GetY()),
-    _Z (image->GetZ())
+    _XY(image->X() * image->Y()),
+    _Z (image->Z())
   {}
 
   ConvolveTruncatedForegroundInZ(const BaseImage *image, double bg, const TKernel *kernel, int size, bool norm = true, int l = 0)
   :
     TruncatedForegroundConvolution1D<TKernel>(image, kernel, size, norm),
     _Offset(l * image->NumberOfSpatialVoxels()),
-    _XY(image->GetX() * image->GetY()),
-    _Z (image->GetZ())
+    _XY(image->X() * image->Y()),
+    _Z (image->Z())
   {
     this->_Background = bg;
   }
 
   ConvolveTruncatedForegroundInZ(const BaseImage *image, const GenericImage<TKernel> *kernel, bool norm = true, int l = 0)
   :
-    TruncatedForegroundConvolution1D<TKernel>(image, kernel->GetPointerToVoxels(), kernel->GetNumberOfVoxels(), norm),
+    TruncatedForegroundConvolution1D<TKernel>(image, kernel->Data(), kernel->NumberOfVoxels(), norm),
     _Offset(l * image->NumberOfSpatialVoxels()),
-    _XY(image->GetX() * image->GetY()),
-    _Z (image->GetZ())
+    _XY(image->X() * image->Y()),
+    _Z (image->Z())
   {}
 
   template <class T1, class T2>
@@ -843,24 +850,24 @@ struct ConvolveTruncatedForegroundInT : public TruncatedForegroundConvolution1D<
   ConvolveTruncatedForegroundInT(const BaseImage *image, const TKernel *kernel, int size, bool norm = true)
   :
     TruncatedForegroundConvolution1D<TKernel>(image, kernel, size, norm),
-    _XYZ(image->GetX() * image->GetY() * image->GetZ()),
-    _T  (image->GetT())
+    _XYZ(image->X() * image->Y() * image->Z()),
+    _T  (image->T())
   {}
 
   ConvolveTruncatedForegroundInT(const BaseImage *image, double bg, const TKernel *kernel, int size, bool norm = true)
   :
     TruncatedForegroundConvolution1D<TKernel>(image, kernel, size, norm),
-    _XYZ(image->GetX() * image->GetY() * image->GetZ()),
-    _T  (image->GetT())
+    _XYZ(image->X() * image->Y() * image->Z()),
+    _T  (image->T())
   {
     this->_Background = bg;
   }
 
   ConvolveTruncatedForegroundInT(const BaseImage *image, const GenericImage<TKernel> *kernel, bool norm = true)
   :
-    TruncatedForegroundConvolution1D<TKernel>(image, kernel->GetPointerToVoxels(), kernel->GetNumberOfVoxels(), norm),
-    _XYZ(image->GetX() * image->GetY() * image->GetZ()),
-    _T  (image->GetT())
+    TruncatedForegroundConvolution1D<TKernel>(image, kernel->Data(), kernel->NumberOfVoxels(), norm),
+    _XYZ(image->X() * image->Y() * image->Z()),
+    _T  (image->T())
   {}
 
   template <class T1, class T2>
@@ -893,8 +900,7 @@ protected:
   /// Constructor
   MirroredForegroundConvolution1D(const BaseImage *image, const TKernel *kernel, int size, double norm = 1.0)
   :
-    _Kernel(kernel), _Size(size), _Radius((size - 1) / 2), _Norm(norm),
-    _Background(image->GetBackgroundValueAsDouble())
+    _Kernel(kernel), _Size(size), _Radius((size - 1) / 2), _Norm(norm)
   {
     if (image->HasBackgroundValue()) {
       _Background = image->GetBackgroundValueAsDouble();
@@ -908,7 +914,7 @@ protected:
   template <class T>
   bool ConvolveCenterVoxel(const T *in, double &acc) const
   {
-    if (AreEqualOrNaN(static_cast<double>(*in), _Background, 1e-6)) {
+    if (AreEqualOrNaN(static_cast<double>(*in), _Background, Epsilon())) {
       acc = _Background / _Norm;
       return false;
     } else {
@@ -928,7 +934,7 @@ protected:
       i  += di;
       in -= s;
       // Reverse if outside image/foreground
-      if (i < 0 || i >= n || AreEqualOrNaN(static_cast<double>(*in), _Background, 1e-6)) {
+      if (i < 0 || i >= n || AreEqualOrNaN(static_cast<double>(*in), _Background, Epsilon())) {
         di  = -di;
         s   = -s;
         i  += di;
@@ -950,7 +956,7 @@ protected:
       i  += di;
       in += s;
       // Reverse if outside image/foreground
-      if (i < 0 || i >= n || AreEqualOrNaN(static_cast<double>(*in), _Background, 1e-6)) {
+      if (i < 0 || i >= n || AreEqualOrNaN(static_cast<double>(*in), _Background, Epsilon())) {
         di  = -di;
         s   = -s;
         i  += di;
@@ -986,12 +992,12 @@ template <class TKernel = double>
 struct ConvolveMirroredForegroundInX : public MirroredForegroundConvolution1D<TKernel>
 {
   ConvolveMirroredForegroundInX(const BaseImage *image, const TKernel *kernel, int size, double norm = 1.0)
-    : MirroredForegroundConvolution1D<TKernel>(image, kernel, size, norm), _X(image->GetX()) {}
+    : MirroredForegroundConvolution1D<TKernel>(image, kernel, size, norm), _X(image->X()) {}
 
   ConvolveMirroredForegroundInX(const BaseImage *image, const GenericImage<TKernel> *kernel, double norm = 1.0)
   :
-    MirroredForegroundConvolution1D<TKernel>(image, kernel->GetPointerToVoxels(), kernel->GetNumberOfVoxels(), norm),
-    _X(image->GetX())
+    MirroredForegroundConvolution1D<TKernel>(image, kernel->Data(), kernel->NumberOfVoxels(), norm),
+    _X(image->X())
   {}
 
   template <class T1, class T2>
@@ -1016,15 +1022,15 @@ struct ConvolveMirroredForegroundInY : public MirroredForegroundConvolution1D<TK
   ConvolveMirroredForegroundInY(const BaseImage *image, const TKernel *kernel, int size, double norm = 1.0)
   :
     MirroredForegroundConvolution1D<TKernel>(image, kernel, size, norm),
-    _X(image->GetX()),
-    _Y(image->GetY())
+    _X(image->X()),
+    _Y(image->Y())
   {}
 
   ConvolveMirroredForegroundInY(const BaseImage *image, const GenericImage<TKernel> *kernel, double norm = 1.0)
   :
-    MirroredForegroundConvolution1D<TKernel>(image, kernel->GetPointerToVoxels(), kernel->GetNumberOfVoxels(), norm),
-    _X(image->GetX()),
-    _Y(image->GetY())
+    MirroredForegroundConvolution1D<TKernel>(image, kernel->Data(), kernel->NumberOfVoxels(), norm),
+    _X(image->X()),
+    _Y(image->Y())
   {}
 
   template <class T1, class T2>
@@ -1050,15 +1056,15 @@ struct ConvolveMirroredForegroundInZ : public MirroredForegroundConvolution1D<TK
   ConvolveMirroredForegroundInZ(const BaseImage *image, const TKernel *kernel, int size, double norm = 1.0)
   :
     MirroredForegroundConvolution1D<TKernel>(image, kernel, size, norm),
-    _XY(image->GetX() * image->GetY()),
-    _Z (image->GetZ())
+    _XY(image->X() * image->Y()),
+    _Z (image->Z())
   {}
 
   ConvolveMirroredForegroundInZ(const BaseImage *image, const GenericImage<TKernel> *kernel, double norm = 1.0)
   :
-    MirroredForegroundConvolution1D<TKernel>(image, kernel->GetPointerToVoxels(), kernel->GetNumberOfVoxels(), norm),
-    _XY(image->GetX() * image->GetY()),
-    _Z (image->GetZ())
+    MirroredForegroundConvolution1D<TKernel>(image, kernel->Data(), kernel->NumberOfVoxels(), norm),
+    _XY(image->X() * image->Y()),
+    _Z (image->Z())
   {}
 
   template <class T1, class T2>
@@ -1084,15 +1090,15 @@ struct ConvolveMirroredForegroundInT : public MirroredForegroundConvolution1D<TK
   ConvolveMirroredForegroundInT(const BaseImage *image, const TKernel *kernel, int size, double norm = 1.0)
   :
     MirroredForegroundConvolution1D<TKernel>(image, kernel, size, norm),
-    _XYZ(image->GetX() * image->GetY() * image->GetZ()),
-    _T  (image->GetT())
+    _XYZ(image->X() * image->Y() * image->Z()),
+    _T  (image->T())
   {}
 
   ConvolveMirroredForegroundInT(const BaseImage *image, const GenericImage<TKernel> *kernel, double norm = 1.0)
   :
-    MirroredForegroundConvolution1D<TKernel>(image, kernel->GetPointerToVoxels(), kernel->GetNumberOfVoxels(), norm),
-    _XYZ(image->GetX() * image->GetY() * image->GetZ()),
-    _T  (image->GetT())
+    MirroredForegroundConvolution1D<TKernel>(image, kernel->Data(), kernel->NumberOfVoxels(), norm),
+    _XYZ(image->X() * image->Y() * image->Z()),
+    _T  (image->T())
   {}
 
   template <class T1, class T2>
@@ -1139,7 +1145,7 @@ protected:
   template <class T>
   bool ConvolveCenterVoxel(const T *in, double &acc) const
   {
-    if (AreEqualOrNaN(static_cast<double>(*in), _Background, 1e-6)) {
+    if (AreEqualOrNaN(static_cast<double>(*in), _Background, Epsilon())) {
       acc = _Background / _Norm;
       return false;
     } else {
@@ -1157,7 +1163,7 @@ protected:
     for (int k = _Radius + 1; k < _Size; ++k) {
       i  -= di;
       in -= s;
-      if (i < 0 || AreEqualOrNaN(static_cast<double>(*in), _Background, 1e-6)) {
+      if (i < 0 || AreEqualOrNaN(static_cast<double>(*in), _Background, Epsilon())) {
         i  += di;
         in += s;
         di = s = 0;
@@ -1176,7 +1182,7 @@ protected:
     for (int k = _Radius - 1; k >= 0; --k) {
       i  += di;
       in += s;
-      if (n <= i || AreEqualOrNaN(static_cast<double>(*in), _Background, 1e-6)) {
+      if (n <= i || AreEqualOrNaN(static_cast<double>(*in), _Background, Epsilon())) {
         i  -= di;
         in -= s;
         di = s = 0;
@@ -1211,12 +1217,12 @@ template <class TKernel = double>
 struct ConvolveExtendedForegroundInX : public ExtendedForegroundConvolution1D<TKernel>
 {
   ConvolveExtendedForegroundInX(const BaseImage *image, const TKernel *kernel, int size, double norm = 1.0)
-    : ExtendedForegroundConvolution1D<TKernel>(image, kernel, size, norm), _X(image->GetX()) {}
+    : ExtendedForegroundConvolution1D<TKernel>(image, kernel, size, norm), _X(image->X()) {}
 
   ConvolveExtendedForegroundInX(const BaseImage *image, const GenericImage<TKernel> *kernel, double norm = 1.0)
   :
-    ExtendedForegroundConvolution1D<TKernel>(image, kernel->GetPointerToVoxels(), kernel->GetNumberOfVoxels(), norm),
-    _X(image->GetX())
+    ExtendedForegroundConvolution1D<TKernel>(image, kernel->Data(), kernel->NumberOfVoxels(), norm),
+    _X(image->X())
   {}
 
   template <class T1, class T2>
@@ -1241,15 +1247,15 @@ struct ConvolveExtendedForegroundInY : public ExtendedForegroundConvolution1D<TK
   ConvolveExtendedForegroundInY(const BaseImage *image, const TKernel *kernel, int size, double norm = 1.0)
   :
     ExtendedForegroundConvolution1D<TKernel>(image, kernel, size, norm),
-    _X(image->GetX()),
-    _Y(image->GetY())
+    _X(image->X()),
+    _Y(image->Y())
   {}
 
   ConvolveExtendedForegroundInY(const BaseImage *image, const GenericImage<TKernel> *kernel, double norm = 1.0)
   :
-    ExtendedForegroundConvolution1D<TKernel>(image, kernel->GetPointerToVoxels(), kernel->GetNumberOfVoxels(), norm),
-    _X(image->GetX()),
-    _Y(image->GetY())
+    ExtendedForegroundConvolution1D<TKernel>(image, kernel->Data(), kernel->NumberOfVoxels(), norm),
+    _X(image->X()),
+    _Y(image->Y())
   {}
 
   template <class T1, class T2>
@@ -1275,15 +1281,15 @@ struct ConvolveExtendedForegroundInZ : public ExtendedForegroundConvolution1D<TK
   ConvolveExtendedForegroundInZ(const BaseImage *image, const TKernel *kernel, int size, double norm = 1.0)
   :
     ExtendedForegroundConvolution1D<TKernel>(image, kernel, size, norm),
-    _XY(image->GetX() * image->GetY()),
-    _Z (image->GetZ())
+    _XY(image->X() * image->Y()),
+    _Z (image->Z())
   {}
 
   ConvolveExtendedForegroundInZ(const BaseImage *image, const GenericImage<TKernel> *kernel, double norm = 1.0)
   :
-    ExtendedForegroundConvolution1D<TKernel>(image, kernel->GetPointerToVoxels(), kernel->GetNumberOfVoxels(), norm),
-    _XY(image->GetX() * image->GetY()),
-    _Z (image->GetZ())
+    ExtendedForegroundConvolution1D<TKernel>(image, kernel->Data(), kernel->NumberOfVoxels(), norm),
+    _XY(image->X() * image->Y()),
+    _Z (image->Z())
   {}
 
   template <class T1, class T2>
@@ -1309,15 +1315,15 @@ struct ConvolveExtendedForegroundInT : public ExtendedForegroundConvolution1D<TK
   ConvolveExtendedForegroundInT(const BaseImage *image, const TKernel *kernel, int size, double norm = 1.0)
   :
     ExtendedForegroundConvolution1D<TKernel>(image, kernel, size, norm),
-    _XYZ(image->GetX() * image->GetY() * image->GetZ()),
-    _T  (image->GetT())
+    _XYZ(image->X() * image->Y() * image->Z()),
+    _T  (image->T())
   {}
 
   ConvolveExtendedForegroundInT(const BaseImage *image, const GenericImage<TKernel> *kernel, double norm = 1.0)
   :
-    ExtendedForegroundConvolution1D<TKernel>(image, kernel->GetPointerToVoxels(), kernel->GetNumberOfVoxels(), norm),
-    _XYZ(image->GetX() * image->GetY() * image->GetZ()),
-    _T  (image->GetT())
+    ExtendedForegroundConvolution1D<TKernel>(image, kernel->Data(), kernel->NumberOfVoxels(), norm),
+    _XYZ(image->X() * image->Y() * image->Z()),
+    _T  (image->T())
   {}
 
   template <class T1, class T2>
@@ -1347,20 +1353,20 @@ struct DownsampleConvolvedMirroredForegroundInX : public ConvolveMirroredForegro
   DownsampleConvolvedMirroredForegroundInX(const GenericImage<TVoxel> *image, int m, const TKernel *kernel, int size, double norm = 1.0)
   :
     ConvolveMirroredForegroundInX<TKernel>(image, kernel, size, norm),
-    _Input(image), _Offset((image->GetX() % m + 1) / 2), _Factor(m)
+    _Input(image), _Offset((image->X() % m + 1) / 2), _Factor(m)
   {}
 
   DownsampleConvolvedMirroredForegroundInX(const GenericImage<TVoxel> *image, int m, const GenericImage<TKernel> *kernel, double norm = 1.0)
   :
-    ConvolveMirroredForegroundInX<TKernel>(image, kernel->GetPointerToVoxels(), kernel->GetNumberOfVoxels(), norm),
-    _Input(image), _Offset((image->GetX() % m + 1) / 2), _Factor(m)
+    ConvolveMirroredForegroundInX<TKernel>(image, kernel->Data(), kernel->NumberOfVoxels(), norm),
+    _Input(image), _Offset((image->X() % m + 1) / 2), _Factor(m)
   {}
 
   template <class T>
   void operator ()(int i, int j, int k, int l, T *out) const
   {
     i = _Offset + i * _Factor;
-    ConvolveMirroredForegroundInX<TKernel>::operator ()(i, j, k, l, _Input->GetPointerToVoxels(i, j, k, l), out);
+    ConvolveMirroredForegroundInX<TKernel>::operator ()(i, j, k, l, _Input->Data(i, j, k, l), out);
   }
 
   const GenericImage<TVoxel> *_Input;  ///< Image to downsample
@@ -1376,20 +1382,20 @@ struct DownsampleConvolvedMirroredForegroundInY : public ConvolveMirroredForegro
   DownsampleConvolvedMirroredForegroundInY(const GenericImage<TVoxel> *image, int m, const TKernel *kernel, int size, double norm = 1.0)
   :
     ConvolveMirroredForegroundInY<TKernel>(image, kernel, size, norm),
-    _Input(image), _Offset((image->GetY() % m + 1) / 2), _Factor(m)
+    _Input(image), _Offset((image->Y() % m + 1) / 2), _Factor(m)
   {}
 
   DownsampleConvolvedMirroredForegroundInY(const GenericImage<TVoxel> *image, int m, const GenericImage<TKernel> *kernel, double norm = 1.0)
   :
-    ConvolveMirroredForegroundInY<TKernel>(image, kernel->GetPointerToVoxels(), kernel->GetNumberOfVoxels(), norm),
-    _Input(image), _Offset((image->GetY() % m + 1) / 2), _Factor(m)
+    ConvolveMirroredForegroundInY<TKernel>(image, kernel->Data(), kernel->NumberOfVoxels(), norm),
+    _Input(image), _Offset((image->Y() % m + 1) / 2), _Factor(m)
   {}
 
   template <class T>
   void operator ()(int i, int j, int k, int l, T *out) const
   {
     j = _Offset + j * _Factor;
-    ConvolveMirroredForegroundInY<TKernel>::operator ()(i, j, k, l, _Input->GetPointerToVoxels(i, j, k, l), out);
+    ConvolveMirroredForegroundInY<TKernel>::operator ()(i, j, k, l, _Input->Data(i, j, k, l), out);
   }
 
   const GenericImage<TVoxel> *_Input;  ///< Image to downsample
@@ -1405,20 +1411,20 @@ struct DownsampleConvolvedMirroredForegroundInZ : public ConvolveMirroredForegro
   DownsampleConvolvedMirroredForegroundInZ(const GenericImage<TVoxel> *image, int m, const TKernel *kernel, int size, double norm = 1.0)
   :
     ConvolveMirroredForegroundInZ<TKernel>(image, kernel, size, norm),
-    _Input(image), _Offset((image->GetZ() % m + 1) / 2), _Factor(m)
+    _Input(image), _Offset((image->Z() % m + 1) / 2), _Factor(m)
   {}
 
   DownsampleConvolvedMirroredForegroundInZ(const GenericImage<TVoxel> *image, int m, const GenericImage<TKernel> *kernel, double norm = 1.0)
   :
-    ConvolveMirroredForegroundInZ<TKernel>(image, kernel->GetPointerToVoxels(), kernel->GetNumberOfVoxels(), norm),
-    _Input(image), _Offset((image->GetZ() % m + 1) / 2), _Factor(m)
+    ConvolveMirroredForegroundInZ<TKernel>(image, kernel->Data(), kernel->NumberOfVoxels(), norm),
+    _Input(image), _Offset((image->Z() % m + 1) / 2), _Factor(m)
   {}
 
   template <class T>
   void operator ()(int i, int j, int k, int l, T *out) const
   {
     k = _Offset + k * _Factor;
-    ConvolveMirroredForegroundInZ<TKernel>::operator ()(i, j, k, l, _Input->GetPointerToVoxels(i, j, k, l), out);
+    ConvolveMirroredForegroundInZ<TKernel>::operator ()(i, j, k, l, _Input->Data(i, j, k, l), out);
   }
 
   const GenericImage<TVoxel> *_Input;  ///< Image to downsample
@@ -1438,20 +1444,20 @@ struct DownsampleConvolvedExtendedForegroundInX : public ConvolveExtendedForegro
   DownsampleConvolvedExtendedForegroundInX(const GenericImage<TVoxel> *image, int m, const TKernel *kernel, int size, double norm = 1.0)
   :
     ConvolveExtendedForegroundInX<TKernel>(image, kernel, size, norm),
-    _Input(image), _Offset((image->GetX() % m + 1) / 2), _Factor(m)
+    _Input(image), _Offset((image->X() % m + 1) / 2), _Factor(m)
   {}
 
   DownsampleConvolvedExtendedForegroundInX(const GenericImage<TVoxel> *image, int m, const GenericImage<TKernel> *kernel, double norm = 1.0)
   :
-    ConvolveExtendedForegroundInX<TKernel>(image, kernel->GetPointerToVoxels(), kernel->GetNumberOfVoxels(), norm),
-    _Input(image), _Offset((image->GetX() % m + 1) / 2), _Factor(m)
+    ConvolveExtendedForegroundInX<TKernel>(image, kernel->Data(), kernel->NumberOfVoxels(), norm),
+    _Input(image), _Offset((image->X() % m + 1) / 2), _Factor(m)
   {}
 
   template <class T>
   void operator ()(int i, int j, int k, int l, T *out) const
   {
     i = _Offset + i * _Factor;
-    ConvolveExtendedForegroundInX<TKernel>::operator ()(i, j, k, l, _Input->GetPointerToVoxels(i, j, k, l), out);
+    ConvolveExtendedForegroundInX<TKernel>::operator ()(i, j, k, l, _Input->Data(i, j, k, l), out);
   }
 
   const GenericImage<TVoxel> *_Input;  ///< Image to downsample
@@ -1467,20 +1473,20 @@ struct DownsampleConvolvedExtendedForegroundInY : public ConvolveExtendedForegro
   DownsampleConvolvedExtendedForegroundInY(const GenericImage<TVoxel> *image, int m, const TKernel *kernel, int size, double norm = 1.0)
   :
     ConvolveExtendedForegroundInY<TKernel>(image, kernel, size, norm),
-    _Input(image), _Offset((image->GetY() % m + 1) / 2), _Factor(m)
+    _Input(image), _Offset((image->Y() % m + 1) / 2), _Factor(m)
   {}
 
   DownsampleConvolvedExtendedForegroundInY(const GenericImage<TVoxel> *image, int m, const GenericImage<TKernel> *kernel, double norm = 1.0)
   :
-    ConvolveExtendedForegroundInY<TKernel>(image, kernel->GetPointerToVoxels(), kernel->GetNumberOfVoxels(), norm),
-    _Input(image), _Offset((image->GetY() % m + 1) / 2), _Factor(m)
+    ConvolveExtendedForegroundInY<TKernel>(image, kernel->Data(), kernel->NumberOfVoxels(), norm),
+    _Input(image), _Offset((image->Y() % m + 1) / 2), _Factor(m)
   {}
 
   template <class T>
   void operator ()(int i, int j, int k, int l, T *out) const
   {
     j = _Offset + j * _Factor;
-    ConvolveExtendedForegroundInY<TKernel>::operator ()(i, j, k, l, _Input->GetPointerToVoxels(i, j, k, l), out);
+    ConvolveExtendedForegroundInY<TKernel>::operator ()(i, j, k, l, _Input->Data(i, j, k, l), out);
   }
 
   const GenericImage<TVoxel> *_Input;  ///< Image to downsample
@@ -1496,20 +1502,20 @@ struct DownsampleConvolvedExtendedForegroundInZ : public ConvolveExtendedForegro
   DownsampleConvolvedExtendedForegroundInZ(const GenericImage<TVoxel> *image, int m, const TKernel *kernel, int size, double norm = 1.0)
   :
     ConvolveExtendedForegroundInZ<TKernel>(image, kernel, size, norm),
-    _Input(image), _Offset((image->GetZ() % m + 1) / 2), _Factor(m)
+    _Input(image), _Offset((image->Z() % m + 1) / 2), _Factor(m)
   {}
 
   DownsampleConvolvedExtendedForegroundInZ(const GenericImage<TVoxel> *image, int m, const GenericImage<TKernel> *kernel, double norm = 1.0)
   :
-    ConvolveExtendedForegroundInZ<TKernel>(image, kernel->GetPointerToVoxels(), kernel->GetNumberOfVoxels(), norm),
-    _Input(image), _Offset((image->GetZ() % m) / 2), _Factor(m)
+    ConvolveExtendedForegroundInZ<TKernel>(image, kernel->Data(), kernel->NumberOfVoxels(), norm),
+    _Input(image), _Offset((image->Z() % m) / 2), _Factor(m)
   {}
 
   template <class T>
   void operator ()(int i, int j, int k, int l, T *out) const
   {
     k = _Offset + k * _Factor;
-    ConvolveExtendedForegroundInZ<TKernel>::operator ()(i, j, k, l, _Input->GetPointerToVoxels(i, j, k, l), out);
+    ConvolveExtendedForegroundInZ<TKernel>::operator ()(i, j, k, l, _Input->Data(i, j, k, l), out);
   }
 
   const GenericImage<TVoxel> *_Input;  ///< Image to downsample

--- a/Modules/Image/include/mirtk/CubicBSplineInterpolateImageFunction.hxx
+++ b/Modules/Image/include/mirtk/CubicBSplineInterpolateImageFunction.hxx
@@ -210,8 +210,8 @@ GenericCubicBSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (bgw > fgw) {
-    val  = voxel_cast<RealType>(this->DefaultValue());
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    val = voxel_cast<RealType>(this->DefaultValue());
   }
   return voxel_cast<VoxelType>(val);
 }
@@ -287,8 +287,8 @@ GenericCubicBSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (bgw > fgw) {
-    val  = voxel_cast<RealType>(this->DefaultValue());
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    val = voxel_cast<RealType>(this->DefaultValue());
   }
   return voxel_cast<VoxelType>(val);
 }
@@ -379,8 +379,8 @@ GenericCubicBSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (bgw > fgw) {
-    val  = voxel_cast<RealType>(this->DefaultValue());
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    val = voxel_cast<RealType>(this->DefaultValue());
   }
   return voxel_cast<VoxelType>(val);
 }
@@ -467,8 +467,8 @@ GenericCubicBSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (bgw > fgw) {
-    val  = voxel_cast<RealType>(this->DefaultValue());
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    val = voxel_cast<RealType>(this->DefaultValue());
   }
   return voxel_cast<VoxelType>(val);
 }
@@ -562,8 +562,8 @@ GenericCubicBSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (bgw > fgw) {
-    val  = voxel_cast<RealType>(this->DefaultValue());
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    val = voxel_cast<RealType>(this->DefaultValue());
   }
   return voxel_cast<VoxelType>(val);
 }
@@ -657,8 +657,8 @@ GenericCubicBSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (bgw > fgw) {
-    val  = voxel_cast<RealType>(this->DefaultValue());
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    val = voxel_cast<RealType>(this->DefaultValue());
   }
   return voxel_cast<VoxelType>(val);
 }

--- a/Modules/Image/include/mirtk/FastCubicBSplineInterpolateImageFunction.hxx
+++ b/Modules/Image/include/mirtk/FastCubicBSplineInterpolateImageFunction.hxx
@@ -220,8 +220,8 @@ GenericFastCubicBSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (bgw > fgw) {
-    val  = voxel_cast<RealType>(this->DefaultValue());
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    val = voxel_cast<RealType>(this->DefaultValue());
   }
   return voxel_cast<VoxelType>(val);
 }
@@ -297,8 +297,8 @@ GenericFastCubicBSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (bgw > fgw) {
-    val  = voxel_cast<RealType>(this->DefaultValue());
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    val = voxel_cast<RealType>(this->DefaultValue());
   }
   return voxel_cast<VoxelType>(val);
 }
@@ -393,8 +393,8 @@ GenericFastCubicBSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (bgw > fgw) {
-    val  = voxel_cast<RealType>(this->DefaultValue());
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    val = voxel_cast<RealType>(this->DefaultValue());
   }
   return voxel_cast<VoxelType>(val);
 }
@@ -484,8 +484,8 @@ GenericFastCubicBSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (bgw > fgw) {
-    val  = voxel_cast<RealType>(this->DefaultValue());
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    val = voxel_cast<RealType>(this->DefaultValue());
   }
   return voxel_cast<VoxelType>(val);
 }
@@ -584,8 +584,8 @@ GenericFastCubicBSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (bgw > fgw) {
-    val  = voxel_cast<RealType>(this->DefaultValue());
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    val = voxel_cast<RealType>(this->DefaultValue());
   }
   return voxel_cast<VoxelType>(val);
 }
@@ -682,8 +682,8 @@ GenericFastCubicBSplineInterpolateImageFunction<TImage>
     }
   }
 
-  if (bgw > fgw) {
-    val  = voxel_cast<RealType>(this->DefaultValue());
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    val = voxel_cast<RealType>(this->DefaultValue());
   }
   return voxel_cast<VoxelType>(val);
 }

--- a/Modules/Image/include/mirtk/FastLinearImageGradientFunction.hxx
+++ b/Modules/Image/include/mirtk/FastLinearImageGradientFunction.hxx
@@ -123,8 +123,8 @@ GenericFastLinearImageGradientFunction<TImage>
     }
   }
 
-  if (nrm) val /= nrm;
-  else     val  = this->DefaultValue();
+  if (nrm > 1e-3) val /= nrm;
+  else val = this->DefaultValue();
 
   return val;
 }
@@ -288,8 +288,8 @@ GenericFastLinearImageGradientFunction<TImage>
     }
   }
 
-  if (nrm) val /= nrm;
-  else     val  = this->DefaultValue();
+  if (nrm > 1e-3) val /= nrm;
+  else val = this->DefaultValue();
 
   return val;
 }
@@ -468,8 +468,8 @@ GenericFastLinearImageGradientFunction<TImage>
     }
   }
 
-  if (nrm) val /= nrm;
-  else     val  = this->DefaultValue();
+  if (nrm > 1e-3) val /= nrm;
+  else val = this->DefaultValue();
 
   return val;
 }

--- a/Modules/Image/include/mirtk/GaussianInterpolateImageFunction.hxx
+++ b/Modules/Image/include/mirtk/GaussianInterpolateImageFunction.hxx
@@ -162,8 +162,8 @@ GenericGaussianInterpolateImageFunction<TImage>
     }
   }
 
-  if (nrm) val /= nrm;
-  else     val  = voxel_cast<RealType>(this->DefaultValue());
+  if (nrm > 1e-3) val /= nrm;
+  else val = voxel_cast<RealType>(this->DefaultValue());
 
   return voxel_cast<VoxelType>(val);
 }
@@ -206,10 +206,10 @@ GenericGaussianInterpolateImageFunction<TImage>
     }
   }
 
-  if (fgw > bgw) val /= fgw;
-  else           val  = voxel_cast<RealType>(this->DefaultValue());
-
-  return voxel_cast<VoxelType>(val);
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    return voxel_cast<VoxelType>(this->DefaultValue());
+  }
+  return voxel_cast<VoxelType>(val / fgw);
 }
 
 // -----------------------------------------------------------------------------
@@ -244,8 +244,8 @@ GenericGaussianInterpolateImageFunction<TImage>
     }
   }
 
-  if (nrm) val /= nrm;
-  else     val  = voxel_cast<RealType>(this->DefaultValue());
+  if (nrm > 1e-3) val /= nrm;
+  else val = voxel_cast<RealType>(this->DefaultValue());
 
   return voxel_cast<VoxelType>(val);
 }
@@ -286,10 +286,10 @@ GenericGaussianInterpolateImageFunction<TImage>
     }
   }
 
-  if (fgw > bgw) val /= fgw;
-  else           val  = voxel_cast<RealType>(this->DefaultValue());
-
-  return voxel_cast<VoxelType>(val);
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    return voxel_cast<VoxelType>(this->DefaultValue());
+  }
+  return voxel_cast<VoxelType>(val / fgw);
 }
 
 // -----------------------------------------------------------------------------
@@ -334,8 +334,8 @@ GenericGaussianInterpolateImageFunction<TImage>
     }
   }
 
-  if (nrm) val /= nrm;
-  else     val  = voxel_cast<RealType>(this->DefaultValue());
+  if (nrm > 1e-3) val /= nrm;
+  else val = voxel_cast<RealType>(this->DefaultValue());
 
   return voxel_cast<VoxelType>(val);
 }
@@ -380,10 +380,10 @@ GenericGaussianInterpolateImageFunction<TImage>
     }
   }
 
-  if (fgw > bgw) val /= fgw;
-  else           val  = voxel_cast<RealType>(this->DefaultValue());
-
-  return voxel_cast<VoxelType>(val);
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    return voxel_cast<VoxelType>(this->DefaultValue());
+  }
+  return voxel_cast<VoxelType>(val / fgw);
 }
 
 // -----------------------------------------------------------------------------
@@ -421,8 +421,8 @@ GenericGaussianInterpolateImageFunction<TImage>
     }
   }
 
-  if (nrm) val /= nrm;
-  else     val  = voxel_cast<RealType>(this->DefaultValue());
+  if (nrm > 1e-3) val /= nrm;
+  else val = voxel_cast<RealType>(this->DefaultValue());
 
   return voxel_cast<VoxelType>(val);
 }
@@ -466,10 +466,10 @@ GenericGaussianInterpolateImageFunction<TImage>
     }
   }
 
-  if (fgw > bgw) val /= fgw;
-  else           val  = voxel_cast<RealType>(this->DefaultValue());
-
-  return voxel_cast<VoxelType>(val);
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    return voxel_cast<VoxelType>(this->DefaultValue());
+  }
+  return voxel_cast<VoxelType>(val / fgw);
 }
 
 // -----------------------------------------------------------------------------
@@ -514,8 +514,8 @@ GenericGaussianInterpolateImageFunction<TImage>
     }
   }
 
-  if (nrm) val /= nrm;
-  else     val  = voxel_cast<RealType>(this->DefaultValue());
+  if (nrm > 1e-3) val /= nrm;
+  else val = voxel_cast<RealType>(this->DefaultValue());
 
   return voxel_cast<VoxelType>(val);
 }
@@ -558,10 +558,10 @@ GenericGaussianInterpolateImageFunction<TImage>
     }
   }
 
-  if (fgw > bgw) val /= fgw;
-  else           val  = voxel_cast<RealType>(this->DefaultValue());
-
-  return voxel_cast<VoxelType>(val);
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    return voxel_cast<VoxelType>(this->DefaultValue());
+  }
+  return voxel_cast<VoxelType>(val / fgw);
 }
 
 // -----------------------------------------------------------------------------
@@ -602,8 +602,8 @@ GenericGaussianInterpolateImageFunction<TImage>
     }
   }
 
-  if (nrm) val /= nrm;
-  else     val  = voxel_cast<RealType>(this->DefaultValue());
+  if (nrm > 1e-3) val /= nrm;
+  else val = voxel_cast<RealType>(this->DefaultValue());
 
   return voxel_cast<VoxelType>(val);
 }
@@ -650,10 +650,10 @@ GenericGaussianInterpolateImageFunction<TImage>
     }
   }
 
-  if (fgw > bgw) val /= fgw;
-  else           val  = voxel_cast<RealType>(this->DefaultValue());
-
-  return voxel_cast<VoxelType>(val);
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    return voxel_cast<VoxelType>(this->DefaultValue());
+  }
+  return voxel_cast<VoxelType>(val / fgw);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Image/include/mirtk/InterpolationMode.h
+++ b/Modules/Image/include/mirtk/InterpolationMode.h
@@ -55,96 +55,6 @@ enum InterpolationMode {
 };
 
 // ----------------------------------------------------------------------------
-template <>
-inline string ToString(const InterpolationMode &m, int w, char c, bool left)
-{
-  const char *str;
-  switch(m) {
-    case Interpolation_Default:                     str = "Default"; break;
-    case Interpolation_NN:                          str = "NN"; break;
-    case Interpolation_Linear:                      str = "Linear"; break;
-    case Interpolation_FastLinear:                  str = "Fast linear"; break;
-    case Interpolation_BSpline:                     str = "BSpline"; break;
-    case Interpolation_CSpline:                     str = "CSpline"; break;
-    case Interpolation_CubicBSpline:                str = "Cubic BSpline"; break;
-    case Interpolation_FastCubicBSpline:            str = "Fast cubic BSpline"; break;
-    case Interpolation_SBased:                      str = "SBased"; break;
-    case Interpolation_Sinc:                        str = "Sinc"; break;
-    case Interpolation_Gaussian:                    str = "Gaussian"; break;
-    case Interpolation_NNWithPadding:               str = "NN with padding"; break;
-    case Interpolation_LinearWithPadding:           str = "Linear with padding"; break;
-    case Interpolation_FastLinearWithPadding:       str = "Fast linear with padding"; break;
-    case Interpolation_BSplineWithPadding:          str = "BSpline with padding"; break;
-    case Interpolation_CubicBSplineWithPadding:     str = "Cubic BSpline with padding"; break;
-    case Interpolation_FastCubicBSplineWithPadding: str = "Fast cubic BSpline with padding"; break;
-    case Interpolation_CSplineWithPadding:          str = "CSpline with padding"; break;
-    case Interpolation_SBasedWithPadding:           str = "SBased with padding"; break;
-    case Interpolation_SincWithPadding:             str = "Sinc with padding"; break;
-    case Interpolation_GaussianWithPadding:         str = "Gaussian with padding"; break;
-    default:                                        str = "Unknown"; break;
-  }
-  return ToString(str, w, c, left);
-}
-
-// ----------------------------------------------------------------------------
-template <>
-inline bool FromString(const char *str, InterpolationMode &m)
-{
-  const string lstr = ToLower(str);
-  if      (lstr == "default") m = Interpolation_Default;
-  else if (lstr == "nn") m = Interpolation_NN;
-  else if (lstr == "linear") m = Interpolation_Linear;
-  else if (lstr == "fast linear") m = Interpolation_FastLinear;
-  else if (lstr == "bspline") m = Interpolation_BSpline;
-  else if (lstr == "b-spline") m = Interpolation_BSpline;
-  else if (lstr == "cspline") m = Interpolation_CSpline;
-  else if (lstr == "c-spline") m = Interpolation_CSpline;
-  else if (lstr == "cubic bspline") m = Interpolation_CubicBSpline;
-  else if (lstr == "cubic b-spline") m = Interpolation_CubicBSpline;
-  else if (lstr == "fast cubic bspline") m = Interpolation_FastCubicBSpline;
-  else if (lstr == "fast cubic b-spline") m = Interpolation_FastCubicBSpline;
-  else if (lstr == "sbased") m = Interpolation_SBased;
-  else if (lstr == "shapebased") m = Interpolation_SBased;
-  else if (lstr == "shape-based") m = Interpolation_SBased;
-  else if (lstr == "sinc") m = Interpolation_Sinc;
-  else if (lstr == "gaussian") m = Interpolation_Gaussian;
-  else if (lstr == "nn with padding") m = Interpolation_NNWithPadding;
-  else if (lstr == "nn (with padding)") m = Interpolation_NNWithPadding;
-  else if (lstr == "linear with padding") m = Interpolation_LinearWithPadding;
-  else if (lstr == "linear (with padding)") m = Interpolation_LinearWithPadding;
-  else if (lstr == "fast linear with padding") m = Interpolation_FastLinearWithPadding;
-  else if (lstr == "fast linear (with padding)") m = Interpolation_FastLinearWithPadding;
-  else if (lstr == "bspline with padding") m = Interpolation_BSplineWithPadding;
-  else if (lstr == "b-spline with padding") m = Interpolation_BSplineWithPadding;
-  else if (lstr == "bspline (with padding)") m = Interpolation_BSplineWithPadding;
-  else if (lstr == "b-spline (with padding)") m = Interpolation_BSplineWithPadding;
-  else if (lstr == "cubic bspline with padding") m = Interpolation_CubicBSplineWithPadding;
-  else if (lstr == "cubic b-spline with padding") m = Interpolation_CubicBSplineWithPadding;
-  else if (lstr == "cubic bspline (with padding)") m = Interpolation_CubicBSplineWithPadding;
-  else if (lstr == "cubic b-spline (with padding)") m = Interpolation_CubicBSplineWithPadding;
-  else if (lstr == "fast cubic bspline with padding") m = Interpolation_FastCubicBSplineWithPadding;
-  else if (lstr == "fast cubic b-spline with padding") m = Interpolation_FastCubicBSplineWithPadding;
-  else if (lstr == "fast cubic bspline (with padding)") m = Interpolation_FastCubicBSplineWithPadding;
-  else if (lstr == "fast cubic b-spline (with padding)") m = Interpolation_FastCubicBSplineWithPadding;
-  else if (lstr == "cspline with padding") m = Interpolation_CSplineWithPadding;
-  else if (lstr == "c-spline with padding") m = Interpolation_CSplineWithPadding;
-  else if (lstr == "cspline (with padding)") m = Interpolation_CSplineWithPadding;
-  else if (lstr == "c-spline (with padding)") m = Interpolation_CSplineWithPadding;
-  else if (lstr == "sbased with padding") m = Interpolation_SBasedWithPadding;
-  else if (lstr == "shapebased with padding") m = Interpolation_SBasedWithPadding;
-  else if (lstr == "shape-based with padding") m = Interpolation_SBasedWithPadding;
-  else if (lstr == "sbased (with padding)") m = Interpolation_SBasedWithPadding;
-  else if (lstr == "shapebased (with padding)") m = Interpolation_SBasedWithPadding;
-  else if (lstr == "shape-based (with padding)") m = Interpolation_SBasedWithPadding;
-  else if (lstr == "sinc with padding") m = Interpolation_SincWithPadding;
-  else if (lstr == "sinc (with padding)") m = Interpolation_SincWithPadding;
-  else if (lstr == "gaussian with padding") m = Interpolation_GaussianWithPadding;
-  else if (lstr == "gaussian (with padding)") m = Interpolation_GaussianWithPadding;
-  else return false;
-  return true;
-}
-
-// ----------------------------------------------------------------------------
 /// Get default interpolation mode
 inline InterpolationMode DefaultInterpolationMode()
 {
@@ -187,6 +97,79 @@ inline InterpolationMode InterpolationWithoutPadding(InterpolationMode m)
     case Interpolation_GaussianWithPadding:         return Interpolation_Gaussian;
     default:                                        return m;
   }
+}
+
+// ----------------------------------------------------------------------------
+template <>
+inline string ToString(const InterpolationMode &m, int w, char c, bool left)
+{
+  string str;
+  const auto mode = InterpolationWithoutPadding(m);
+  switch(mode) {
+    case Interpolation_Default:          str = "Default"; break;
+    case Interpolation_NN:               str = "NN"; break;
+    case Interpolation_Linear:           str = "Linear"; break;
+    case Interpolation_FastLinear:       str = "Fast linear"; break;
+    case Interpolation_BSpline:          str = "BSpline"; break;
+    case Interpolation_CSpline:          str = "CSpline"; break;
+    case Interpolation_CubicBSpline:     str = "Cubic BSpline"; break;
+    case Interpolation_FastCubicBSpline: str = "Fast cubic BSpline"; break;
+    case Interpolation_SBased:           str = "SBased"; break;
+    case Interpolation_Sinc:             str = "Sinc"; break;
+    case Interpolation_Gaussian:         str = "Gaussian"; break;
+    default:                             str = "Unknown"; break;
+  }
+  if (mode != m) str += " with padding";
+  return ToString(str, w, c, left);
+}
+
+// ----------------------------------------------------------------------------
+template <>
+inline bool FromString(const char *str, InterpolationMode &m)
+{
+  string lstr = ToLower(str);
+  bool with_padding = false;
+  auto pos = lstr.find(" (with padding)");
+  if (pos != string::npos) {
+    lstr.erase(pos, 15);
+    with_padding = true;
+  } else {
+    pos = lstr.find(" with padding");
+    if (pos != string::npos) {
+      lstr.erase(pos, 13);
+      with_padding = true;
+    } else {
+      pos = lstr.find(" (without padding)");
+      if (pos != string::npos) {
+        lstr.erase(pos, 18);
+      } else {
+        pos = lstr.find(" without padding");
+        if (pos != string::npos) lstr.erase(pos, 16);
+      }
+    }
+  }
+  if      (lstr == "default") m = Interpolation_Default;
+  else if (lstr == "nn") m = Interpolation_NN;
+  else if (lstr == "linear") m = Interpolation_Linear;
+  else if (lstr == "fast linear") m = Interpolation_FastLinear;
+  else if (lstr == "bspline") m = Interpolation_BSpline;
+  else if (lstr == "b-spline") m = Interpolation_BSpline;
+  else if (lstr == "cspline") m = Interpolation_CSpline;
+  else if (lstr == "c-spline") m = Interpolation_CSpline;
+  else if (lstr == "cubic bspline") m = Interpolation_CubicBSpline;
+  else if (lstr == "cubic b-spline") m = Interpolation_CubicBSpline;
+  else if (lstr == "fast cubic bspline") m = Interpolation_FastCubicBSpline;
+  else if (lstr == "fast cubic b-spline") m = Interpolation_FastCubicBSpline;
+  else if (lstr == "sbased") m = Interpolation_SBased;
+  else if (lstr == "shapebased") m = Interpolation_SBased;
+  else if (lstr == "shape-based") m = Interpolation_SBased;
+  else if (lstr == "sinc") m = Interpolation_Sinc;
+  else if (lstr == "gaussian") m = Interpolation_Gaussian;
+  else return false;
+  if (with_padding) {
+    m = InterpolationWithPadding(m);
+  }
+  return true;
 }
 
 

--- a/Modules/Image/include/mirtk/LinearInterpolateImageFunction.h
+++ b/Modules/Image/include/mirtk/LinearInterpolateImageFunction.h
@@ -57,6 +57,15 @@ public:
   virtual void Initialize(bool = false);
 
   // ---------------------------------------------------------------------------
+  // Linear interpolation weights
+
+  /// Returns truncated integral part of floating point
+  ///
+  /// \param[in]  x Floating point number.
+  /// \param[out] w Linear interpolation weights for closest lattice nodes.
+  static int ComputeWeights(double, Real[2]);
+
+  // ---------------------------------------------------------------------------
   // Domain checks
 
   /// Returns interval of discrete image indices whose values are needed for

--- a/Modules/Image/include/mirtk/ResamplingWithPadding.h
+++ b/Modules/Image/include/mirtk/ResamplingWithPadding.h
@@ -1,8 +1,9 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2008-2015 Imperial College London
+ * Copyright 2008-2017 Imperial College London
  * Copyright 2008-2015 Daniel Rueckert, Julia Schnabel
+ * Copyright 2017 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,11 +31,9 @@ namespace mirtk {
  * Class for resampling of padded images
  *
  * This class defines and implements the resampling of images with arbitrary
- * voxel dimensions.  The new image intensity of the voxels is calculated by
- * interpolation of the old image intensities.  Only linear interpolation is
- * currently supported. If more than 50% of the voxels used for interpolation
- * have intensities smaller or equal to the padding value, the resampled
- * voxel will be filled with the padding value.
+ * voxel dimensions. The new image intensity of the voxels is calculated by
+ * interpolation of the old image intensities, using
+ * InterpolateImageFunction::EvaluateWithPadding.
  */
 template <class TVoxel>
 class ResamplingWithPadding : public Resampling<TVoxel>

--- a/Modules/Image/include/mirtk/SincInterpolateImageFunction.hxx
+++ b/Modules/Image/include/mirtk/SincInterpolateImageFunction.hxx
@@ -138,8 +138,8 @@ GenericSincInterpolateImageFunction<TImage>
     }
   }
 
-  if (nrm) val /= nrm;
-  else     val  = voxel_cast<RealType>(this->DefaultValue());
+  if (nrm > 1e-3) val /= nrm;
+  else val = voxel_cast<RealType>(this->DefaultValue());
 
   return voxel_cast<VoxelType>(val);
 }
@@ -193,10 +193,10 @@ GenericSincInterpolateImageFunction<TImage>
     }
   }
 
-  if (fgw > bgw) val /= fgw;
-  else           val  = voxel_cast<RealType>(this->DefaultValue());
-
-  return voxel_cast<VoxelType>(val);
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    return voxel_cast<VoxelType>(this->DefaultValue());
+  }
+  return voxel_cast<VoxelType>(val / fgw);
 }
 
 // -----------------------------------------------------------------------------
@@ -238,8 +238,8 @@ GenericSincInterpolateImageFunction<TImage>
     }
   }
 
-  if (nrm) val /= nrm;
-  else     val  = voxel_cast<RealType>(this->DefaultValue());
+  if (nrm > 1e-3) val /= nrm;
+  else val = voxel_cast<RealType>(this->DefaultValue());
 
   return voxel_cast<VoxelType>(val);
 }
@@ -291,10 +291,10 @@ GenericSincInterpolateImageFunction<TImage>
     }
   }
 
-  if (fgw > bgw) val /= fgw;
-  else           val  = voxel_cast<RealType>(this->DefaultValue());
-
-  return voxel_cast<VoxelType>(val);
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    return voxel_cast<VoxelType>(this->DefaultValue());
+  }
+  return voxel_cast<VoxelType>(val / fgw);
 }
 
 // -----------------------------------------------------------------------------
@@ -355,8 +355,8 @@ GenericSincInterpolateImageFunction<TImage>
     }
   }
 
-  if (nrm) val /= nrm;
-  else     val  = voxel_cast<RealType>(this->DefaultValue());
+  if (nrm > 1e-3) val /= nrm;
+  else val = voxel_cast<RealType>(this->DefaultValue());
 
   return voxel_cast<VoxelType>(val);
 }
@@ -415,10 +415,10 @@ GenericSincInterpolateImageFunction<TImage>
     }
   }
 
-  if (fgw > bgw) val /= fgw;
-  else           val  = voxel_cast<RealType>(this->DefaultValue());
-
-  return voxel_cast<VoxelType>(val);
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    return voxel_cast<VoxelType>(this->DefaultValue());
+  }
+  return voxel_cast<VoxelType>(val / fgw);
 }
 
 // -----------------------------------------------------------------------------
@@ -466,8 +466,8 @@ GenericSincInterpolateImageFunction<TImage>
     }
   }
 
-  if (nrm) val /= nrm;
-  else     val  = voxel_cast<RealType>(this->DefaultValue());
+  if (nrm > 1e-3) val /= nrm;
+  else val = voxel_cast<RealType>(this->DefaultValue());
 
   return voxel_cast<VoxelType>(val);
 }
@@ -525,10 +525,10 @@ GenericSincInterpolateImageFunction<TImage>
     }
   }
 
-  if (fgw > bgw) val /= fgw;
-  else           val  = voxel_cast<RealType>(this->DefaultValue());
-
-  return voxel_cast<VoxelType>(val);
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    return voxel_cast<VoxelType>(this->DefaultValue());
+  }
+  return voxel_cast<VoxelType>(val / fgw);
 }
 
 // -----------------------------------------------------------------------------
@@ -591,8 +591,8 @@ GenericSincInterpolateImageFunction<TImage>
     }
   }
 
-  if (nrm) val /= nrm;
-  else     val  = voxel_cast<RealType>(this->DefaultValue());
+  if (nrm > 1e-3) val /= nrm;
+  else val = voxel_cast<RealType>(this->DefaultValue());
 
   return voxel_cast<VoxelType>(val);
 }
@@ -653,10 +653,10 @@ GenericSincInterpolateImageFunction<TImage>
     }
   }
 
-  if (fgw > bgw) val /= fgw;
-  else           val  = voxel_cast<RealType>(this->DefaultValue());
-
-  return voxel_cast<VoxelType>(val);
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    return voxel_cast<VoxelType>(this->DefaultValue());
+  }
+  return voxel_cast<VoxelType>(val / fgw);
 }
 
 // -----------------------------------------------------------------------------
@@ -710,8 +710,8 @@ GenericSincInterpolateImageFunction<TImage>
     }
   }
 
-  if (nrm) val /= nrm;
-  else     val  = voxel_cast<RealType>(this->DefaultValue());
+  if (nrm > 1e-3) val /= nrm;
+  else val = voxel_cast<RealType>(this->DefaultValue());
 
   return voxel_cast<VoxelType>(val);
 }
@@ -775,10 +775,10 @@ GenericSincInterpolateImageFunction<TImage>
     }
   }
 
-  if (fgw > bgw) val /= fgw;
-  else           val  = voxel_cast<RealType>(this->DefaultValue());
-
-  return voxel_cast<VoxelType>(val);
+  if (bgw > fgw || AreEqual(bgw, fgw, 1e-3)) {
+    return voxel_cast<VoxelType>(this->DefaultValue());
+  }
+  return voxel_cast<VoxelType>(val / fgw);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Image/src/GaussianBlurring.cc
+++ b/Modules/Image/src/GaussianBlurring.cc
@@ -203,6 +203,16 @@ void GaussianBlurring<VoxelType>::Finalize()
   // Finalize base class
   ImageToImage<VoxelType>::Finalize();
 
+  // Copy background information
+  if (this->Input() != this->Output()) {
+    if (this->Input()->HasBackgroundValue()) {
+      this->Output()->PutBackgroundValueAsDouble(this->Input()->GetBackgroundValueAsDouble());
+    }
+    if (this->Input()->HasMask()) {
+      this->Output()->PutMask(new BinaryImage(*this->Input()->GetMask()), true);
+    }
+  }
+
   // Free convolution kernel
   Delete(_Kernel);
 }

--- a/Modules/Image/src/GaussianBlurring.cc
+++ b/Modules/Image/src/GaussianBlurring.cc
@@ -1,9 +1,9 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2008-2015 Imperial College London
+ * Copyright 2008-2017 Imperial College London
  * Copyright 2008-2013 Daniel Rueckert, Julia Schnabel
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2017 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,12 +131,12 @@ void GaussianBlurring<VoxelType>::Run()
   GenericImage<VoxelType> *output = this->Output();
 
   const ImageAttributes &attr = input->Attributes();
-  const int N = ((attr._dt == .0) ? attr._t : 1);
+  const int N = (AreEqual(attr._dt, 0.) ? attr._t : 1);
 
   // Blur along x axis
-  if (_SigmaX != .0 && input->X() > 1) {
+  if (!AreEqual(_SigmaX, 0.) && input->X() > 1) {
     if (output == this->Input()) output = new GenericImage<VoxelType>(attr);
-    this->InitializeKernel(_SigmaX / input->GetXSize());
+    this->InitializeKernel(_SigmaX / input->XSize());
     for (int n = 0; n < N; ++n) {
       using ConvolutionFunction::ConvolveInX;
       ConvolveInX<RealPixel> conv(input, _Kernel->Data(), _Kernel->X(), true, n);
@@ -146,9 +146,9 @@ void GaussianBlurring<VoxelType>::Run()
   }
 
   // Blur along y axis
-  if (_SigmaY != .0 && input->Y() > 1) {
+  if (!AreEqual(_SigmaY, 0.) && input->Y() > 1) {
     if (output == this->Input()) output = new GenericImage<VoxelType>(attr);
-    this->InitializeKernel(_SigmaY / input->GetYSize());
+    this->InitializeKernel(_SigmaY / input->YSize());
     for (int n = 0; n < N; ++n) {
       using ConvolutionFunction::ConvolveInY;
       ConvolveInY<RealPixel> conv(input, _Kernel->Data(), _Kernel->X(), true, n);
@@ -158,9 +158,9 @@ void GaussianBlurring<VoxelType>::Run()
   }
 
   // Blur along z axis
-  if (_SigmaZ != .0 && input->Z() > 1) {
+  if (!AreEqual(_SigmaZ, 0.) && input->Z() > 1) {
     if (output == this->Input()) output = new GenericImage<VoxelType>(attr);
-    this->InitializeKernel(_SigmaZ / input->GetZSize());
+    this->InitializeKernel(_SigmaZ / input->ZSize());
     for (int n = 0; n < N; ++n) {
       using ConvolutionFunction::ConvolveInZ;
       ConvolveInZ<RealPixel> conv(input, _Kernel->Data(), _Kernel->X(), true, n);
@@ -170,9 +170,9 @@ void GaussianBlurring<VoxelType>::Run()
   }
 
   // Blur along t axis
-  if (_SigmaT != .0 && input->T() > 1) {
+  if (!AreEqual(_SigmaT, 0.) && input->T() > 1) {
     if (output == this->Input()) output = new GenericImage<VoxelType>(attr);
-    this->InitializeKernel(_SigmaT / input->GetTSize());
+    this->InitializeKernel(_SigmaT / input->TSize());
     using ConvolutionFunction::ConvolveInT;
     ConvolveInT<RealPixel> conv(input, _Kernel->Data(), _Kernel->X(), true);
     ParallelForEachVoxel(attr, input, output, conv);
@@ -186,7 +186,7 @@ void GaussianBlurring<VoxelType>::Run()
       if (output != this->Input()) Delete(output);
     } else {
       this->Output()->CopyFrom(input->Data());
-      if (input != this->Input ()) Delete(input);
+      if (input != this->Input()) Delete(input);
     }
   }
 

--- a/Modules/Image/src/GaussianBlurringWithPadding.cc
+++ b/Modules/Image/src/GaussianBlurringWithPadding.cc
@@ -1,9 +1,9 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2008-2015 Imperial College London
+ * Copyright 2008-2017 Imperial College London
  * Copyright 2008-2013 Daniel Rueckert, Julia Schnabel
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2017 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,12 +87,12 @@ void GaussianBlurringWithPadding<VoxelType>::Run()
   GenericImage<VoxelType> *output = this->Output();
 
   const ImageAttributes &attr = input->Attributes();
-  const int N = ((attr._dt == .0) ? attr._t : 1);
+  const int N = (AreEqual(attr._dt, 0.) ? attr._t : 1);
 
   // Blur along x axis
-  if (this->_SigmaX != .0 && input->X() > 1) {
+  if (!AreEqual(this->_SigmaX, 0.) && input->X() > 1) {
     if (output == this->Input()) output = new GenericImage<VoxelType>(attr);
-    this->InitializeKernel(this->_SigmaX / input->GetXSize());
+    this->InitializeKernel(this->_SigmaX / input->XSize());
     typedef ConvolutionFunction::ConvolveTruncatedForegroundInX<RealPixel> Conv;
     for (int n = 0; n < N; ++n) {
       Conv conv(input, _PaddingValue, this->_Kernel->Data(), this->_Kernel->X(), true, n);
@@ -102,9 +102,9 @@ void GaussianBlurringWithPadding<VoxelType>::Run()
   }
 
   // Blur along y axis
-  if (this->_SigmaY != .0 && input->Y() > 1) {
+  if (!AreEqual(this->_SigmaY, 0.) && input->Y() > 1) {
     if (output == this->Input()) output = new GenericImage<VoxelType>(attr);
-    this->InitializeKernel(this->_SigmaY / input->GetYSize());
+    this->InitializeKernel(this->_SigmaY / input->YSize());
     typedef ConvolutionFunction::ConvolveTruncatedForegroundInY<RealPixel> Conv;
     for (int n = 0; n < N; ++n) {
       Conv conv(input, _PaddingValue, this->_Kernel->Data(), this->_Kernel->X(), true, n);
@@ -114,9 +114,9 @@ void GaussianBlurringWithPadding<VoxelType>::Run()
   }
 
   // Blur along z axis
-  if (this->_SigmaZ != .0 && input->Z() > 1) {
+  if (!AreEqual(this->_SigmaZ, 0.) && input->Z() > 1) {
     if (output == this->Input()) output = new GenericImage<VoxelType>(attr);
-    this->InitializeKernel(this->_SigmaZ / input->GetZSize());
+    this->InitializeKernel(this->_SigmaZ / input->ZSize());
     typedef ConvolutionFunction::ConvolveTruncatedForegroundInZ<RealPixel> Conv;
     for (int n = 0; n < N; ++n) {
       Conv conv(input, _PaddingValue, this->_Kernel->Data(), this->_Kernel->X(), true, n);
@@ -126,9 +126,9 @@ void GaussianBlurringWithPadding<VoxelType>::Run()
   }
 
   // Blur along t axis
-  if (this->_SigmaT != .0 && input->T() > 1) {
+  if (!AreEqual(this->_SigmaT, 0.) && input->T() > 1) {
     if (output == this->Input()) output = new GenericImage<VoxelType>(attr);
-    this->InitializeKernel(this->_SigmaT / input->GetTSize());
+    this->InitializeKernel(this->_SigmaT / input->TSize());
     typedef ConvolutionFunction::ConvolveTruncatedForegroundInT<RealPixel> Conv;
     Conv conv(input, _PaddingValue, this->_Kernel->Data(), this->_Kernel->X(), true);
     ParallelForEachVoxel(attr, input, output, conv);
@@ -142,7 +142,7 @@ void GaussianBlurringWithPadding<VoxelType>::Run()
       if (output != this->Input()) Delete(output);
     } else {
       this->Output()->CopyFrom(input->Data());
-      if (input != this->Input ()) Delete(input);
+      if (input != this->Input()) Delete(input);
     }
   }
 

--- a/Modules/Image/src/GradientImageFilter.cc
+++ b/Modules/Image/src/GradientImageFilter.cc
@@ -1,9 +1,9 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2008-2015 Imperial College London
+ * Copyright 2008-2017 Imperial College London
  * Copyright 2008-2013 Daniel Rueckert, Julia Schnabel
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2017 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -230,7 +230,7 @@ GradientImageFilter<VoxelType>::GradientImageFilter(GradientType type)
   _Type(type),
   _UseVoxelSize(true),
   _UseOrientation(false),
-  _PaddingValue(-numeric_limits<double>::infinity())
+  _PaddingValue(-inf)
 {
 }
 
@@ -243,11 +243,11 @@ template <class VoxelType>
 void GradientImageFilter<VoxelType>::Initialize()
 {
   // Check inputs and outputs
-  if (this->Input() == NULL) {
+  if (this->Input() == nullptr) {
     cerr << this->NameOfClass() << "::Initialize: Filter has no input" << endl;
     exit(1);
   }
-  if (this->Output() == NULL) {
+  if (this->Output() == nullptr) {
     cerr << this->NameOfClass() << "::Initialize: Filter has no output" << endl;
     exit(1);
   }
@@ -265,7 +265,7 @@ void GradientImageFilter<VoxelType>::Initialize()
     this->Buffer(this->Output());
     this->Output(new GenericImage<VoxelType>());
   } else {
-    this->Buffer(NULL);
+    this->Buffer(nullptr);
   }
 
   // Initialize output image
@@ -288,7 +288,7 @@ void GradientImageFilter<VoxelType>::Run()
   Matrix R;
   if (_UseOrientation) R = attr.GetWorldToImageOrientation();
   EvaluateImageGradient<VoxelType> eval(
-    _Type, this->Input(), _PaddingValue, _UseVoxelSize, _UseOrientation ? &R : NULL
+    _Type, this->Input(), _PaddingValue, _UseVoxelSize, _UseOrientation ? &R : nullptr
   );
   ParallelForEachVoxel(attr, this->Output(), eval);
 
@@ -303,7 +303,7 @@ void GradientImageFilter<VoxelType>::Finalize()
     this->Buffer()->CopyFrom(this->Output()->Data());
     delete this->Output();
     this->Output(this->Buffer());
-    this->Buffer(NULL);
+    this->Buffer(nullptr);
   }
 }
 

--- a/Modules/Image/src/ImageAttributes.cc
+++ b/Modules/Image/src/ImageAttributes.cc
@@ -543,7 +543,9 @@ Matrix ImageAttributes::GetWorldToLatticeMatrix() const
 // -----------------------------------------------------------------------------
 void ImageAttributes::PutAffineMatrix(const Matrix &m, bool apply)
 {
-  if (apply) {
+  if (m.IsIdentity()) {
+    _smat.Ident();
+  } else if (apply) {
     // Split transformation into composition of affine 9 DoF transformation
     // without shearing which is applied directly to the image attributes,
     // and a residual shearing transformation stored as additional transformation

--- a/Modules/Image/src/InterpolateImageFunction.cc
+++ b/Modules/Image/src/InterpolateImageFunction.cc
@@ -284,6 +284,7 @@ mirtkInterpolatorInstantiations(GenericInterpolateImageFunction);
 
 // ND
 template class GenericNearestNeighborInterpolateImageFunction<ByteImage>;
+template class GenericLinearInterpolateImageFunction<ByteImage>;
 mirtkInterpolatorInstantiations(GenericNearestNeighborInterpolateImageFunction);
 mirtkInterpolatorInstantiations(GenericLinearInterpolateImageFunction);
 mirtkInterpolatorInstantiations(GenericBSplineInterpolateImageFunction);
@@ -294,6 +295,7 @@ mirtkInterpolatorInstantiations(GenericGaussianInterpolateImageFunction);
 mirtkInterpolatorInstantiations(GenericSincInterpolateImageFunction);
 
 // 2D
+template class GenericLinearInterpolateImageFunction2D<ByteImage>;
 mirtkInterpolatorInstantiations(GenericLinearInterpolateImageFunction2D);
 mirtkInterpolatorInstantiations(GenericBSplineInterpolateImageFunction2D);
 mirtkInterpolatorInstantiations(GenericCubicBSplineInterpolateImageFunction2D);
@@ -303,6 +305,7 @@ mirtkInterpolatorInstantiations(GenericGaussianInterpolateImageFunction2D);
 mirtkInterpolatorInstantiations(GenericSincInterpolateImageFunction2D);
 
 // 3D
+template class GenericLinearInterpolateImageFunction3D<ByteImage>;
 mirtkInterpolatorInstantiations(GenericLinearInterpolateImageFunction3D);
 mirtkInterpolatorInstantiations(GenericBSplineInterpolateImageFunction3D);
 mirtkInterpolatorInstantiations(GenericCubicBSplineInterpolateImageFunction3D);
@@ -312,6 +315,7 @@ mirtkInterpolatorInstantiations(GenericGaussianInterpolateImageFunction3D);
 mirtkInterpolatorInstantiations(GenericSincInterpolateImageFunction3D);
 
 // 4D
+template class GenericLinearInterpolateImageFunction4D<ByteImage>;
 mirtkInterpolatorInstantiations(GenericLinearInterpolateImageFunction4D);
 mirtkInterpolatorInstantiations(GenericBSplineInterpolateImageFunction4D);
 mirtkInterpolatorInstantiations(GenericCubicBSplineInterpolateImageFunction4D);

--- a/Modules/Image/src/Resampling.cc
+++ b/Modules/Image/src/Resampling.cc
@@ -75,9 +75,8 @@ void Resampling<VoxelType>::Initialize()
   ImageToImage<VoxelType>::Initialize(false);
 
   // Set up interpolator
-  if (_Interpolator == NULL) {
-    cerr << "Resampling::Initialize: No interpolator found!" << endl;
-    exit(1);
+  if (_Interpolator == nullptr) {
+    Throw(ERR_InvalidArgument, __FUNCTION__, "Interpolator must be set");
   }
   _Interpolator->Input(this->_Input);
   _Interpolator->Initialize();

--- a/Modules/Image/src/Resampling.cc
+++ b/Modules/Image/src/Resampling.cc
@@ -97,11 +97,10 @@ void Resampling<VoxelType>::InitializeOutput()
     attr._dx = _XSize;
   } else if (_X > 0) {
     attr._x  = _X;
-    attr._dx = this->_Input->X() * this->_Input->GetXSize() / static_cast<double>(_X);
-  } else if (_XSize > 0) {
-    attr._x  = iround(this->_Input->X() * this->_Input->GetXSize() / this->_XSize);
-    if (attr._x < 1) attr._x  = 1;
-    else             attr._dx = _XSize;
+    attr._dx = this->_Input->X() * this->_Input->XSize() / static_cast<double>(_X);
+  } else if (_XSize > 0 && this->_Input->XSize() > 0. && this->_Input->X() > 1) {
+    attr._x  = iceil(this->_Input->X() * this->_Input->XSize() / this->_XSize);
+    attr._dx = _XSize;
   }
 
   if (_Y > 0 && _YSize > 0) {
@@ -109,11 +108,10 @@ void Resampling<VoxelType>::InitializeOutput()
     attr._dy = _YSize;
   } else if (_Y > 0) {
     attr._y  = _Y;
-    attr._dy = this->_Input->Y() * this->_Input->GetYSize() / static_cast<double>(_Y);
-  } else if (_YSize > 0) {
-    attr._y  = iround(this->_Input->Y() * this->_Input->GetYSize() / this->_YSize);
-    if (attr._y < 1) attr._y  = 1;
-    else             attr._dy = _YSize;
+    attr._dy = this->_Input->Y() * this->_Input->YSize() / static_cast<double>(_Y);
+  } else if (_YSize > 0 && this->_Input->YSize() > 0. && this->_Input->Y() > 1) {
+    attr._y  = iceil(this->_Input->Y() * this->_Input->YSize() / this->_YSize);
+    attr._dy = _YSize;
   }
   
   if (_Z > 0 && _ZSize > 0) {
@@ -121,11 +119,10 @@ void Resampling<VoxelType>::InitializeOutput()
     attr._dz = _ZSize;
   } else if (_Z > 0) {
     attr._z  = _Z;
-    attr._dz = this->_Input->Z() * this->_Input->GetZSize() / static_cast<double>(_Z);
-  } else if (_ZSize > 0) {
-    attr._z  = iround(this->_Input->Z() * this->_Input->GetZSize() / this->_ZSize);
-    if (attr._z < 1) attr._z  = 1;
-    else             attr._dz = _ZSize;
+    attr._dz = this->_Input->Z() * this->_Input->ZSize() / static_cast<double>(_Z);
+  } else if (_ZSize > 0 && this->_Input->ZSize() > 0. && this->_Input->Z() > 1) {
+    attr._z  = iceil(this->_Input->Z() * this->_Input->ZSize() / this->_ZSize);
+    attr._dz = _ZSize;
   }
 
   this->_Output->Initialize(attr);

--- a/Modules/Numerics/include/mirtk/AdaptiveLineSearch.h
+++ b/Modules/Numerics/include/mirtk/AdaptiveLineSearch.h
@@ -78,6 +78,9 @@ public:
   // ---------------------------------------------------------------------------
   // Optimization
 
+  /// Initialize optimization
+  virtual void Initialize();
+
   /// Make optimal step along search direction
   virtual double Run();
 

--- a/Modules/Numerics/include/mirtk/EnergyThreshold.h
+++ b/Modules/Numerics/include/mirtk/EnergyThreshold.h
@@ -67,12 +67,11 @@ public:
   /// Test stopping criterion
   ///
   /// \param[in] iter  Current number of iterations.
-  /// \param[in] prev  Objective function value at previous iteration (unused).
-  /// \param[in] value Objective function value at current  iteration (unused).
+  /// \param[in] value Objective function value at current iteration.
   /// \param[in] delta Last change of objective function parameters.
   ///
   /// \returns Whether stopping criterion is fulfilled.
-  virtual bool Fulfilled(int iter, double prev, double value, const double *delta);
+  virtual bool Fulfilled(int iter, double value, const double *delta);
 
   // ---------------------------------------------------------------------------
   // Logging

--- a/Modules/Numerics/include/mirtk/InexactLineSearch.h
+++ b/Modules/Numerics/include/mirtk/InexactLineSearch.h
@@ -52,6 +52,8 @@ class InexactLineSearch : public LineSearch
   ///    previously accumulated total step length is being reused.
   /// 1: Incremental steps are strictly limited to [min, max].
   /// 2: Accumulated total step length is strictly limited to [min, max].
+  /// 3: Equivalent to 2, but indicates that both incremental and accumulated
+  ///    step length ranges have been restricted.
   mirtkPublicAttributeMacro(int, StrictStepLengthRange);
 
   /// Whether to refuse any function parameter sign changes

--- a/Modules/Numerics/include/mirtk/LineSearch.h
+++ b/Modules/Numerics/include/mirtk/LineSearch.h
@@ -117,6 +117,9 @@ public:
   // ---------------------------------------------------------------------------
   // Optimization
 
+  /// Initialize optimization
+  virtual void Initialize();
+
   /// Make optimal step along search direction
   /// \returns New value of objective function or previous if no step successful
   virtual double Run() = 0;

--- a/Modules/Numerics/include/mirtk/LocalOptimizer.h
+++ b/Modules/Numerics/include/mirtk/LocalOptimizer.h
@@ -24,6 +24,7 @@
 
 #include "mirtk/Math.h"
 #include "mirtk/Array.h"
+#include "mirtk/Queue.h"
 #include "mirtk/OptimizationMethod.h"
 #include "mirtk/ObjectiveFunction.h"
 #include "mirtk/ObjectFactory.h"
@@ -57,6 +58,15 @@ class LocalOptimizer : public Observable
 
   /// Second convergence criterium: Required maximum change of DoFs
   mirtkPublicAttributeMacro(double, Delta);
+
+  /// Last n objective function values
+  mirtkReadOnlyAttributeMacro(Deque<double>, LastValues);
+
+  /// Current slope of curve fit to last n function values
+  mirtkReadOnlyAttributeMacro(double, LastValuesSlope);
+
+  /// Number of last objective function values to store
+  mirtkPublicAttributeMacro(int, NumberOfLastValues);
 
   /// Whether optimization converged within maximum number of steps
   mirtkReadOnlyAttributeMacro(bool, Converged);
@@ -145,19 +155,18 @@ protected:
   /// value after a change of the parameters must be evaluated before this
   /// function is called to be able to provide this value as argument.
   ///
-  /// \note The objective function value may be NaN in case of a non-parametric
+  /// \note The objective function value may be infinite in case of a non-parametric
   ///       deformable surface model. In this case, stopping criteria are based
   ///       only on the current surface geometry or last node displacements.
   ///       Stopping criteria based on the objective function value should
   ///       never be fulfilled in this case and always return \c false.
   ///
   /// \param[in] iter  Current number of iterations.
-  /// \param[in] prev  Objective function value at previous iteration.
-  /// \param[in] value Objective function value at current  iteration.
+  /// \param[in] value Objective function value at current iteration.
   /// \param[in] delta Last change of objective function parameters.
   ///
   /// \returns True when at least one stopping criterion is fulfilled.
-  virtual bool Converged(int iter, double prev, double value, const double *delta);
+  virtual bool Converged(int iter, double value, const double *delta);
 
   // ---------------------------------------------------------------------------
   // Optimization

--- a/Modules/Numerics/include/mirtk/StoppingCriterion.h
+++ b/Modules/Numerics/include/mirtk/StoppingCriterion.h
@@ -87,19 +87,18 @@ public:
   /// value after a change of the parameters must be evaluated before this
   /// function is called to be able to provide this value as argument.
   ///
-  /// \note The objective function value may be NaN in case of a non-parametric
+  /// \note The objective function value may be infinite in case of a non-parametric
   ///       deformable surface model. In this case, stopping criteria are based
   ///       only on the current surface geometry or last node displacements.
   ///       Stopping criteria based on the objective function value should
   ///       never be fulfilled in this case and always return \c false.
   ///
   /// \param[in] iter  Current number of iterations.
-  /// \param[in] prev  Objective function value at previous iteration.
-  /// \param[in] value Objective function value at current  iteration.
+  /// \param[in] value Objective function value at current iteration.
   /// \param[in] delta Last change of objective function parameters.
   ///
   /// \returns Whether stopping criterion is fulfilled.
-  virtual bool Fulfilled(int iter, double prev, double value, const double *delta) = 0;
+  virtual bool Fulfilled(int iter, double value, const double *delta) = 0;
 
   // ---------------------------------------------------------------------------
   // Logging

--- a/Modules/Numerics/src/EnergyThreshold.cc
+++ b/Modules/Numerics/src/EnergyThreshold.cc
@@ -77,7 +77,7 @@ EnergyThreshold::~EnergyThreshold()
 // =============================================================================
 
 // -----------------------------------------------------------------------------
-bool EnergyThreshold::Fulfilled(int, double, double value, const double *)
+bool EnergyThreshold::Fulfilled(int, double value, const double *)
 {
   return value <= _Threshold;
 }

--- a/Modules/Numerics/src/GradientDescent.cc
+++ b/Modules/Numerics/src/GradientDescent.cc
@@ -257,6 +257,8 @@ double GradientDescent::Run()
 
     // Get initial value of (modified) energy function
     value = _Function->Value();
+    _LastValues.clear();
+    _LastValues.push_back(value);
 
     // Current number of iterations
     const int iter = step.Iter();
@@ -301,8 +303,11 @@ double GradientDescent::Run()
       if (_Epsilon < .0) _LineSearch->Epsilon(abs(_Epsilon * value));
 
       // Check convergence
-      _Converged = (value == _LineSearch->CurrentValue())
-          || Converged(step.Iter(), _LineSearch->CurrentValue(), value, _Gradient);
+      if (_LineSearch->StepLength() > 0.) {
+        _Converged = this->Converged(step.Iter(), value, _Gradient);
+      } else {
+        _Converged = true;
+      }
 
       // Notify observers about end of gradient descent iteration
       Broadcast(IterationEndEvent, &step);

--- a/Modules/Numerics/src/GradientDescent.cc
+++ b/Modules/Numerics/src/GradientDescent.cc
@@ -153,17 +153,19 @@ bool GradientDescent::Set(const char *name, const char *value)
   if (strcmp(name, "Line search strategy") == 0) {
     return FromString(value, _LineSearchStrategy);
   }
-  if (strstr(name, "line search")                      != NULL ||
-      strstr(name, "line iterations")                  != NULL ||
+  if (strstr(name, "line search") != NULL ||
+      strstr(name, "line iterations") != NULL ||
       strcmp(name, "Maximum streak of rejected steps") == 0    ||
-      strcmp(name, "Length of steps")                  == 0    ||
-      strcmp(name, "Minimum length of steps")          == 0    ||
-      strcmp(name, "Maximum length of steps")          == 0    ||
-      strcmp(name, "Strict step length range")         == 0    ||
-      strcmp(name, "Strict total step length range")   == 0    ||
-      strcmp(name, "Step length rise")                 == 0    ||
-      strcmp(name, "Step length drop")                 == 0    ||
-      strcmp(name, "Reuse previous step length")       == 0) {
+      strcmp(name, "Length of steps")  == 0 ||
+      strcmp(name, "Minimum length of steps") == 0 ||
+      strcmp(name, "Maximum length of steps") == 0 ||
+      strcmp(name, "Strict step length range") == 0 ||
+      strcmp(name, "Strict total step length range") == 0 ||
+      strcmp(name, "Strict incremental step length range") == 0 ||
+      strcmp(name, "Strict accumulated step length range") == 0 ||
+      strcmp(name, "Step length rise") == 0 ||
+      strcmp(name, "Step length drop") == 0 ||
+      strcmp(name, "Reuse previous step length") == 0) {
     Insert(_LineSearchParameter, name, value);
     return true;
   }
@@ -210,12 +212,12 @@ void GradientDescent::Initialize()
   // Initialize line search object
   _LineSearch->Function   (Function());
   _LineSearch->Parameter  (_LineSearchParameter);
-  _LineSearch->StepLength (_LineSearch->MaxStepLength());
   _LineSearch->Delta      (_Delta);
   _LineSearch->Epsilon    (max(.0, _Epsilon));
   _LineSearch->Direction  (_Gradient);
   _LineSearch->Revert     (true);
   _LineSearch->AddObserver(_EventDelegate);
+  _LineSearch->Initialize();
   // Check line search parameters
   if (_LineSearch->MaxStepLength() == .0) {
     cerr << this->NameOfClass() << "::Initialize: Line search interval length is zero!" << endl;

--- a/Modules/Numerics/src/InexactLineSearch.cc
+++ b/Modules/Numerics/src/InexactLineSearch.cc
@@ -125,14 +125,22 @@ bool InexactLineSearch::Set(const char *name, const char *value)
       strcmp(name, "Strict incremental step length range") == 0) {
     bool limit_increments;
     if (!FromString(value, limit_increments)) return false;
-    _StrictStepLengthRange = limit_increments ? 1 : 0;
+    if (limit_increments) {
+      _StrictStepLengthRange |= 1;
+    } else {
+      _StrictStepLengthRange &= ~1;
+    }
     return true;
   }
   if (strcmp(name, "Strict total step length range")       == 0 ||
       strcmp(name, "Strict accumulated step length range") == 0) {
     bool limit_step;
     if (!FromString(value, limit_step)) return false;
-    _StrictStepLengthRange = limit_step ? 2 : 0;
+    if (limit_step) {
+      _StrictStepLengthRange |= 2;
+    } else {
+      _StrictStepLengthRange &= ~2;
+    }
     return true;
   }
   return LineSearch::Set(name, value);
@@ -144,11 +152,8 @@ ParameterList InexactLineSearch::Parameter() const
   ParameterList params = LineSearch::Parameter();
   Insert(params, "Maximum streak of rejected steps", _MaxRejectedStreak);
   Insert(params, "Reuse previous step length",       _ReusePreviousStepLength);
-  if (_StrictStepLengthRange == 2) {
-    Insert(params, "Strict total step length range", true);
-  } else {
-    Insert(params, "Strict incremental step length range", _StrictStepLengthRange != 0);
-  }
+  Insert(params, "Strict incremental step length range", (_StrictStepLengthRange & 1) != 0);
+  Insert(params, "Strict total step length range", (_StrictStepLengthRange & 2) != 0);
   return params;
 }
 

--- a/Modules/Numerics/src/InexactLineSearch.cc
+++ b/Modules/Numerics/src/InexactLineSearch.cc
@@ -122,14 +122,14 @@ bool InexactLineSearch::Set(const char *name, const char *value)
   // Whether [min, max] step length range is strict
   }
   if (strcmp(name, "Strict step length range")             == 0 ||
-             strcmp(name, "Strict incremental step length range") == 0) {
+      strcmp(name, "Strict incremental step length range") == 0) {
     bool limit_increments;
     if (!FromString(value, limit_increments)) return false;
     _StrictStepLengthRange = limit_increments ? 1 : 0;
     return true;
   }
   if (strcmp(name, "Strict total step length range")       == 0 ||
-             strcmp(name, "Strict accumulated step length range") == 0) {
+      strcmp(name, "Strict accumulated step length range") == 0) {
     bool limit_step;
     if (!FromString(value, limit_step)) return false;
     _StrictStepLengthRange = limit_step ? 2 : 0;

--- a/Modules/Numerics/src/LineSearch.cc
+++ b/Modules/Numerics/src/LineSearch.cc
@@ -169,5 +169,27 @@ ParameterList LineSearch::Parameter() const
   return params;
 }
 
+// =============================================================================
+// Optimization
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+void LineSearch::Initialize()
+{
+  // Initialize base class
+  LocalOptimizer::Initialize();
+
+  // Check parameters
+  if (_MinStepLength <= 0.) {
+    Throw(ERR_InvalidArgument, __FUNCTION__, "Minimum length of steps must be positive, but is ", _MinStepLength);
+  }
+  if (_MaxStepLength < _MinStepLength) {
+    Throw(ERR_InvalidArgument, __FUNCTION__, "Maximum length of steps must be greater or equal minimum length, but is ", _MaxStepLength);
+  }
+
+  // Set initial step length
+  _StepLength = _MaxStepLength;
+}
+
 
 } // namespace mirtk

--- a/Modules/Numerics/src/Matrix.cc
+++ b/Modules/Numerics/src/Matrix.cc
@@ -939,7 +939,7 @@ bool Matrix::IsIdentity() const
 
   for (int c = 0; c < _cols; ++c)
   for (int r = 0; r < _rows; ++r) {
-    if (_matrix[c][r] != static_cast<double>(r == c)) return false;
+    if (!AreEqual(_matrix[c][r], r == c ? 1. : 0., 1e-6)) return false;
   }
 
   return true;
@@ -957,7 +957,7 @@ bool Matrix::IsSymmetric() const
   if (_rows == 0 || _cols == 0 || _rows != _cols) return false;
   for (int c = 0; c < _cols; ++c)
   for (int r = 0; r < _rows; ++r) {
-    if (!fequal(_matrix[c][r], _matrix[r][c], 1e-6)) return false;
+    if (!AreEqual(_matrix[c][r], _matrix[r][c], 1e-6)) return false;
   }
   return true;
 }
@@ -971,7 +971,7 @@ bool Matrix::IsDiagonalizable() const
   Matrix AAT = (*this) * AT;
   for (int c = 0; c < _cols; ++c)
   for (int r = 0; r < _rows; ++r) {
-    if (!fequal(AAT(r, c), ATA(r, c), 1e-6)) return false;
+    if (!AreEqual(AAT(r, c), ATA(r, c), 1e-6)) return false;
   }
   return true;
 }

--- a/Modules/PointSet/include/mirtk/ImplicitSurfaceUtils.h
+++ b/Modules/PointSet/include/mirtk/ImplicitSurfaceUtils.h
@@ -94,7 +94,7 @@ inline double Evaluate(const DistanceFunction &dist, const double p[3], double o
     x = clamp(x, xmin, xmax);
     y = clamp(y, ymin, ymax);
     z = clamp(z, zmin, zmax);
-    d = max(0., dist.GetInside(x, y, z));
+    d = max(0., static_cast<double>(dist.GetInside(x, y, z)));
     dist.ImageToWorld(x, y, z);
     x -= p[0], y -= p[1], z -= p[2];
     d += sqrt(x*x + y*y + z*z);
@@ -111,7 +111,9 @@ inline void Evaluate(const DistanceGradient &gradient, const double p[3], double
   if (gradient.IsInside(x, y, z)) {
     DistanceGradient::GradientType v = gradient.GetInside(x, y, z);
     if (normalize) v.Normalize();
-    g[0] = v._x, g[1] = v._y, g[2] = v._z;
+    g[0] = static_cast<double>(v._x);
+    g[1] = static_cast<double>(v._y);
+    g[2] = static_cast<double>(v._z);
   } else {
     g[0] = g[1] = g[2] = .0;
   }
@@ -941,7 +943,7 @@ DistanceImage Evaluate(double maxh, const DistanceImage &dmap,
     output.ImageToWorld(p[0], p[1], p[2]);
     d.Evaluate(p, dirs, minh, maxh, distance, offset, tol);
     for (int l = 0; l < output.T(); ++l) {
-      output(i, j, k, l) = d.Get(l);
+      output(i, j, k, l) = static_cast<DistanceImage::VoxelType>(d.Get(l));
     }
   }
 

--- a/Modules/Registration/include/mirtk/GenericRegistrationFilter.h
+++ b/Modules/Registration/include/mirtk/GenericRegistrationFilter.h
@@ -290,6 +290,19 @@ public:
   /// Whether to allow z coordinate transformation
   mirtkPublicAttributeMacro(bool, RegisterZ);
 
+  /// Enforce Dirichlet boundary condition on FFD transformations
+  ///
+  /// When this option is enabled, the status of control points at the
+  /// boundary of the finite FFD lattice is set to Passive and the parameters
+  /// of these control points set to zero. This is always the case for FFDs
+  /// whose parameters are control point displacements. In case of FFDs
+  /// parameterized by (stationary) velocities, the default extrapolation
+  /// mode is nearest neighbor, however, and a layer of passive CPs with
+  /// constant value is needed if the velocity should be forced to zero
+  /// outside the finite domain on which the velocity field is defined.
+  /// Alternatively, FFD extrapolation mode "Const" can be used.
+  mirtkPublicAttributeMacro(bool, DirichletBoundaryCondition);
+
   /// Mask which defines where to evaluate the energy function
   mirtkPublicAggregateMacro(BinaryImage, Domain);
 

--- a/Modules/Registration/include/mirtk/GenericRegistrationFilter.h
+++ b/Modules/Registration/include/mirtk/GenericRegistrationFilter.h
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2017 Imperial College London
+ * Copyright 2013-2017 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,16 +82,16 @@ class GenericRegistrationFilter : public RegistrationFilter
 public:
 
   /// Type of resolution pyramid images
-  typedef RegisteredImage::InputImageType         ResampledImageType;
+  typedef RegisteredImage::InputImageType   ResampledImageType;
 
   /// List type storing images for one resolution pyramid level
-  typedef Array<ResampledImageType>               ResampledImageList;
+  typedef Array<ResampledImageType>   ResampledImageList;
 
   /// Scalar type of resolution pyramid images
-  typedef ResampledImageType::VoxelType           VoxelType;
+  typedef ResampledImageType::VoxelType   VoxelType;
 
   /// Type of cached displacement field
-  typedef GenericImage<double>                    DisplacementImageType;
+  typedef RegisteredImage::DisplacementImageType   DisplacementImageType;
 
   /// Structure storing information about transformation instance
   struct TransformationInfo
@@ -238,11 +238,27 @@ public:
   /// Transformation model
   mirtkPublicAttributeMacro(Array<enum TransformationModel>, TransformationModel);
 
-  ///< Default image interpolation mode
+  /// Default image interpolation mode
   mirtkPublicAttributeMacro(enum InterpolationMode, DefaultInterpolationMode);
 
-  ///< Default image extrapolation mode
+  /// Default image extrapolation mode
   mirtkPublicAttributeMacro(enum ExtrapolationMode, DefaultExtrapolationMode);
+
+  /// Rescale input image intensities from [imin, imax] to [0, omax]
+  ///
+  /// Here [imin, imax] is the intensity range of the respective input image
+  /// excluding the background (if specified) and omax is the maximum intensity
+  /// of the rescaled intensities. This maximum value influences the relative
+  /// weighting of image similarity gradient vs. the gradient of constraint terms
+  /// such as the bending energy.
+  ///
+  /// This normalization ensures that the magnitude of image derivatives used
+  /// for energy gradient computation have comparable magnitude in order to
+  /// prevent one image to have stronger influence than another. This is more
+  /// important for symmetric, inverse consistent, or multi-modal settings.
+  ///
+  /// By default, this parameter is set to inf and no rescaling is done.
+  mirtkPublicAttributeMacro(double, MaxRescaledIntensity);
 
   /// Whether to precompute image derivatives or compute them on the fly
   mirtkPublicAttributeMacro(bool, PrecomputeDerivatives);
@@ -315,11 +331,9 @@ protected:
   Array<double>              _MinEdgeLength[MAX_NO_RESOLUTIONS]; ///< Minimum edge length in mm
   Array<double>              _MaxEdgeLength[MAX_NO_RESOLUTIONS]; ///< Maximum edge length in mm
   int                        _UseGaussianResolutionPyramid;   ///< Whether resolution levels correspond to a Gaussian pyramid
-  Array<double>              _Blurring  [MAX_NO_RESOLUTIONS]; ///< Image blurring value
+  Array<double>              _Blurring[MAX_NO_RESOLUTIONS];   ///< Image blurring value
   double                     _DefaultBackground;              ///< Default background value
   Array<double>              _Background;                     ///< Image background value
-  double                     _DefaultPadding;                 ///< Default padding value
-  Array<double>              _Padding;                        ///< Image padding value
   bool                       _DownsampleWithPadding;          ///< Whether to take background into account
                                                               ///< during initialization of the image pyramid
   bool                       _CropPadImages;                  ///< Whether to crop/pad input images

--- a/Modules/Registration/include/mirtk/GradientFieldSimilarity.h
+++ b/Modules/Registration/include/mirtk/GradientFieldSimilarity.h
@@ -44,11 +44,11 @@ class GradientFieldSimilarity : public ImageSimilarity
 
   /// Transformed gradient of the target image
   /// Used only if the target image is being transformed
-  mirtkAttributeMacro(GradientImageType, TargetTransformedGradient);
+  mirtkAttributeMacro(GenericImage<RegisteredImage::VoxelType>, TargetTransformedGradient);
 
   /// Transformed gradient of the source image
   /// Used only if the source image is being transformed
-  mirtkAttributeMacro(GradientImageType, SourceTransformedGradient);
+  mirtkAttributeMacro(GenericImage<RegisteredImage::VoxelType>, SourceTransformedGradient);
 
   // ---------------------------------------------------------------------------
   // Construction/Destruction

--- a/Modules/Registration/include/mirtk/ImageSimilarity.h
+++ b/Modules/Registration/include/mirtk/ImageSimilarity.h
@@ -67,13 +67,13 @@ class ImageSimilarity : public DataFidelity
 public:
 
   /// Voxel type of registered images
-  typedef RegisteredImage::VoxelType           VoxelType;
-
-  /// Type of similarity gradient image
-  typedef RegisteredImage::GradientImageType   GradientImageType;
+  typedef RegisteredImage::VoxelType   VoxelType;
 
   /// Type of similarity gradient components
-  typedef GradientImageType::VoxelType         GradientType;
+  typedef double   GradientType;
+
+  /// Type of similarity gradient image
+  typedef GenericImage<GradientType>   GradientImageType;
 
   // ---------------------------------------------------------------------------
   // Attributes

--- a/Modules/Registration/include/mirtk/ImageSimilarity.h
+++ b/Modules/Registration/include/mirtk/ImageSimilarity.h
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2017 Imperial College London
+ * Copyright 2013-2017 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,6 +75,19 @@ public:
   /// Type of similarity gradient image
   typedef GenericImage<GradientType>   GradientImageType;
 
+  /// Enumeration of available set operations to define region within which
+  /// to evaluate the image similarity given the two foreground regions of
+  /// the two co-registered input images. The resulting foreground region
+  /// is further intersected with the specified binary mask. When no mask
+  /// is given, a mask with constant value 1 is assumed.
+  enum ForegroundRegion
+  {
+    FG_Mask,     ///< Evaluate similarity for all voxels in image domain
+    FG_Target,   ///< Evaluate similarity for foreground of untransformed image
+    FG_Overlap,  ///< Evaluate similarity for intersection of foreground regions
+    FG_Union     ///< Evaluate similarity for union of foreground regions
+  };
+
   // ---------------------------------------------------------------------------
   // Attributes
 
@@ -84,11 +97,19 @@ public:
   /// (Transformed) Source image
   mirtkLooseComponentMacro(RegisteredImage, Source);
 
-  /// Domain on which to evaluate similarity
+  /// Finite regular domain on which to resample images and evaluate similarity
   mirtkPublicAttributeMacro(ImageAttributes, Domain);
 
+  /// Set operation used to define common foreground region of co-registered images
+  mirtkPublicAttributeMacro(ForegroundRegion, Foreground);
+
   /// Mask which defines arbitrary domain on which the similarity is evaluated
-  mirtkPublicAggregateMacro(BinaryImage,     Mask);
+  ///
+  /// Intensities outside the mask (i.e., mask value is zero) are excluded from
+  /// the similarity comparison. The foreground domain of the registered image
+  /// is the intersection of the domain defined by non-zero mask entries with
+  /// the foreground domain used when no mask is set.
+  mirtkPublicAggregateMacro(BinaryImage, Mask);
 
   /// Memory for (non-parametric) similarity gradient w.r.t target transformation
   mirtkComponentMacro(GradientImageType, GradientWrtTarget);
@@ -415,52 +436,69 @@ public:
 // Inline definitions
 ////////////////////////////////////////////////////////////////////////////////
 
+// ----------------------------------------------------------------------------
+template <>
+inline string ToString(const ImageSimilarity::ForegroundRegion &value, int w, char c, bool left)
+{
+  const char *str;
+  switch (value) {
+    case ImageSimilarity::FG_Mask:    str = "Mask"; break;
+    case ImageSimilarity::FG_Target:  str = "Target"; break;
+    case ImageSimilarity::FG_Overlap: str = "Overlap"; break;
+    case ImageSimilarity::FG_Union:   str = "Union"; break;
+    default:                          str = "Unknown"; break;
+  }
+  return ToString(str, w, c, left);
+}
+
+// ----------------------------------------------------------------------------
+template <>
+inline bool FromString(const char *str, ImageSimilarity::ForegroundRegion &value)
+{
+  string lstr = ToLower(str);
+  if (lstr == "mask" || lstr == "including background" || lstr == "incl. background") {
+    value = ImageSimilarity::FG_Mask;
+  } else if (lstr == "target" || lstr == "target foreground" || lstr == "excluding target background" || lstr == "excl. target background") {
+    value = ImageSimilarity::FG_Target;
+  } else if (lstr == "overlap" || lstr == "intersection" || lstr == "excluding background" || lstr == "excl. background") {
+    value = ImageSimilarity::FG_Overlap;
+  } else if (lstr == "union") {
+    value = ImageSimilarity::FG_Union;
+  } else {
+    return false;
+  }
+  return true;
+}
+
 // -----------------------------------------------------------------------------
 inline bool ImageSimilarity::IsForeground(int idx) const
 {
-  // Never evaluate similarity outside explicitly specified domain
-  if (_Mask && !_Mask->Get(idx)) return false;
-  // If both images are transformed (symmetric registration)...
-  if (_Target->Transformation() && _Source->Transformation()) {
-    // ... evaluate within union of foreground regions
-    return _Target->IsForeground(idx) || _Source->IsForeground(idx);
-  // If second image is transformed...
-  } else if (_Source->Transformation()) {
-    // ... try to match masked region of transformed image if given
-    if (_Source->HasMask()) return _Source->IsForeground(idx);
-    // ... otherwise evaluate similarity for each untransformed voxel,
-    //     but consider that similarity gradient is anyway zero for voxels
-    //     that are mapped outside the transformed image foreground
-    return _Source->IsForeground(idx) && _Target->IsForeground(idx);
-  // If first image is transformed same as above with reversed order though
-  } else {
-    if (_Target->HasMask()) return _Target->IsForeground(idx);
-    return _Target->IsForeground(idx) && _Source->IsForeground(idx);
+  if (_Mask && !_Mask->Get(idx)) {
+    // Never evaluate similarity outside explicitly specified domain
+    return false;
   }
+  switch (_Foreground) {
+    case FG_Mask:
+      return true;
+    case FG_Target:
+      if ((_Source->Transformation() == nullptr) != (_Target->Transformation() == nullptr)) {
+        // Either both or none of the images is being tranformed
+        return _Source->IsForeground(idx) || _Target->IsForeground(idx);
+      }
+      // Only one of the image is being transformed
+      if (_Target->Transformation()) return _Source->IsForeground(idx);
+      else                           return _Target->IsForeground(idx);
+    case FG_Overlap:
+      return _Source->IsForeground(idx) && _Target->IsForeground(idx);
+    case FG_Union:
+      return _Source->IsForeground(idx) || _Target->IsForeground(idx);
+  };
 }
 
 // -----------------------------------------------------------------------------
 inline bool ImageSimilarity::IsForeground(int i, int j, int k) const
 {
-  // Never evaluate similarity outside explicitly specified domain
-  if (_Mask && !_Mask->Get(i, j, k)) return false;
-  // If both images are transformed (symmetric registration)...
-  if (_Target->Transformation() && _Source->Transformation()) {
-    // ... evaluate within union of foreground regions
-    return _Target->IsForeground(i, j, k) || _Source->IsForeground(i, j, k);
-  // If second image is transformed...
-  } else if (_Source->Transformation()) {
-    // ... try to match masked region of transformed image if given
-    if (_Source->HasMask()) return _Source->IsForeground(i, j, k);
-    // ... otherwise evaluate similarity for each untransformed voxel,
-    //     but consider that similarity gradient is anyway zero for voxels
-    //     that are mapped outside the transformed image foreground
-    return _Source->IsForeground(i, j, k) && _Target->IsForeground(i, j, k);
-  // If first image is transformed same as above with reversed order though
-  } else {
-    if (_Target->HasMask()) return _Target->IsForeground(i, j, k);
-    return _Target->IsForeground(i, j, k) && _Source->IsForeground(i, j, k);
-  }
+  return IsForeground(_Domain.LatticeToIndex(i, j, k));
 }
 
 

--- a/Modules/Registration/include/mirtk/NormalizedIntensityCrossCorrelation.h
+++ b/Modules/Registration/include/mirtk/NormalizedIntensityCrossCorrelation.h
@@ -42,9 +42,9 @@ class NormalizedIntensityCrossCorrelation : public ImageSimilarity
   // Types
 public:
 
-  typedef voxel_info<VoxelType>::RealType   RealType;
-  typedef GenericImage<RealType>            RealImage;
-  typedef GenericImage<RealPixel>           KernelImage;
+  typedef GradientImageType::VoxelType   RealType;
+  typedef GenericImage<RealType>         RealImage;
+  typedef GenericImage<RealType>         KernelImage;
 
   /// Enumeration of local window size units
   enum Units { UNITS_Default, UNITS_MM, UNITS_Voxel };
@@ -112,7 +112,7 @@ private:
   // Construction/Destruction
 
   /// Create 1D Gaussian kernel with given standard deviation
-  static RealImage *CreateGaussianKernel(double);
+  static KernelImage *CreateGaussianKernel(double);
 
   /// Reset local window kernel
   virtual void ClearKernel();

--- a/Modules/Registration/include/mirtk/RegistrationEnergy.h
+++ b/Modules/Registration/include/mirtk/RegistrationEnergy.h
@@ -71,6 +71,14 @@ private:
   /// \attention The use of this option is experimental!
   mirtkPublicAttributeMacro(bool, NormalizeGradients);
 
+  /// Exclude values of transformation constraint from total energy value
+  ///
+  /// The gradient of the energy function always includes the gradient
+  /// of the transformation constraint terms which have non-zero weight.
+  /// When this option is enabled, the transformation constraints have
+  /// no direct influence on the stopping criteria.
+  mirtkPublicAttributeMacro(bool, ExcludeConstraints);
+
   /// Energy gradient preconditioning sigma used to supress noise.
   /// A non-positive value disables the preconditioning all together.
   ///
@@ -113,11 +121,26 @@ public:
   /// Whether energy function has no terms
   bool Empty() const;
 
+  /// Whether the n-th energy term has non-zero weight
+  bool IsActive(int) const;
+
+  /// Whether the n-th energy term is a data term
+  bool IsDataTerm(int) const;
+
+  /// Whether the n-th energy term is a penalty term
+  bool IsConstraint(int) const;
+
   /// Number of energy terms
   int NumberOfTerms() const;
 
   /// Number of energy terms with non-zero weight
   int NumberOfActiveTerms() const;
+
+  /// Number of data terms, i.e., with base type DataFidelity
+  int NumberOfDataTerms() const;
+
+  /// Number of penalty terms, i.e., with base type TransformationConstraint
+  int NumberOfConstraints() const;
 
   /// Add energy term and take over ownership of the object
   void Add(EnergyTerm *);

--- a/Modules/Registration/src/CosineOfNormalizedGradientField.cc
+++ b/Modules/Registration/src/CosineOfNormalizedGradientField.cc
@@ -83,8 +83,8 @@ public:
     _Cnt += rhs._Cnt;
   }
 
-  template <class T>
-  void operator()(int i, int j, int k, int, const T *dF, const T *dM)
+  template <class TGradient>
+  void operator ()(int i, int j, int k, int, const TGradient *dF, const TGradient *dM)
   {
 
     if (_Similarity->IsForeground(i, j, k)) {
@@ -132,8 +132,8 @@ public:
     _z         (2 * _y)
   {}
 
-  template <class T>
-  void operator()(int i, int j, int k, int, const T *dF, const T *dM, T *g)
+  template <class TGradient, class TReal>
+  void operator ()(int i, int j, int k, int, const TGradient *dF, const TGradient *dM, TReal *g)
   {
     if (_Similarity->IsForeground(i, j, k)) {
       const int    power = _Similarity->Power();

--- a/Modules/Registration/src/GenericRegistrationFilter.cc
+++ b/Modules/Registration/src/GenericRegistrationFilter.cc
@@ -1391,7 +1391,7 @@ bool GenericRegistrationFilter::Set(const char *param, const char *value, int le
     // Convert to signed "units"
     if (units != "signed") {
       if (sigma < .0) {
-        cerr << "Value of paramter '" << name << "' with units " << units << " must be positive!" << endl;
+        cerr << "Value of parameter '" << name << "' with units " << units << " must be positive!" << endl;
         return false;
       }
       if (units == "vox") {
@@ -2386,22 +2386,22 @@ void GenericRegistrationFilter::GuessParameter()
   if (!Contains(_Parameter[0], MINSTEP) && !Contains(_Parameter[0], MAXSTEP)) {
     // By default, limit step length to one (target) voxel unit
     const double maxres = max(avgres[0], max(avgres[1], avgres[2]));
-    Insert(_Parameter[0], MINSTEP, ToString(maxres / 100.0));
-    Insert(_Parameter[0], MAXSTEP, ToString(maxres));
+    Insert(_Parameter[0], MINSTEP, maxres / 100.);
+    Insert(_Parameter[0], MAXSTEP, maxres);
   } else if (!Contains(_Parameter[0], MINSTEP)) {
     if (!FromString(Get(_Parameter[0], MAXSTEP).c_str(), value)) {
       cerr << "GenericRegistrationFilter::GuessParameter: Invalid '"
            << MAXSTEP << "' argument: " << Get(_Parameter[0], MAXSTEP) << endl;
       exit(1);
     }
-    Insert(_Parameter[0], MINSTEP, ToString(value / 100.0));
+    Insert(_Parameter[0], MINSTEP, value / 100.);
   } else if (!Contains(_Parameter[0], MAXSTEP)) {
     if (!FromString(Get(_Parameter[0], MINSTEP).c_str(), value)) {
       cerr << "GenericRegistrationFilter::GuessParameter: Invalid '"
            << MINSTEP << "' argument: " << Get(_Parameter[0], MINSTEP) << endl;
       exit(1);
     }
-    Insert(_Parameter[0], MAXSTEP, ToString(value * 100.0));
+    Insert(_Parameter[0], MAXSTEP, value * 100.);
   }
   for (int level = 1; level <= _NumberOfLevels; ++level) {
     if (!Contains(_Parameter[level], MINSTEP) && !Contains(_Parameter[level], MAXSTEP)) {
@@ -2410,14 +2410,13 @@ void GenericRegistrationFilter::GuessParameter()
              << MINSTEP << "' argument: " << Get(_Parameter[level-1], MINSTEP) << endl;
         exit(1);
       }
-      if (level > 1) value *= 2.0;
       Insert(_Parameter[level], MINSTEP, ToString(value));
       if (!FromString(Get(_Parameter[level-1], MAXSTEP).c_str(), value)) {
         cerr << "GenericRegistrationFilter::GuessParameter: Invalid '"
              << MAXSTEP << "' argument: " << Get(_Parameter[level-1], MAXSTEP) << endl;
         exit(1);
       }
-      if (level > 1) value *= 2.0;
+      if (level > 1) value = min(2. * value, 8.);
       Insert(_Parameter[level], MAXSTEP, ToString(value));
     } else if (!Contains(_Parameter[level], MINSTEP)) {
       if (!FromString(Get(_Parameter[level], MAXSTEP).c_str(), value)) {
@@ -2425,14 +2424,14 @@ void GenericRegistrationFilter::GuessParameter()
              << MAXSTEP << "' argument: " << Get(_Parameter[level], MAXSTEP) << endl;
         exit(1);
       }
-      Insert(_Parameter[level], MINSTEP, ToString(value / 100.0));
+      Insert(_Parameter[level], MINSTEP, value / 100.);
     } else if (!Contains(_Parameter[level], MAXSTEP)) {
       if (!FromString(Get(_Parameter[level], MINSTEP).c_str(), value)) {
         cerr << "GenericRegistrationFilter::GuessParameter: Invalid '"
              << MINSTEP << "' argument: " << Get(_Parameter[level], MINSTEP) << endl;
         exit(1);
       }
-      Insert(_Parameter[level], MAXSTEP, ToString(value * 100.0));
+      Insert(_Parameter[level], MAXSTEP, value * 100.);
     }
   }
 }
@@ -4207,12 +4206,12 @@ void GenericRegistrationFilter::InitializeEnergy()
   if (_NormalizeWeights) {
     double W = .0;
     for (int i = 0; i < _Energy.NumberOfTerms(); ++i) {
-      if (dynamic_cast<const DataFidelity *>(_Energy.Term(i))) {
+      if (_Energy.IsDataTerm(i)) {
         W += abs(_Energy.Term(i)->Weight());
       }
     }
     for (int i = 0; i < _Energy.NumberOfTerms(); ++i) {
-      if (dynamic_cast<const DataFidelity *>(_Energy.Term(i))) {
+      if (_Energy.IsDataTerm(i)) {
         _Energy.Term(i)->Weight(_Energy.Term(i)->Weight() / W);
       }
     }

--- a/Modules/Registration/src/GenericRegistrationFilter.cc
+++ b/Modules/Registration/src/GenericRegistrationFilter.cc
@@ -2455,6 +2455,7 @@ void GenericRegistrationFilter::Write(const char *fname) const
       PrintParameter(to, it->first, it->second);
     }
   }
+  to.close();
 }
 
 // =============================================================================

--- a/Modules/Registration/src/GenericRegistrationFilter.cc
+++ b/Modules/Registration/src/GenericRegistrationFilter.cc
@@ -2447,10 +2447,9 @@ void GenericRegistrationFilter::Write(const char *fname) const
   }
   PrintVersion(to, "## Version");
   for (int level = 0; level <= _NumberOfLevels; ++level) {
-    to << endl << "#" << endl << "# Registration parameters";
-    if (level > 0) to << " for resolution level " << level;
-    to << endl << "#" << endl << endl;
-    if (level > 0) PrintParameter(to, "Resolution level", level);
+    to << "\n";
+    if (level == 0) to << "[default]\n";
+    else to << "[level " << level << "]\n";
     ParameterList params = this->Parameter(level);
     for (ParameterConstIterator it = params.begin(); it != params.end(); ++it) {
       PrintParameter(to, it->first, it->second);

--- a/Modules/Registration/src/GenericRegistrationFilter.cc
+++ b/Modules/Registration/src/GenericRegistrationFilter.cc
@@ -3645,7 +3645,6 @@ void GenericRegistrationFilter::InitializeOutput()
   _Transformation->Verify();
 
   // Memorize (all) used (non-DoF) transformation settings for -parout file
-  ParameterList params = _Transformation->Parameter();
   Insert(_Parameter[_CurrentLevel], _Transformation->Parameter());
 
   MIRTK_DEBUG_TIMING(3, "initialization of output");

--- a/Modules/Registration/src/GenericRegistrationLogger.cc
+++ b/Modules/Registration/src/GenericRegistrationLogger.cc
@@ -438,17 +438,19 @@ void GenericRegistrationLogger::HandleEvent(Observable *obj, Event event, const 
         if (_NumberOfSteps > 0) {
           if (_Verbosity > 0) {
             if (step->_Info && strcmp(step->_Info, "incremental") == 0) {
-              os << "\n               Gradient scale = ";
-              PrintNumber(os, step->_TotalLength) << " / ";
+              os << "\n            Gradient scale = ";
+              PrintNumber(os, step->_TotalLength) << " /";
               PrintNumber(os, step->_Unit) << "\n";
+              os <<   "            Max. delta     = ";
+              PrintNumber(os, step->_TotalDelta) << "\n";
             } else {
-              os << "\n               Gradient scale = ";
+              os << "\n            Gradient scale = ";
               PrintNumber(os, step->_TotalLength / step->_Unit) << "\n";
             }
           }
         } else {
           if (step->_Delta < reg->_Optimizer->Delta()) {
-            os << "\n         Converged (Max. Delta <= " << setprecision(1) << scientific << reg->_Optimizer->Delta() << ")\n";
+            os << "\n         Converged, max. delta <= " << setprecision(1) << scientific << reg->_Optimizer->Delta() << "\n";
           } else {
             os << "\n         No further improvement within search range\n";
           }
@@ -462,7 +464,7 @@ void GenericRegistrationLogger::HandleEvent(Observable *obj, Event event, const 
       if (_Verbosity > 0) {
         if (_Color) os << xboldblack;
         if (_NumberOfSteps > 0) {
-          os << "               Energy slope   = ";
+          os << "            Energy slope   = ";
           PrintNumber(os, reg->_Optimizer->LastValuesSlope()) << "\n";
         }
         if (reg->_Optimizer->Converged()) {
@@ -470,7 +472,7 @@ void GenericRegistrationLogger::HandleEvent(Observable *obj, Event event, const 
           double value   = reg->_Optimizer->LastValues().back();
           if (epsilon < 0.) epsilon = abs(epsilon * value);
           if (abs(reg->_Optimizer->LastValuesSlope()) < epsilon) {
-            os << "\n        Converged (Avg. Change < " << setprecision(1) << scientific << epsilon << ")\n";
+            os << "\n        Converged, energy slope < " << setprecision(1) << scientific << epsilon << "\n";
           }
         }
         os << "\n";

--- a/Modules/Registration/src/ImageSimilarity.cc
+++ b/Modules/Registration/src/ImageSimilarity.cc
@@ -81,9 +81,9 @@ public:
   template <class Image, class TScalar, class TReal>
   void operator ()(const Image &, int, const TScalar *dI, TReal *gradient)
   {
-    (*gradient) *= dI[_dx]; gradient += _NumberOfVoxels;
-    (*gradient) *= dI[_dy]; gradient += _NumberOfVoxels;
-    (*gradient) *= dI[_dz];
+    (*gradient) *= static_cast<TReal>(dI[_dx]); gradient += _NumberOfVoxels;
+    (*gradient) *= static_cast<TReal>(dI[_dy]); gradient += _NumberOfVoxels;
+    (*gradient) *= static_cast<TReal>(dI[_dz]);
   }
 };
 
@@ -123,7 +123,10 @@ public:
   template <class Image, class TReal>
   void operator ()(const Image &, int, TReal *gradient)
   {
-    double norm = pow(gradient[_x], 2) + pow(gradient[_y], 2) + pow(gradient[_z], 2);
+    double gx = static_cast<double>(gradient[_x]);
+    double gy = static_cast<double>(gradient[_y]);
+    double gz = static_cast<double>(gradient[_z]);
+    double norm = gx * gx + gy * gy + gz * gz;
     if (norm > _norm) _norm = norm;
   }
 };
@@ -207,12 +210,15 @@ public:
   template <class Image, class TReal>
   void operator ()(const Image &, int, TReal *gradient)
   {
-    double norm = pow(gradient[_x], 2) + pow(gradient[_y], 2) + pow(gradient[_z], 2);
+    double gx = static_cast<double>(gradient[_x]);
+    double gy = static_cast<double>(gradient[_y]);
+    double gz = static_cast<double>(gradient[_z]);
+    double norm = gx * gx + gy * gy + gz * gz;
     if (norm) {
       norm = sqrt(norm) + _Sigma;
-      gradient[_x] /= norm;
-      gradient[_y] /= norm;
-      gradient[_z] /= norm;
+      gradient[_x] = static_cast<TReal>(gx / norm);
+      gradient[_y] = static_cast<TReal>(gy / norm);
+      gradient[_z] = static_cast<TReal>(gz / norm);
     }
   }
 };

--- a/Modules/Registration/src/ImageSimilarity.cc
+++ b/Modules/Registration/src/ImageSimilarity.cc
@@ -284,7 +284,7 @@ ImageSimilarity::ImageSimilarity(const char *name, double weight)
   DataFidelity(name, weight),
   _Target(new RegisteredImage()), _TargetOwner(true),
   _Source(new RegisteredImage()), _SourceOwner(true),
-  _Foreground              (FG_Target),
+  _Foreground              (FG_Overlap),
   _Mask                    (nullptr),
   _GradientWrtTarget       (nullptr),
   _GradientWrtSource       (nullptr),

--- a/Modules/Registration/test/testRegisteredImage.cc
+++ b/Modules/Registration/test/testRegisteredImage.cc
@@ -65,9 +65,9 @@ TEST(RegisteredImage, IdentityTransformation)
 TEST(RegisteredImage, GlobalAndLocalTransformation)
 {
   // Allocate images
-  ImageAttributes      attr(64, 64, 32);
-  GenericImage<double> image(attr);
-  RegisteredImage      source;
+  ImageAttributes attr(64, 64, 32);
+  RegisteredImage::InputImageType image(attr);
+  RegisteredImage source;
   // Initialize untransformed source image such that voxels can be distinguished
   fill_test_image(image);
   // Prepare global transformation which translates image one voxel in y

--- a/Modules/Transformation/include/mirtk/RegisteredImage.h
+++ b/Modules/Transformation/include/mirtk/RegisteredImage.h
@@ -149,15 +149,6 @@ public:
   /// Maximum foreground intensity of warped image or NaN
   mirtkPublicAttributeMacro(double, MaxIntensity);
 
-  /// Intensity value used to pad this image when transformed point is outside
-  /// the foreground of the input image. When NaN (default), the background
-  /// value of the input image is used. When the input image has no background
-  /// value set, the minimum input intensity is used instead.
-  ///
-  /// When this value is set and the input image has no background value set,
-  /// it is used as background value when computing the input derivatives.
-  mirtkPublicAttributeMacro(double, OutsideValue);
-
   /// Standard deviation of Gaussian smoothing kernel applied before
   /// 1st order derivative computations in voxel units
   mirtkPublicAttributeMacro(double, GradientSigma);

--- a/Modules/Transformation/include/mirtk/RegisteredImage.h
+++ b/Modules/Transformation/include/mirtk/RegisteredImage.h
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2017 Imperial College London
+ * Copyright 2013-2017 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ class RegisteredImage : public GenericImage<double>
 public:
 
   // Do not override other base class overloads
-  using GenericImage<double>::ImageToWorld;
+  using GenericImage<VoxelType>::ImageToWorld;
 
   // ---------------------------------------------------------------------------
   // Types
@@ -84,13 +84,13 @@ public:
   enum Channel { I = 0, Dx, Dy, Dz, Dxx, Dxy, Dxz, Dyx, Dyy, Dyz, Dzx, Dzy, Dzz };
 
   /// Type of untransformed input image
-  typedef GenericImage<double>   InputImageType;
+  typedef GenericImage<VoxelType>   InputImageType;
 
   /// Type of untransformed gradient image
-  typedef GenericImage<double>   GradientImageType;
+  typedef GenericImage<VoxelType>   InputGradientType;
 
   /// Type of untransformed Hessian image
-  typedef GenericImage<double>   HessianImageType;
+  typedef GenericImage<VoxelType>   InputHessianType;
 
   /// Type of cached displacement fields
   typedef GenericImage<double>   DisplacementImageType;
@@ -102,10 +102,10 @@ public:
   mirtkPublicAggregateMacro(InputImageType, InputImage);
 
   /// Untransformed input gradient image
-  mirtkPublicComponentMacro(GradientImageType, InputGradient);
+  mirtkPublicComponentMacro(InputGradientType, InputGradient);
 
   /// Untransformed input Hessian image
-  mirtkPublicComponentMacro(HessianImageType, InputHessian);
+  mirtkPublicComponentMacro(InputHessianType, InputHessian);
 
   /// Current transformation estimate
   mirtkPublicAggregateMacro(const class Transformation, Transformation);
@@ -149,6 +149,15 @@ public:
   /// Maximum foreground intensity of warped image or NaN
   mirtkPublicAttributeMacro(double, MaxIntensity);
 
+  /// Intensity value used to pad this image when transformed point is outside
+  /// the foreground of the input image. When NaN (default), the background
+  /// value of the input image is used. When the input image has no background
+  /// value set, the minimum input intensity is used instead.
+  ///
+  /// When this value is set and the input image has no background value set,
+  /// it is used as background value when computing the input derivatives.
+  mirtkPublicAttributeMacro(double, OutsideValue);
+
   /// Standard deviation of Gaussian smoothing kernel applied before
   /// 1st order derivative computations in voxel units
   mirtkPublicAttributeMacro(double, GradientSigma);
@@ -161,6 +170,14 @@ public:
   /// true:  Compute derivatives of input image and transform these
   /// false: Use derivative of interpolation kernel to evaluate image derivative
   mirtkPublicAttributeMacro(bool, PrecomputeDerivatives);
+
+  /// Maximum gradient magnitude as percentile of all gradient magnitudes
+  ///
+  /// \note Used only when _PrecomputeDerivatives is enabled.
+  mirtkPublicAttributeMacro(int, MaxGradientPercentile);
+
+  /// When positive and not inf, linearly rescale gradient vectors to this maximum magnitude
+  mirtkPublicAttributeMacro(double, MaxGradientMagnitude);
 
 protected:
 

--- a/Modules/Transformation/src/RegisteredImage.cc
+++ b/Modules/Transformation/src/RegisteredImage.cc
@@ -767,7 +767,7 @@ public:
     }
     if (inside && check_value && _InterpolateWithPadding) {
       double value = _IntensityFunction->EvaluateWithPadding(x, y, z);
-      if (value == _IntensityFunction->DefaultValue()) inside = false;
+      if (IsNaN(value) || AreEqual(value, _IntensityFunction->DefaultValue(), 1e-6)) inside = false;
     }
     if (inside) return 1;
     if (0. <= x && x <= _InputSize._x - 1. &&
@@ -799,8 +799,8 @@ public:
           *o = _IntensityFunction->EvaluateOutside(x, y, z);
         }
       }
-      // Set background to output padding value
-      if (*o == _IntensityFunction->DefaultValue()) {
+      // Set background to outside value
+      if (IsNaN(*o) || AreEqual(*o, _IntensityFunction->DefaultValue(), 1e-6)) {
         *o = _PaddingValue;
         if (_InterpolateWithPadding) return -1;
       // Rescale/clamp foreground to [min, max] range

--- a/Modules/Transformation/src/RegisteredImage.cc
+++ b/Modules/Transformation/src/RegisteredImage.cc
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2017 Imperial College London
+ * Copyright 2013-2017 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@
 #include "mirtk/ImageGradientFunction.h"
 #include "mirtk/FluidFreeFormTransformation.h"
 #include "mirtk/Vector3D.h"
+#include "mirtk/DataStatistics.h"
 
 #include "mirtk/LinearInterpolateImageFunction.hxx"  // incl. inline definitions
 #include "mirtk/FastLinearImageGradientFunction.hxx" // incl. inline definitions
@@ -41,29 +42,134 @@
 namespace mirtk {
 
 
+// =============================================================================
+// Auxiliaries
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+/// Voxel function used to compute squared magnitude of image gradient vectors
+class CalculateSquaredGradientMagnitude : public VoxelFunction
+{
+  Array<double> *_SquaredMagnitude;
+  const bool    *_Mask;
+
+  const int _x = 0;
+  int _y, _z;
+
+public:
+
+  CalculateSquaredGradientMagnitude(const BaseImage *gradient, Array<double> *mag2, const bool *mask = nullptr)
+  :
+    _SquaredMagnitude(mag2), _Mask(mask),
+    _y(gradient->NumberOfSpatialVoxels()), _z(_y + _y)
+  {}
+
+  template <class TImage, class T>
+  void operator ()(const TImage&, int vox, const T *g) const
+  {
+    if (_Mask && !_Mask[vox]) {
+      (*_SquaredMagnitude)[vox] = 0.;
+    } else {
+      const double gx = static_cast<double>(g[_x]);
+      const double gy = static_cast<double>(g[_y]);
+      const double gz = static_cast<double>(g[_z]);
+      (*_SquaredMagnitude)[vox] = gx * gx + gy * gy + gz * gz;
+    }
+  }
+};
+
+// -----------------------------------------------------------------------------
+/// Voxel function used to clamp magnitude of image gradient vectors
+class ClampSquaredGradientMagnitude : public VoxelFunction
+{
+  Array<double> *_SquaredMagnitude;
+  double         _SquaredThreshold;
+
+  const int _x = 0;
+  int _y, _z;
+
+public:
+
+  ClampSquaredGradientMagnitude(const BaseImage *gradient, Array<double> *mag2, double thres2)
+  :
+    _SquaredMagnitude(mag2), _SquaredThreshold(thres2),
+    _y(gradient->NumberOfSpatialVoxels()), _z(_y + _y)
+  {}
+
+  template <class TImage, class T>
+  void operator ()(const TImage&, int vox, T *g) const
+  {
+    double &mag2 = (*_SquaredMagnitude)[vox];
+    if (mag2 > _SquaredThreshold) {
+      const double scale = sqrt(_SquaredThreshold / mag2);
+      g[_x] = static_cast<T>(scale * static_cast<double>(g[_x]));
+      g[_y] = static_cast<T>(scale * static_cast<double>(g[_y]));
+      g[_z] = static_cast<T>(scale * static_cast<double>(g[_z]));
+      mag2 = _SquaredThreshold;
+    }
+  }
+};
+
+// -----------------------------------------------------------------------------
+/// Voxel function used to rescale magnitude of image gradient vectors
+class RescaleSquaredGradientMagnitude : public VoxelFunction
+{
+  const Array<double> *_SquaredMagnitude;
+  double               _Scale;
+
+  const int _x = 0;
+  int _y, _z;
+
+public:
+
+  RescaleSquaredGradientMagnitude(const BaseImage *gradient, const Array<double> *mag2, double thres2)
+  :
+    _SquaredMagnitude(mag2),
+    _y(gradient->NumberOfSpatialVoxels()), _z(_y + _y)
+  {
+    double max2 = data::statistic::Max::Calculate(static_cast<int>(mag2->size()), mag2->data());
+    _Scale = sqrt(thres2 / max2);
+  }
+
+  template <class TImage, class T>
+  void operator ()(const TImage&, int vox, T *g) const
+  {
+    g[_x] = static_cast<T>(_Scale * static_cast<double>(g[_x]));
+    g[_y] = static_cast<T>(_Scale * static_cast<double>(g[_y]));
+    g[_z] = static_cast<T>(_Scale * static_cast<double>(g[_z]));
+  }
+};
+
+// =============================================================================
+// Registered image
+// =============================================================================
+
 // -----------------------------------------------------------------------------
 RegisteredImage::RegisteredImage()
 :
-  _InputImage            (NULL),
-  _InputGradient         (NULL),
-  _InputHessian          (NULL),
-  _Transformation        (NULL),
+  _InputImage            (nullptr),
+  _InputGradient         (nullptr),
+  _InputHessian          (nullptr),
+  _Transformation        (nullptr),
   _InterpolationMode     (Interpolation_Default),
   _ExtrapolationMode     (Extrapolation_Default),
-  _WorldCoordinates      (NULL),
-  _ImageToWorld          (NULL),
-  _ExternalDisplacement  (NULL),
-  _FixedDisplacement     (NULL),
-  _Displacement          (NULL),
+  _WorldCoordinates      (nullptr),
+  _ImageToWorld          (nullptr),
+  _ExternalDisplacement  (nullptr),
+  _FixedDisplacement     (nullptr),
+  _Displacement          (nullptr),
   _CacheWorldCoordinates (true),  // FIXME: MUST be true to also cache anything else...
   _CacheFixedDisplacement(false), // by default, only if required by transformation
   _CacheDisplacement     (false), // (c.f. Transformation::RequiresCachingOfDisplacements)
   _SelfUpdate            (true),
   _MinIntensity          (NaN),
   _MaxIntensity          (NaN),
-  _GradientSigma         (.0),
-  _HessianSigma          (.0),
+  _OutsideValue          (NaN),
+  _GradientSigma         (0.),
+  _HessianSigma          (0.),
   _PrecomputeDerivatives (false),
+  _MaxGradientPercentile (0),
+  _MaxGradientMagnitude  (0.),
   _NumberOfActiveLevels  (0),
   _NumberOfPassiveLevels (0)
 {
@@ -73,27 +179,30 @@ RegisteredImage::RegisteredImage()
 // -----------------------------------------------------------------------------
 RegisteredImage::RegisteredImage(const RegisteredImage &other)
 :
-  GenericImage<double>(other),
+  GenericImage<VoxelType>(other),
   _InputImage            (other._InputImage),
-  _InputGradient         (other._InputGradient  ? new GradientImageType(*other._InputGradient)  : NULL),
-  _InputHessian          (other._InputHessian   ? new GradientImageType(*other._InputHessian)   : NULL),
+  _InputGradient         (other._InputGradient ? new InputGradientType(*other._InputGradient) : nullptr),
+  _InputHessian          (other._InputHessian ? new InputHessianType(*other._InputHessian) : nullptr),
   _Transformation        (other._Transformation),
   _InterpolationMode     (other._InterpolationMode),
   _ExtrapolationMode     (other._ExtrapolationMode),
   _WorldCoordinates      (other._WorldCoordinates),
-  _ImageToWorld          (other._ImageToWorld      ? new WorldCoordsImage (*other._ImageToWorld)      : NULL),
+  _ImageToWorld          (other._ImageToWorld ? new WorldCoordsImage (*other._ImageToWorld) : nullptr),
   _ExternalDisplacement  (other._ExternalDisplacement),
-  _FixedDisplacement     (other._FixedDisplacement ? new DisplacementImageType(*other._FixedDisplacement) : NULL),
-  _Displacement          (other._Displacement      ? new DisplacementImageType(*other._Displacement)      : NULL),
+  _FixedDisplacement     (other._FixedDisplacement ? new DisplacementImageType(*other._FixedDisplacement) : nullptr),
+  _Displacement          (other._Displacement ? new DisplacementImageType(*other._Displacement) : nullptr),
   _CacheWorldCoordinates (other._CacheWorldCoordinates),
   _CacheFixedDisplacement(other._CacheFixedDisplacement),
   _CacheDisplacement     (other._CacheDisplacement),
   _SelfUpdate            (other._SelfUpdate),
   _MinIntensity          (other._MinIntensity),
   _MaxIntensity          (other._MaxIntensity),
+  _OutsideValue          (other._OutsideValue),
   _GradientSigma         (other._GradientSigma),
   _HessianSigma          (other._HessianSigma),
   _PrecomputeDerivatives (other._PrecomputeDerivatives),
+  _MaxGradientPercentile (other._MaxGradientPercentile),
+  _MaxGradientMagnitude  (other._MaxGradientMagnitude),
   _NumberOfActiveLevels  (other._NumberOfActiveLevels),
   _NumberOfPassiveLevels (other._NumberOfPassiveLevels)
 {
@@ -103,27 +212,30 @@ RegisteredImage::RegisteredImage(const RegisteredImage &other)
 // -----------------------------------------------------------------------------
 RegisteredImage &RegisteredImage::operator =(const RegisteredImage &other)
 {
-  GenericImage<double>::operator =(other);
+  GenericImage<VoxelType>::operator =(other);
   _InputImage             = other._InputImage;
-  _InputGradient          = other._InputGradient  ? new GradientImageType(*other._InputGradient)  : NULL;
-  _InputHessian           = other._InputHessian   ? new GradientImageType(*other._InputHessian)   : NULL;
+  _InputGradient          = other._InputGradient ? new InputGradientType(*other._InputGradient) : nullptr;
+  _InputHessian           = other._InputHessian ? new InputHessianType(*other._InputHessian) : nullptr;
   _Transformation         = other._Transformation;
   _InterpolationMode      = other._InterpolationMode;
   _ExtrapolationMode      = other._ExtrapolationMode;
   _WorldCoordinates       = other._WorldCoordinates;
-  _ImageToWorld           = other._ImageToWorld      ? new WorldCoordsImage (*other._ImageToWorld)      : NULL;
+  _ImageToWorld           = other._ImageToWorld ? new WorldCoordsImage(*other._ImageToWorld) : nullptr;
   _ExternalDisplacement   = other._ExternalDisplacement;
-  _FixedDisplacement      = other._FixedDisplacement ? new DisplacementImageType(*other._FixedDisplacement) : NULL;
-  _Displacement           = other._Displacement      ? new DisplacementImageType(*other._Displacement)      : NULL;
+  _FixedDisplacement      = other._FixedDisplacement ? new DisplacementImageType(*other._FixedDisplacement) : nullptr;
+  _Displacement           = other._Displacement ? new DisplacementImageType(*other._Displacement) : nullptr;
   _CacheWorldCoordinates  = other._CacheWorldCoordinates;
   _CacheFixedDisplacement = other._CacheFixedDisplacement;
   _CacheDisplacement      = other._CacheDisplacement;
   _SelfUpdate             = other._SelfUpdate;
   _MinIntensity           = other._MinIntensity;
   _MaxIntensity           = other._MaxIntensity;
+  _OutsideValue           = other._OutsideValue;
   _GradientSigma          = other._GradientSigma;
   _HessianSigma           = other._HessianSigma;
   _PrecomputeDerivatives  = other._PrecomputeDerivatives;
+  _MaxGradientPercentile  = other._MaxGradientPercentile;
+  _MaxGradientMagnitude   = other._MaxGradientMagnitude;
   _NumberOfActiveLevels   = other._NumberOfActiveLevels;
   _NumberOfPassiveLevels  = other._NumberOfPassiveLevels;
   memcpy(_Offset, other._Offset, 13 * sizeof(int));
@@ -136,9 +248,10 @@ RegisteredImage::~RegisteredImage()
   if (_ImageToWorld != _WorldCoordinates) delete _ImageToWorld;
   delete _FixedDisplacement;
   delete _Displacement;
-  if (_InputGradient != _InputImage) delete _InputGradient;
+  if ((void *)_InputGradient != (void *)_InputImage) delete _InputGradient;
   delete _InputHessian;
 }
+
 // =============================================================================
 // Initialization
 // =============================================================================
@@ -156,30 +269,18 @@ void RegisteredImage::Initialize(const ImageAttributes &attr, int t)
 
   // Check if input image is set
   if (!_InputImage) {
-    cerr << "RegisteredImage::Initialize: Missing input image" << endl;
-    exit(1);
+    Throw(ERR_InvalidArgument, __FUNCTION__, "Missing input image");
   }
 
   // Initialize base class
   if (attr._t > 1) {
-    cerr << "RegisteredImage::Initialize: Split multi-channel image/temporal sequence up into separate 2D/3D images" << endl;
-    exit(1);
+    Throw(ERR_InvalidArgument, __FUNCTION__, "Split multi-channel image/temporal sequence up into separate 2D/3D images");
   }
   if (t == 0) t = 1;
   if (t != 1 && t != 4 && t != 10 && t != 13) {
-    cerr << "RegisteredImage::Initialize: Number of registered image channels must be either 1, 4, 10 or 13" << endl;
-    exit(1);
+    Throw(ERR_InvalidArgument, __FUNCTION__, "Number of registered image channels must be either 1, 4, 10 or 13");
   }
-  GenericImage<double>::Initialize(attr, t);
-
-  // Set background value/foreground mask
-  if (_InputImage->HasBackgroundValue()) {
-    this->PutBackgroundValueAsDouble(_InputImage->GetBackgroundValueAsDouble());
-  } else {
-    double min, max;
-    _InputImage->GetMinMaxAsDouble(&min, &max);
-    this->PutBackgroundValueAsDouble(min - 1.);
-  }
+  GenericImage<VoxelType>::Initialize(attr, t);
 
   // Pre-compute world coordinates
   if (_WorldCoordinates) {
@@ -196,7 +297,7 @@ void RegisteredImage::Initialize(const ImageAttributes &attr, int t)
 
   // Determine number of active (changing) and passive (fixed) levels
   bool cache_fixed = !_ExternalDisplacement && _CacheFixedDisplacement;
-  const MultiLevelTransformation *mffd = NULL;
+  const MultiLevelTransformation *mffd = nullptr;
   if ((mffd = dynamic_cast<const MultiLevelTransformation *>(_Transformation))) {
     _NumberOfPassiveLevels = 0;
     for (int l = 0; l < mffd->NumberOfLevels(); ++l) {
@@ -261,55 +362,104 @@ void RegisteredImage::Initialize(const ImageAttributes &attr, int t)
 void RegisteredImage::ComputeInputGradient(double sigma)
 {
   MIRTK_START_TIMING();
-  // Smooth input image
-  InputImageType *blurred_image = _InputImage;
-  if (sigma > .0) {
-    blurred_image = new InputImageType;
-    if (this->HasBackgroundValue()) {
-      blurred_image->PutBackgroundValueAsDouble(this->GetBackgroundValueAsDouble());
-      GaussianBlurringWithPadding<double> blurring(sigma * _InputImage->GetXSize(),
-                                                   sigma * _InputImage->GetYSize(),
-                                                   sigma * _InputImage->GetZSize(),
-                                                   this->GetBackgroundValueAsDouble());
-      blurring.Input (_InputImage);
-      blurring.Output(blurred_image);
-      blurring.Run();
+  Delete(_InputGradient);
+  if (sigma > 0. || _PrecomputeDerivatives) {
+    // Background value
+    double bgvalue;
+    if (_InputImage->HasBackgroundValue()) {
+      bgvalue = _InputImage->GetBackgroundValueAsDouble();
     } else {
-      GaussianBlurring<double> blurring(sigma * _InputImage->GetXSize(),
-                                        sigma * _InputImage->GetYSize(),
-                                        sigma * _InputImage->GetZSize());
-      blurring.Input (_InputImage);
-      blurring.Output(blurred_image);
+      bgvalue = _OutsideValue;
+    }
+    // Cast to gradient voxel type
+    InputGradientType *image;
+    UniquePtr<InputGradientType> temp;
+    if (typeid(InputGradientType) != typeid(InputImageType)) {
+      temp.reset(new InputGradientType(*_InputImage));
+      image = temp.get();
+    } else {
+      image = reinterpret_cast<InputGradientType *>(_InputImage);
+    }
+    // Smooth input image
+    if (sigma > 0.) {
+      UniquePtr<InputGradientType> blurred(new InputGradientType());
+      typedef GaussianBlurringWithPadding<InputGradientType::VoxelType> GaussianFilter;
+      GaussianFilter blurring(sigma * image->XSize(),
+                              sigma * image->YSize(),
+                              sigma * image->ZSize(), bgvalue);
+      blurring.Input(image);
+      blurring.Output(blurred.get());
       blurring.Run();
+      temp.reset(blurred.release());
+      image = temp.get();
     }
-  }
-  if (_PrecomputeDerivatives) {
-    // Compute image gradient using finite differences
-    typedef GradientImageFilter<GradientImageType::VoxelType> FilterType;
-    FilterType filter(FilterType::GRADIENT_VECTOR);
-    filter.Input (blurred_image);
-    filter.Output(_InputGradient ? _InputGradient : new GradientImageType);
-    // Note that even though the original IRTK nreg2 implementation did divide
-    // the image gradient initially by the voxel size, the similarity gradient
-    // was reoriented then by ImageRegistration2::EvaluateGradient using the
-    // upper 3x3 image to world matrix. This effectively multiplied by the voxel
-    // size again which is equivalent to only reorienting the image gradient
-    // computed w.r.t. the voxel coordinates, i.e., leaving the magnitude of the
-    // gradient in voxel units rather than world units (i.e., mm's).
-    filter.UseVoxelSize  (true);
-    filter.UseOrientation(true);
-    if (this->HasBackgroundValue()) {
-      filter.PaddingValue(this->GetBackgroundValueAsDouble());
+    if (_PrecomputeDerivatives) {
+      UniquePtr<InputGradientType> gradient(new InputGradientType());
+      // Compute image gradient using finite differences
+      typedef GradientImageFilter<InputGradientType::VoxelType> GradientFilterType;
+      GradientFilterType filter(GradientFilterType::GRADIENT_VECTOR);
+      filter.Input(image);
+      filter.Output(gradient.get());
+      // Note that even though the original IRTK nreg2 implementation did divide
+      // the image gradient initially by the voxel size, the similarity gradient
+      // was reoriented then by ImageRegistration2::EvaluateGradient using the
+      // upper 3x3 image to world matrix. This effectively multiplied by the voxel
+      // size again which is equivalent to only reorienting the image gradient
+      // computed w.r.t. the voxel coordinates, i.e., leaving the magnitude of the
+      // gradient in voxel units rather than world units (i.e., mm's).
+      filter.UseVoxelSize(true);
+      filter.UseOrientation(true);
+      filter.PaddingValue(bgvalue);
+      filter.Run();
+      gradient->PutTSize(0.);
+      gradient->PutBackgroundValueAsDouble(0.);
+      MIRTK_DEBUG_TIMING(5, "computation of 1st order image derivatives");
+      if (_MaxGradientPercentile > 0 || (_MaxGradientMagnitude > 0. && !IsInf(_MaxGradientMagnitude))) {
+        const int nvox = gradient->NumberOfSpatialVoxels();
+        // Initialize foreground mask
+        UniquePtr<bool[]> mask(new bool[nvox]);
+        for (int vox = 0; vox < nvox; ++vox) {
+          mask[vox] = image->IsForeground(vox);
+        }
+        // Compute gradient magnitude
+        Array<double> mag2(nvox);
+        CalculateSquaredGradientMagnitude eval_mag2(gradient.get(), &mag2, mask.get());
+        ParallelForEachVoxel(gradient.get(), eval_mag2);
+        if (_MaxGradientPercentile > 0) {
+          MIRTK_START_TIMING();
+          // Compute percentile threshold
+          using data::statistic::Percentile;
+          double thres2 = Percentile::Calculate(_MaxGradientPercentile, nvox, mag2.data(), mask.get());
+          // Clamp gradient magnitude
+          ClampSquaredGradientMagnitude clamp_mag2(gradient.get(), &mag2, thres2);
+          ParallelForEachVoxel(gradient.get(), clamp_mag2);
+          MIRTK_DEBUG_TIMING(5, "clamping of 1st order image derivatives");
+        }
+        // Rescale to specified maximum magnitude
+        if (_MaxGradientMagnitude > 0. && !IsInf(_MaxGradientMagnitude)) {
+          MIRTK_START_TIMING();
+          RescaleSquaredGradientMagnitude rescale(gradient.get(), &mag2, _MaxGradientMagnitude);
+          ParallelForEachVoxel(gradient.get(), rescale);
+          MIRTK_DEBUG_TIMING(5, "rescaling of 1st order image derivatives");
+        }
+      }
+      _InputGradient = gradient.release();
+    } else {
+      temp.release();
+      _InputGradient = image;
+      if (_InputImage->HasBackgroundValue()) {
+        _InputGradient->PutBackgroundValueAsDouble(_InputImage->GetBackgroundValueAsDouble());
+      }
     }
-    filter.Run();
-    _InputGradient = filter.Output();
-    _InputGradient->PutTSize(.0);
-    _InputGradient->PutBackgroundValueAsDouble(.0);
-    if (blurred_image != _InputImage) delete blurred_image;
-    MIRTK_DEBUG_TIMING(5, "computation of 1st order image derivatives");
   } else {
-    delete _InputGradient;
-    _InputGradient = blurred_image;
+    if (typeid(InputGradientType) != typeid(InputImageType)) {
+      _InputGradient = new InputGradientType(*_InputImage);
+      if (_InputImage->HasBackgroundValue()) {
+        _InputGradient->PutBackgroundValueAsDouble(_InputImage->GetBackgroundValueAsDouble());
+      }
+    } else {
+      _InputGradient = reinterpret_cast<InputGradientType *>(_InputImage);
+    }
     MIRTK_DEBUG_TIMING(5, "low-pass filtering of image for 1st order derivatives");
   }
 }
@@ -318,43 +468,49 @@ void RegisteredImage::ComputeInputGradient(double sigma)
 void RegisteredImage::ComputeInputHessian(double sigma)
 {
   MIRTK_START_TIMING();
+  Delete(_InputHessian);
+  // Background value
+  double bgvalue;
+  if (_InputImage->HasBackgroundValue()) {
+    bgvalue = _InputImage->GetBackgroundValueAsDouble();
+  } else {
+    bgvalue = _OutsideValue;
+  }
+  // Cast to gradient voxel type
+  InputHessianType *image;
+  UniquePtr<InputHessianType> temp;
+  if (typeid(InputHessianType) != typeid(InputImageType)) {
+    temp.reset(new InputHessianType(*_InputImage));
+    image = temp.get();
+  } else {
+    image = reinterpret_cast<InputHessianType *>(_InputImage);
+  }
   // Smooth input image
-  InputImageType *blurred_image = _InputImage;
   if (sigma > .0) {
-    blurred_image = new InputImageType;
-    if (this->HasBackgroundValue()) {
-      blurred_image->PutBackgroundValueAsDouble(this->GetBackgroundValueAsDouble());
-      GaussianBlurringWithPadding<double> blurring(sigma * _InputImage->GetXSize(),
-                                                   sigma * _InputImage->GetYSize(),
-                                                   sigma * _InputImage->GetZSize(),
-                                                   this->GetBackgroundValueAsDouble());
-      blurring.Input (_InputImage);
-      blurring.Output(blurred_image);
-      blurring.Run();
-    } else {
-      GaussianBlurring<double> blurring(sigma * _InputImage->GetXSize(),
-                                        sigma * _InputImage->GetYSize(),
-                                        sigma * _InputImage->GetZSize());
-      blurring.Input (_InputImage);
-      blurring.Output(blurred_image);
-      blurring.Run();
-    }
+    UniquePtr<InputHessianType> blurred(new InputHessianType());
+    typedef GaussianBlurringWithPadding<InputHessianType::VoxelType> GaussianFilter;
+    GaussianFilter blurring(sigma * image->XSize(),
+                            sigma * image->YSize(),
+                            sigma * image->ZSize(), bgvalue);
+    blurring.Input (image);
+    blurring.Output(blurred.get());
+    blurring.Run();
+    temp.reset(blurred.release());
+    image = temp.get();
   }
   // Compute 2nd order image derivatives using finite differences
-  typedef HessianImageFilter<HessianImageType::VoxelType> FilterType;
-  FilterType filter(FilterType::HESSIAN_MATRIX);
-  filter.Input(blurred_image);
-  filter.Output(_InputHessian ? _InputHessian : new HessianImageType);
+  UniquePtr<InputHessianType> hessian(new InputHessianType());
+  typedef HessianImageFilter<InputHessianType::VoxelType> HessianFilterType;
+  HessianFilterType filter(HessianFilterType::HESSIAN_MATRIX);
+  filter.Input(image);
+  filter.Output(hessian.get());
   filter.UseVoxelSize  (true);
   filter.UseOrientation(true);
-  if (this->HasBackgroundValue()) {
-    filter.PaddingValue(this->GetBackgroundValueAsDouble());
-  }
+  filter.PaddingValue(bgvalue);
   filter.Run();
-  _InputHessian = filter.Output();
-  _InputHessian->PutTSize(.0);
-  _InputHessian->PutBackgroundValueAsDouble(.0);
-  if (blurred_image != _InputImage) delete blurred_image;
+  hessian->PutTSize(.0);
+  hessian->PutBackgroundValueAsDouble(.0);
+  _InputHessian = hessian.get();
   MIRTK_DEBUG_TIMING(5, "computation of 2nd order image derivatives");
 }
 
@@ -367,6 +523,7 @@ void RegisteredImage::ComputeInputHessian(double sigma)
 struct Transformer
 {
   typedef WorldCoordsImage::VoxelType CoordType;
+  typedef RegisteredImage::DisplacementImageType::VoxelType DisplacementType;
 
   /// Constructor
   Transformer()
@@ -407,11 +564,11 @@ struct Transformer
   }
 
   /// Transform output voxel using pre-computed world coordinates and displacements
-  void operator ()(double &x, double &y, double &z, const CoordType *wc, const double *dx)
+  void operator ()(double &x, double &y, double &z, const CoordType *wc, const DisplacementType *dx)
   {
-    x = wc[_x] + dx[_x];
-    y = wc[_y] + dx[_y];
-    z = wc[_z] + dx[_z];
+    x = static_cast<double>(wc[_x]) + static_cast<double>(dx[_x]);
+    y = static_cast<double>(wc[_y]) + static_cast<double>(dx[_y]);
+    z = static_cast<double>(wc[_z]) + static_cast<double>(dx[_z]);
     _Input->WorldToImage(x, y, z);
   }
 
@@ -437,10 +594,9 @@ struct DefaultTransformer : public Transformer
 
   /// As this transformer is only used when no fixed transformation is cached,
   /// this overloaded operator should never be invoked
-  void operator ()(double &, double &, double &, const CoordType *, const double *, const double *)
+  void operator ()(double &, double &, double &, const CoordType *, const DisplacementType *, const DisplacementType *)
   {
-    cerr << "RegisteredImage::DefaultTransformer used even though _FixedDisplacement assumed to be NULL ?!?" << endl;
-    exit(1);
+    mirtk::Throw(ERR_LogicError, "RegisteredImage::DefaultTransformer", "Transformer used even though _FixedDisplacement assumed to be nullptr?!");
   }
 };
 
@@ -451,11 +607,11 @@ struct AdditiveTransformer : public Transformer
   using Transformer::operator();
 
   /// Transform output voxel using pre-computed world coordinates and displacements
-  void operator ()(double &x, double &y, double &z, const CoordType *wc, const double *d1, const double *d2)
+  void operator ()(double &x, double &y, double &z, const CoordType *wc, const DisplacementType *d1, const DisplacementType *d2)
   {
-    x = wc[_x] + d1[_x] + d2[_x];
-    y = wc[_y] + d1[_y] + d2[_y];
-    z = wc[_z] + d1[_z] + d2[_z];
+    x = static_cast<double>(wc[_x]) + static_cast<double>(d1[_x]) + static_cast<double>(d2[_x]);
+    y = static_cast<double>(wc[_y]) + static_cast<double>(d1[_y]) + static_cast<double>(d2[_y]);
+    z = static_cast<double>(wc[_z]) + static_cast<double>(d1[_z]) + static_cast<double>(d2[_z]);
     _Input->WorldToImage(x, y, z);
   }
 };
@@ -471,11 +627,11 @@ struct FluidTransformer : public Transformer
   /// Because fluid composition of displacement fields would require interpolation,
   /// let Transformation::Displacement handle the fluid composition already when
   /// computing the second displacement field.
-  void operator ()(double &x, double &y, double &z, const CoordType *wc, const double *, const double *dx)
+  void operator ()(double &x, double &y, double &z, const CoordType *wc, const DisplacementType *, const DisplacementType *dx)
   {
-    x = wc[_x] + dx[_x];
-    y = wc[_y] + dx[_y];
-    z = wc[_z] + dx[_z];
+    x = static_cast<double>(wc[_x]) + static_cast<double>(dx[_x]);
+    y = static_cast<double>(wc[_y]) + static_cast<double>(dx[_y]);
+    z = static_cast<double>(wc[_z]) + static_cast<double>(dx[_z]);
     _Input->WorldToImage(x, y, z);
   }
 };
@@ -505,17 +661,16 @@ struct FixedTransformer : public Transformer
   }
 
   /// Transform output voxel using pre-computed world coordinates and displacements
-  void operator ()(double &x, double &y, double &z, const CoordType *wc, const double *dx)
+  void operator ()(double &x, double &y, double &z, const CoordType *wc, const DisplacementType *dx)
   {
     Transformer::operator()(x, y, z, wc, dx);
   }
 
   /// As this transformer is only used when no transformation is set,
   /// this overloaded operator should never be invoked
-  void operator ()(double &, double &, double &, const CoordType *, const double *, const double *)
+  void operator ()(double &, double &, double &, const CoordType *, const DisplacementType *, const DisplacementType *)
   {
-    cerr << "RegisteredImage::FixedTransformer(..., d1, d2) used even though _Transformation assumed to be NULL ?!?" << endl;
-    exit(1);
+    Throw(ERR_LogicError, "RegisteredImage::FixedTransformer(..., d1, d2)", "Transformer used even though _Transformation assumed to be nullptr?!");
   }
 };
 
@@ -607,9 +762,10 @@ class Interpolator : public Object
 
 public:
 
-  typedef TIntensityFunction  IntensityFunction;
-  typedef TGradientFunction   GradientFunction;
-  typedef THessianFunction    HessianFunction;
+  typedef TIntensityFunction           IntensityFunction;
+  typedef TGradientFunction            GradientFunction;
+  typedef THessianFunction             HessianFunction;
+  typedef RegisteredImage::VoxelType   VoxelType;
 
 protected:
 
@@ -618,7 +774,7 @@ protected:
   HessianFunction   *_HessianFunction;
   bool               _InterpolateWithPadding;
   bool               _PrecomputedDerivatives;
-  double             _PaddingValue;
+  double             _OutsideValue;
   double             _MinIntensity;
   double             _MaxIntensity;
   double             _RescaleSlope;
@@ -637,11 +793,11 @@ public:
     _HessianFunction       (nullptr),
     _InterpolateWithPadding(false),
     _PrecomputedDerivatives(false),
-    _PaddingValue          (-1.),
+    _OutsideValue          (0.),
     _MinIntensity          (NaN),
     _MaxIntensity          (NaN),
     _RescaleSlope          (1.),
-    _RescaleIntercept      (.0),
+    _RescaleIntercept      (0.),
     _NumberOfVoxels        (0),
     _NumberOfChannels      (0)
   {
@@ -656,7 +812,7 @@ public:
     _HessianFunction       (nullptr),
     _InterpolateWithPadding(other._InterpolateWithPadding),
     _PrecomputedDerivatives(other._PrecomputedDerivatives),
-    _PaddingValue          (other._PaddingValue),
+    _OutsideValue          (other._OutsideValue),
     _MinIntensity          (other._MinIntensity),
     _MaxIntensity          (other._MaxIntensity),
     _RescaleSlope          (other._RescaleSlope),
@@ -667,7 +823,7 @@ public:
   {
     if (other._IntensityFunction) {
       const BaseImage *f = other._IntensityFunction->Input();
-      const double f_bg = (f->HasBackgroundValue() ? f->GetBackgroundValueAsDouble() : MIN_GREY);
+      const double f_bg = (f->HasBackgroundValue() ? f->GetBackgroundValueAsDouble() : NaN);
       New<IntensityFunction>(_IntensityFunction, f,
                              other._IntensityFunction->InterpolationMode(),
                              other._IntensityFunction->ExtrapolationMode(),
@@ -675,19 +831,19 @@ public:
     }
     if (other._GradientFunction) {
       const BaseImage *g = other._GradientFunction->Input();
-      const double g_bg = (g->HasBackgroundValue() ? g->GetBackgroundValueAsDouble() : .0);
+      const double g_bg = (g->HasBackgroundValue() ? g->GetBackgroundValueAsDouble() : 0.);
       New<GradientFunction>(_GradientFunction, g,
                             other._GradientFunction->InterpolationMode(),
                             other._GradientFunction->ExtrapolationMode(),
-                            g_bg, .0);
+                            g_bg, 0.);
     }
     if (other._HessianFunction) {
       const BaseImage *h = other._HessianFunction->Input();
-      const double h_bg = (h->HasBackgroundValue() ? h->GetBackgroundValueAsDouble() : .0);
+      const double h_bg = (h->HasBackgroundValue() ? h->GetBackgroundValueAsDouble() : 0.);
       New<HessianFunction>(_HessianFunction, h,
                            other._HessianFunction->InterpolationMode(),
                            other._HessianFunction->ExtrapolationMode(),
-                           h_bg, .0);
+                           h_bg, 0.);
     }
   }
 
@@ -708,38 +864,57 @@ public:
     } else {
       interp = o->InterpolationMode();
     }
-    _PrecomputedDerivatives = o->PrecomputeDerivatives();
-    _InterpolateWithPadding = (interp != InterpolationWithoutPadding(interp));
-    if (o->HasBackgroundValue()) _PaddingValue = o->GetBackgroundValueAsDouble();
-    _NumberOfVoxels   = o->X() * o->Y() * o->Z();
-    _NumberOfChannels = o->T();
     const BaseImage * const f = o->InputImage();
     const BaseImage * const g = o->InputGradient();
     const BaseImage * const h = o->InputHessian();
-    const double f_bg = (f->HasBackgroundValue() ? f->GetBackgroundValueAsDouble() : MIN_GREY);
-    const double g_bg = (g && g->HasBackgroundValue() ? g->GetBackgroundValueAsDouble() : .0);
-    const double h_bg = (h && h->HasBackgroundValue() ? h->GetBackgroundValueAsDouble() : .0);
+    const double f_bg = (f->HasBackgroundValue() ? f->GetBackgroundValueAsDouble() : NaN);
+    const double g_bg = (g && g->HasBackgroundValue() ? g->GetBackgroundValueAsDouble() : 0.);
+    const double h_bg = (h && h->HasBackgroundValue() ? h->GetBackgroundValueAsDouble() : 0.);
     New<IntensityFunction>(_IntensityFunction, f, interp, o->ExtrapolationMode(), f_bg, f_bg);
-    New<GradientFunction >(_GradientFunction,  g, interp, Extrapolation_Default,  g_bg, .0);
-    New<HessianFunction  >(_HessianFunction,   h, interp, Extrapolation_Default,  h_bg, .0);
+    New<GradientFunction >(_GradientFunction,  g, interp, Extrapolation_Default,  g_bg, 0.);
+    New<HessianFunction  >(_HessianFunction,   h, interp, Extrapolation_Default,  h_bg, 0.);
     f->GetMinMaxAsDouble(_MinIntensity, _MaxIntensity);
+    _PrecomputedDerivatives = o->PrecomputeDerivatives();
+    _InterpolateWithPadding = (interp != InterpolationWithoutPadding(interp));
+    _NumberOfChannels       = o->T();
+    _NumberOfVoxels         = o->X() * o->Y() * o->Z();
+    _InputSize              = Vector3D<int>(f->X(), f->Y(), f->Z());
+    // Set outside value
+    _OutsideValue = f_bg;
+    if (IsNaN(_OutsideValue)) {
+      _OutsideValue = o->OutsideValue();
+      if (IsNaN(_OutsideValue)) {
+        _OutsideValue = _MinIntensity;
+      }
+    }
+    // Set rescaling parameters
     double omin = o->MinIntensity();
     double omax = o->MaxIntensity();
     if (!IsNaN(omin) || !IsNaN(omax)) {
+      // Compute linear rescaling parameters of resampled intensities
       if (IsNaN(omin)) omin = _MinIntensity;
       if (IsNaN(omax)) omax = _MaxIntensity;
       _RescaleSlope     = (omax - omin) / (_MaxIntensity - _MinIntensity);
       _RescaleIntercept = omin - _RescaleSlope * _MinIntensity;
-      _MinIntensity     = omin;
-      _MaxIntensity     = omax;
-    } else {
-      _RescaleSlope     = 1.0;
-      _RescaleIntercept = 0.0;
-      if (f->HasBackgroundValue() && _MinIntensity > f->GetBackgroundValueAsDouble()) {
-        _MinIntensity = f->GetBackgroundValueAsDouble();
+      // Rescale outside value or force it to be within explicitly requested range
+      if (_OutsideValue < _MinIntensity && !IsNaN(o->MinIntensity())) {
+        _OutsideValue = omin;
+      } else if (_OutsideValue > _MaxIntensity && !IsNaN(o->MaxIntensity())) {
+        _OutsideValue = omax;
+      } else {
+        _OutsideValue = _RescaleSlope * _OutsideValue + _RescaleIntercept;
       }
+      // Change min/max values **after** outside value is set
+      _MinIntensity = omin;
+      _MaxIntensity = omax;
+    } else {
+      _RescaleSlope     = 1.;
+      _RescaleIntercept = 0.;
     }
-    _InputSize = Vector3D<int>(f->X(), f->Y(), f->Z());
+    // Set background value of resampled image
+    if (f->HasBackgroundValue()) {
+      o->PutBackgroundValueAsDouble(_OutsideValue);
+    }
   }
 
   /// Get input image
@@ -779,103 +954,129 @@ public:
   /// Interpolate input intensity function
   ///
   /// \return The interpolation mode, i.e., result of inside/outside domain check.
-  int Intensity(double x, double y, double z, double *o) const
+  int Intensity(double x, double y, double z, VoxelType *o) const
   {
+    double value;
     // Check if location is inside image domain
     int mode = Mode(x, y, z, false);
     if (mode != -1) {
       // Either interpolate using the input padding value to exclude background
       if (_InterpolateWithPadding) {
         if (mode == 1) {
-          *o = _IntensityFunction->EvaluateWithPaddingInside(x, y, z);
+          value = _IntensityFunction->EvaluateWithPaddingInside(x, y, z);
         } else {
-          *o = _IntensityFunction->EvaluateWithPaddingOutside(x, y, z);
+          value = _IntensityFunction->EvaluateWithPaddingOutside(x, y, z);
         }
       // or simply ignore the input background value as done by nreg2
       } else {
         if (mode == 1) {
-          *o = _IntensityFunction->EvaluateInside(x, y, z);
+          value = _IntensityFunction->EvaluateInside(x, y, z);
         } else {
-          *o = _IntensityFunction->EvaluateOutside(x, y, z);
+          value = _IntensityFunction->EvaluateOutside(x, y, z);
         }
       }
       // Set background to outside value
-      if (IsNaN(*o) || AreEqual(*o, _IntensityFunction->DefaultValue(), 1e-6)) {
-        *o = _PaddingValue;
-        if (_InterpolateWithPadding) return -1;
+      if (IsNaN(value) || AreEqual(value, _IntensityFunction->DefaultValue(), 1e-6)) {
+        value = _OutsideValue;
+        if (_InterpolateWithPadding) mode = -1;
       // Rescale/clamp foreground to [min, max] range
       } else {
-        *o = (*o) * _RescaleSlope + _RescaleIntercept;
-        if      (*o < _MinIntensity) *o = _MinIntensity;
-        else if (*o > _MaxIntensity) *o = _MaxIntensity;
+        value = value * _RescaleSlope + _RescaleIntercept;
+        if      (value < _MinIntensity) value = _MinIntensity;
+        else if (value > _MaxIntensity) value = _MaxIntensity;
       }
     // Otherwise, set output intensity to outside value
     } else {
-      *o = _PaddingValue;
+      value = _OutsideValue;
     }
+    *o = static_cast<VoxelType>(value);
     // Pass inside/outside check result on to derivative interpolation
     // functions such that these boundary checks are only done once.
     // This requires the same interpolation mode for all channels.
     return mode;
   }
 
+private:
+
   /// Interpolate 1st order derivatives of input intensity function
-  void Gradient(double x, double y, double z, double *o, int mode = 0) const
+  void EvaluateGradient(double x, double y, double z, double *o, int mode = 0, int stride = 1) const
   {
-    o += _NumberOfVoxels;
     switch (mode) {
       // Inside
       case 1:
         if (_InterpolateWithPadding) {
-          _GradientFunction->EvaluateWithPaddingInside(o, x, y, z, _NumberOfVoxels);
+          _GradientFunction->EvaluateWithPaddingInside(o, x, y, z, stride);
         } else {
-          _GradientFunction->EvaluateInside(o, x, y, z, _NumberOfVoxels);
+          _GradientFunction->EvaluateInside(o, x, y, z, stride);
         }
         break;
       // Boundary
       case 0:
         if (_PrecomputedDerivatives) {
           if (_InterpolateWithPadding) {
-            _GradientFunction->EvaluateWithPaddingOutside(o, x, y, z, _NumberOfVoxels);
+            _GradientFunction->EvaluateWithPaddingOutside(o, x, y, z, stride);
           } else {
-            _GradientFunction->EvaluateOutside(o, x, y, z, _NumberOfVoxels);
+            _GradientFunction->EvaluateOutside(o, x, y, z, stride);
           }
           break;
         } // otherwise continue with Outside case
       // Outside
       default: {
-        for (int c = 1; c <= 3; ++c, o += _NumberOfVoxels) *o = .0;
+        for (int c = 1; c <= 3; ++c, o += stride) *o = 0.;
       } break;
     }
   }
 
   /// Interpolate 2nd order derivatives of input intensity function
-  void Hessian(double x, double y, double z, double *o, int mode = 0) const
+  void EvaluateHessian(double x, double y, double z, double *o, int mode = 0, int stride = 1) const
   {
-    o += 4 * _NumberOfVoxels;
     switch (mode) {
       // Inside
       case 1:
         if (_InterpolateWithPadding) {
-          _HessianFunction->EvaluateWithPaddingInside(o, x, y, z, _NumberOfVoxels);
+          _HessianFunction->EvaluateWithPaddingInside(o, x, y, z, stride);
         } else {
-          _HessianFunction->EvaluateInside(o, x, y, z, _NumberOfVoxels);
+          _HessianFunction->EvaluateInside(o, x, y, z, stride);
         }
         break;
       // Boundary
       case 0:
         if (_PrecomputedDerivatives) {
           if (_InterpolateWithPadding) {
-            _HessianFunction->EvaluateWithPaddingOutside(o, x, y, z, _NumberOfVoxels);
+            _HessianFunction->EvaluateWithPaddingOutside(o, x, y, z, stride);
           } else {
-            _HessianFunction->EvaluateOutside(o, x, y, z, _NumberOfVoxels);
+            _HessianFunction->EvaluateOutside(o, x, y, z, stride);
           }
           break;
         } // otherwise continue with Outside case
       // Outside
       default: {
-        for (int c = 4; c < _NumberOfChannels; ++c, o += _NumberOfVoxels) *o = .0;
+        for (int c = 4; c < _NumberOfChannels; ++c, o += stride) *o = 0.;
       } break;
+    }
+  }
+
+public:
+
+  /// Interpolate 2nd order derivatives of input intensity function
+  void Gradient(double x, double y, double z, VoxelType *o, int mode = 0) const
+  {
+    double gradient[3];
+    EvaluateGradient(x, y, z, gradient, mode);
+    o += _NumberOfVoxels;
+    for (int c = 0; c < 3; ++c, o += _NumberOfVoxels) {
+      *o = static_cast<VoxelType>(gradient[c]);
+    }
+  }
+
+  /// Interpolate 2nd order derivatives of input intensity function
+  void Hessian(double x, double y, double z, VoxelType *o, int mode = 0) const
+  {
+    double hessian[9];
+    EvaluateHessian(x, y, z, hessian, mode);
+    o += 4 * _NumberOfVoxels;
+    for (int c = 4; c < _NumberOfChannels; ++c, o += _NumberOfVoxels) {
+      *o = static_cast<VoxelType>(hessian[c - 4]);
     }
   }
 };
@@ -886,6 +1087,7 @@ template <class IntensityFunction, class GradientFunction, class HessianFunction
 struct IntensityInterpolator
 {
   typedef Interpolator<IntensityFunction, GradientFunction, HessianFunction> Evaluator;
+  typedef typename Evaluator::VoxelType VoxelType;
 
   const Evaluator *_Evaluate;
   IntensityInterpolator(const Evaluator *eval = nullptr)
@@ -893,7 +1095,7 @@ struct IntensityInterpolator
     _Evaluate(eval)
   {}
 
-  void operator()(double x, double y, double z, double *o)
+  void operator()(double x, double y, double z, VoxelType *o)
   {
     _Evaluate->Intensity(x, y, z, o);
   }
@@ -905,6 +1107,7 @@ template <class IntensityFunction, class GradientFunction, class HessianFunction
 struct GradientInterpolator
 {
   typedef Interpolator<IntensityFunction, GradientFunction, HessianFunction> Evaluator;
+  typedef typename Evaluator::VoxelType VoxelType;
 
   const Evaluator *_Evaluate;
   GradientInterpolator(const Evaluator *eval = nullptr)
@@ -912,7 +1115,7 @@ struct GradientInterpolator
     _Evaluate(eval)
   {}
 
-  void operator()(double x, double y, double z, double *o)
+  void operator()(double x, double y, double z, VoxelType *o)
   {
     int mode = _Evaluate->Mode(x, y, z);
     _Evaluate->Gradient(x, y, z, o, mode);
@@ -925,6 +1128,7 @@ template <class IntensityFunction, class GradientFunction, class HessianFunction
 struct HessianInterpolator
 {
   typedef Interpolator<IntensityFunction, GradientFunction, HessianFunction> Evaluator;
+  typedef typename Evaluator::VoxelType VoxelType;
 
   const Evaluator *_Evaluate;
   HessianInterpolator(const Evaluator *eval = nullptr)
@@ -932,7 +1136,7 @@ struct HessianInterpolator
     _Evaluate(eval)
   {}
 
-  void operator()(double x, double y, double z, double *o)
+  void operator()(double x, double y, double z, VoxelType *o)
   {
     int mode = _Evaluate->Mode(x, y, z);
     _Evaluate->Hessian(x, y, z, o, mode);
@@ -945,6 +1149,7 @@ template <class IntensityFunction, class GradientFunction, class HessianFunction
 struct IntensityAndGradientInterpolator
 {
   typedef Interpolator<IntensityFunction, GradientFunction, HessianFunction> Evaluator;
+  typedef typename Evaluator::VoxelType VoxelType;
 
   const Evaluator *_Evaluate;
   IntensityAndGradientInterpolator(const Evaluator *eval = nullptr)
@@ -952,7 +1157,7 @@ struct IntensityAndGradientInterpolator
     _Evaluate(eval)
   {}
 
-  void operator()(double x, double y, double z, double *o)
+  void operator()(double x, double y, double z, VoxelType *o)
   {
     int mode = _Evaluate->Intensity(x, y, z, o);
     _Evaluate->Gradient(x, y, z, o, mode);
@@ -965,6 +1170,7 @@ template <class IntensityFunction, class GradientFunction, class HessianFunction
 struct IntensityAndHessianInterpolator
 {
   typedef Interpolator<IntensityFunction, GradientFunction, HessianFunction> Evaluator;
+  typedef typename Evaluator::VoxelType VoxelType;
 
   const Evaluator *_Evaluate;
   IntensityAndHessianInterpolator(const Evaluator *eval = nullptr)
@@ -972,7 +1178,7 @@ struct IntensityAndHessianInterpolator
     _Evaluate(eval)
   {}
 
-  void operator()(double x, double y, double z, double *o)
+  void operator()(double x, double y, double z, VoxelType *o)
   {
     int mode = _Evaluate->Intensity(x, y, z, o);
     _Evaluate->Hessian(x, y, z, o, mode);
@@ -985,6 +1191,7 @@ template <class IntensityFunction, class GradientFunction, class HessianFunction
 struct GradientAndHessianInterpolator
 {
   typedef Interpolator<IntensityFunction, GradientFunction, HessianFunction> Evaluator;
+  typedef typename Evaluator::VoxelType VoxelType;
 
   const Evaluator *_Evaluate;
   GradientAndHessianInterpolator(const Evaluator *eval = nullptr)
@@ -992,7 +1199,7 @@ struct GradientAndHessianInterpolator
     _Evaluate(eval)
   {}
 
-  void operator()(double x, double y, double z, double *o)
+  void operator()(double x, double y, double z, VoxelType *o)
   {
     int mode = _Evaluate->Mode(x, y, z);
     _Evaluate->Gradient(x, y, z, o, mode);
@@ -1006,6 +1213,7 @@ template <class IntensityFunction, class GradientFunction, class HessianFunction
 struct IntensityAndGradientAndHessianInterpolator
 {
   typedef Interpolator<IntensityFunction, GradientFunction, HessianFunction> Evaluator;
+  typedef typename Evaluator::VoxelType VoxelType;
 
   const Evaluator *_Evaluate;
   IntensityAndGradientAndHessianInterpolator(const Evaluator *eval = nullptr)
@@ -1013,7 +1221,7 @@ struct IntensityAndGradientAndHessianInterpolator
     _Evaluate(eval)
   {}
 
-  void operator()(double x, double y, double z, double *o)
+  void operator()(double x, double y, double z, VoxelType *o)
   {
     int mode = _Evaluate->Intensity(x, y, z, o);
     _Evaluate->Gradient(x, y, z, o, mode);
@@ -1028,8 +1236,10 @@ struct UpdateVoxelFunction : public VoxelFunction
 {
 private:
 
-  typedef typename Transformer::CoordType  CoordType;
-  typedef typename Interpolator::Evaluator Evaluator;
+  typedef typename Transformer::CoordType          CoordType;
+  typedef typename Transformer::DisplacementType   DisplacementType;
+  typedef typename Interpolator::Evaluator         Evaluator;
+  typedef typename Evaluator::VoxelType            VoxelType;
 
   Transformer  _Transform;
   Interpolator _Interpolate;
@@ -1045,7 +1255,7 @@ public:
   }
 
   /// Resample input without pre-computed maps
-  void operator ()(int i, int j, int k, int, double *o)
+  void operator ()(int i, int j, int k, int, VoxelType *o)
   {
     double x = i, y = j, z = k;
     _Transform  (x, y, z);
@@ -1053,7 +1263,7 @@ public:
   }
 
   /// Resample input using pre-computed world coordinates
-  void operator ()(int i, int j, int k, int, const CoordType *wc, double *o)
+  void operator ()(int i, int j, int k, int, const CoordType *wc, VoxelType *o)
   {
     double x = i, y = j, z = k;
     _Transform  (x, y, z, wc);
@@ -1061,7 +1271,7 @@ public:
   }
 
   /// Resample input using pre-computed world coordinates and displacements
-  void operator ()(int i, int j, int k, int, const CoordType *wc, const double *dx, double *o)
+  void operator ()(int i, int j, int k, int, const CoordType *wc, const DisplacementType *dx, VoxelType *o)
   {
     double x = i, y = j, z = k;
     _Transform  (x, y, z, wc, dx);
@@ -1069,7 +1279,7 @@ public:
   }
 
   /// Resample input using pre-computed world coordinates and additive displacements
-  void operator ()(int i, int j, int k, int, const CoordType *wc, const double *d1, const double *d2, double *o)
+  void operator ()(int i, int j, int k, int, const CoordType *wc, const DisplacementType *d1, const DisplacementType *d2, VoxelType *o)
   {
     double x = i, y = j, z = k;
     _Transform  (x, y, z, wc, d1, d2);
@@ -1146,8 +1356,7 @@ void RegisteredImage::Update2(const blocked_range3d<int> &region,
       if (hessian) {
         _update_using(HessianInterpolator);
       } else {
-        cerr << "RegisteredImage::Update: At least one output channel should be updated" << endl;
-        exit(1);
+        Throw(ERR_InvalidArgument, __FUNCTION__, "At least one output channel should be updated");
       }
     }
   }
@@ -1173,8 +1382,8 @@ void RegisteredImage::Update1(const blocked_range3d<int> &region,
       // Auxiliary macro -- undefined again at the end of this body
       #define _update_using(InterpolatorType)                                  \
         Update2<Transformer, InterpolatorType<InputImageType>,                 \
-                             InterpolatorType<GradientImageType>,              \
-                             InterpolatorType<HessianImageType> >              \
+                             InterpolatorType<InputGradientType>,              \
+                             InterpolatorType<InputHessianType> >              \
             (region, intensity, gradient, hessian)
       if (this->GetZ() == 1) {
         _update_using(GenericLinearInterpolateImageFunction2D);
@@ -1194,14 +1403,13 @@ void RegisteredImage::Update1(const blocked_range3d<int> &region,
     // TODO: Use also some HessianInterpolatorType
     #define _update_using(InterpolatorType, GradientInterpolatorType)          \
       Update2<Transformer, InterpolatorType<InputImageType>,                   \
-                           GradientInterpolatorType<InputImageType>,           \
-                           InterpolatorType<HessianImageType> >                \
+                           GradientInterpolatorType<InputGradientType>,        \
+                           InterpolatorType<InputHessianType> >                \
           (region, intensity, gradient, hessian)
     // Instantiate image functions for commonly used interpolation methods
     // to allow the compiler to generate optimized code for these
     if (interp == Interpolation_Linear) {
-
-      if (this->GetZ() == 1) {
+      if (this->Z() == 1) {
         _update_using(GenericLinearInterpolateImageFunction2D,
                       GenericLinearImageGradientFunction2D);
       } else {
@@ -1209,7 +1417,7 @@ void RegisteredImage::Update1(const blocked_range3d<int> &region,
                       GenericLinearImageGradientFunction3D);
       }
     } else if (interp == Interpolation_FastLinear) {
-      if (this->GetZ() == 1) {
+      if (this->Z() == 1) {
         _update_using(GenericLinearInterpolateImageFunction2D,
                       GenericFastLinearImageGradientFunction2D);
       } else {
@@ -1363,11 +1571,10 @@ void RegisteredImage::Update(const blocked_range3d<int> &region,
         if (!IsNaN(_MinIntensity) || !IsNaN(_MaxIntensity)) {
           const int nvox = NumberOfVoxels();
           if (nvox > 0) {
-            InputImageType::VoxelType *iptr = _InputImage->Data();
-            InputImageType::VoxelType  imin;
-            InputImageType::VoxelType  imax;
-            imin = voxel_limits<InputImageType::VoxelType>::max();
-            imax = voxel_limits<InputImageType::VoxelType>::min();
+            typedef InputImageType::VoxelType InputVoxelType;
+            InputVoxelType *iptr = _InputImage->Data();
+            InputVoxelType  imin = voxel_limits<InputVoxelType>::max();
+            InputVoxelType  imax = voxel_limits<InputVoxelType>::min();
             for (int idx = 0; idx < nvox; ++idx, ++iptr) {
               if (_InputImage->IsForeground(idx)) {
                 if (*iptr < imin) imin = *iptr;
@@ -1450,7 +1657,7 @@ void RegisteredImage::Update(const blocked_range3d<int>  &region,
 
   // Replace displacement fields by user arguments
   _Displacement      = const_cast<DisplacementImageType *>(disp);
-  _FixedDisplacement = NULL;
+  _FixedDisplacement = nullptr;
 
   // Interpolate within specified region using fixed transfomer
   Update1<FixedTransformer>(region, intensity, gradient, hessian);


### PR DESCRIPTION
- Added "Image similarity foreground" parameter.
  - `Mask`: Evaluate within set mask region or all voxels if none set.
  - `Target`: Evaluate for foreground of untransformed image.
  - `Overlap`: Evaluate for intersection of foreground regions (**new default**).
  - `Union`: Evaluate for union of foreground regions.
- Convergence test based on slope of line fit to past n energy values.
  - `n` by default 2 which corresponds to previous behaviour.
  - Parameter "No. of last function values" / "No. of past function values".
- Option to "Exclude constraints from energy value".
- Workaround for issue when input images have affine sform matrix.
  - Apply affine transformation (except shearing) to attributes before running the registration filter.
- Binary search-like adaptive line search with strict total step length range.
- ~~Change `VoxelType` of `RegisteredImage` to `float`.~~
- Refactor generation of resolution pyramid.
  - Fixes issue with foreground boundary issues of brain extracted images when no "Padding value" is specified. Problem solved by also blurring images at finest resolution level to smooth over sharp edges between brain extracted foreground and background.
- Options to normalize image gradient of `RegisteredImage`.
- Added `ElapsedTimeToString` helper function.
- Added `-reset-mask` option to `register` command.
- Use tolerance of 1e-3 in `InterpolateImageFunction` subclasses for comparison of `bgw > fgw`.
  - Downsampled images using `ResamplingWithPadding` otherwise differ considerably at foreground boundary leading to differing results when compiled on Ubuntu with GCC and macOS with Clang, for example.
  - Still numeric differences occur between machines...
- Use domain mask only to crop/pad FFD when set such that FFD lattice is identical for any registration with the same domain mask, i.e., independent of target image content.
- Option to force status of FFD lattice boundary CPs to passive with zero values.
  - Parameter: "Dirichlet boundary condition"
  - Fixed `BSplineFreeFormTransformationSV::ParametricGradient` with scaling and squaring using BCH formula to not add derivative to passive CP gradient.
- Resampling and Gaussian filter sets image background value and/or binary foreground mask of output when input has one set.