### PR TITLE
fix: Flush stdout before running subprocess [Applications]

### DIFF
--- a/Applications/lib/python/mirtk/subprocess.py.in
+++ b/Applications/lib/python/mirtk/subprocess.py.in
@@ -110,7 +110,8 @@ def _call(argv, verbose=0, execfunc=subprocess.call):
         for arg in argv:
             if ' ' in arg: arg = '"' + arg + '"'
             args.append(arg)
-        print(' '.join(args))
+        print('> ' + ' '.join(args) + '\n')
+    sys.stdout.flush()
     return execfunc(argv)
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Otherwise, the subprocess output may be printed before anything the main Python process has buffered.