### PR TITLE
enh: Add register -disp option and corresponding MSDE term [Registration]

### DIFF
--- a/Modules/Common/include/mirtk/EnergyMeasure.h
+++ b/Modules/Common/include/mirtk/EnergyMeasure.h
@@ -106,6 +106,11 @@ enum EnergyMeasure
     EM_MinDetJac,               ///< Constrain minimum Jacobian determinant
 
   CM_End,
+
+  // ---------------------------------------------------------------------------
+  // Others
+  EM_MeanSquaredDisplacementError,  ///< Mean squared deviation from given deformation
+
   // ---------------------------------------------------------------------------
   // Add new enumeration values above
   EM_Last ///< Number of enumeration values + 1
@@ -175,6 +180,10 @@ inline string ToString(const EnergyMeasure &value, int w, char c, bool left)
     case EM_L2Norm:               str = "L2"; break;
     case EM_SqLogDetJac:          str = "SqLogDetJac"; break;
     case EM_MinDetJac:            str = "MinDetJac"; break;
+
+    // -------------------------------------------------------------------------
+    // Others
+    case EM_MeanSquaredDisplacementError: str = "MSDE"; break;
 
     // ---------------------------------------------------------------------------
     // Unknown/invalid enumeration value
@@ -246,6 +255,10 @@ inline string ToPrettyString(const EnergyMeasure &value, int w = 0, char c = ' '
     case EM_L2Norm:               str = "l2 norm"; break;
     case EM_SqLogDetJac:          str = "Squared logarithm of Jacobian determinant"; break;
     case EM_MinDetJac:            str = "Minimum Jacobian determinant"; break;
+
+    // -------------------------------------------------------------------------
+    // Others
+    case EM_MeanSquaredDisplacementError: str = "Mean squared displacement error"; break;
 
     // ---------------------------------------------------------------------------
     // Unknown/invalid enumeration value

--- a/Modules/Registration/include/mirtk/GenericRegistrationFilter.h
+++ b/Modules/Registration/include/mirtk/GenericRegistrationFilter.h
@@ -278,6 +278,15 @@ public:
   /// Initial guess of optimal transformation
   mirtkPublicAggregateMacro(const Transformation, InitialGuess);
 
+  /// Target transformation to be approximated by output transformation
+  mirtkPublicAggregateMacro(const Transformation, TargetTransformation);
+
+  /// Name of target transformation MSDE term
+  mirtkPublicAttributeMacro(string, TargetTransformationErrorName);
+
+  /// Weight of target transformation MSDE term
+  mirtkPublicAttributeMacro(double, TargetTransformationErrorWeight);
+
   /// Whether to merge initial global transformation into (local) transformation
   mirtkPublicAttributeMacro(bool, MergeGlobalAndLocalTransformation);
 

--- a/Modules/Registration/include/mirtk/MeanSquaredDisplacementError.h
+++ b/Modules/Registration/include/mirtk/MeanSquaredDisplacementError.h
@@ -1,0 +1,119 @@
+/*
+ * Medical Image Registration ToolKit (MIRTK)
+ *
+ * Copyright 2017 Imperial College London
+ * Copyright 2017 Andreas Schuh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MIRTK_MeanSquaredDisplacementError_H
+#define MIRTK_MeanSquaredDisplacementError_H
+
+#include "mirtk/DataFidelity.h"
+#include "mirtk/RegisteredImage.h"
+
+
+namespace mirtk {
+
+
+/**
+ * Constrains displacement of each target voxel to be close to another transformation
+ *
+ * This constraint can be used to enforce some consistency of the optimized
+ * displacements with a given mean or pre-composed target displacement.
+ * The constraint may be relaxed for voxels with a stronger misalignment.
+ */
+class MeanSquaredDisplacementError : public DataFidelity
+{
+  mirtkEnergyTermMacro(DisplacementConstraint, EM_MeanSquaredDisplacementError);
+
+  // ---------------------------------------------------------------------------
+  // Types
+public:
+
+  /// Type of non-parametric gradient components
+  typedef double   GradientType;
+
+  /// Type of non-parametric gradient image
+  typedef GenericImage<GradientType>   GradientImageType;
+
+  /// Type of cached displacement fields
+  typedef RegisteredImage::DisplacementImageType   DisplacementImageType;
+
+  // ---------------------------------------------------------------------------
+  // Attributes
+protected:
+
+  /// Finite regular grid over which to integrate error
+  mirtkPublicAttributeMacro(ImageAttributes, Domain);
+
+  /// Target transformation
+  mirtkPublicAggregateMacro(const class Transformation, TargetTransformation);
+
+  /// Target displacements
+  mirtkAttributeMacro(DisplacementImageType, TargetDisplacement);
+
+  /// Current displacements
+  ///
+  /// This displacement field is used only when the transformation requires
+  /// the caching of the entire dense displacements for efficienty reasons
+  /// such as the scaling and squaring of a SV FFD. When an externally
+  /// computed/updated displacement field is given, it is used instead.
+  mirtkAttributeMacro(DisplacementImageType, CurrentDisplacement);
+
+  /// Pre-computed displacements which are updated by an external process
+  ///
+  /// When this displacement field is given, it is used instead of the
+  /// current transformation. The external process managing the optimization
+  /// has to ensure that the displacement field is updated whenever the
+  /// transformation changes.
+  mirtkPublicAggregateMacro(DisplacementImageType, ExternalDisplacement);
+
+  /// Non-parametric gradient
+  mirtkAttributeMacro(GradientImageType, NonParametricGradient);
+
+  // ---------------------------------------------------------------------------
+  // Construction/Destruction
+public:
+
+  /// Constructor
+  MeanSquaredDisplacementError(const char * = "", double = 1.);
+
+  // ---------------------------------------------------------------------------
+  // Evaluation
+
+  /// Initialize energy term once input and parameters have been set
+  virtual void Initialize();
+
+  /// Update internal state after change of DoFs
+  ///
+  /// \param[in] gradient Whether to also update internal state for evaluation
+  ///                     of energy gradient. If \c false, only the internal state
+  ///                     required for the energy evaluation need to be updated.
+  virtual void Update(bool gradient = true);
+
+protected:
+
+  /// Compute penalty for current transformation estimate
+  virtual double Evaluate();
+
+  /// Compute gradient of penalty term w.r.t transformation parameters
+  virtual void EvaluateGradient(double *, double, double);
+
+};
+
+
+} // namespace mirtk
+
+#endif // MIRTK_MeanSquaredDisplacementError_H

--- a/Modules/Registration/src/CMakeLists.txt
+++ b/Modules/Registration/src/CMakeLists.txt
@@ -39,6 +39,7 @@ set(HEADERS
   IntensityCrossCorrelation.h
   JointImageEntropy.h
   LabelConsistency.h
+  MeanSquaredDisplacementError.h
   MutualImageInformation.h
   NormalizedGradientFieldSimilarity.h
   NormalizedIntensityCrossCorrelation.h
@@ -66,6 +67,7 @@ set(SOURCES
   IntensityCrossCorrelation.cc
   JointImageEntropy.cc
   LabelConsistency.cc
+  MeanSquaredDisplacementError.cc
   MutualImageInformation.cc
   NormalizedGradientFieldSimilarity.cc
   NormalizedIntensityCrossCorrelation.cc

--- a/Modules/Registration/src/MeanSquaredDisplacementError.cc
+++ b/Modules/Registration/src/MeanSquaredDisplacementError.cc
@@ -1,0 +1,203 @@
+/*
+ * Medical Image Registration ToolKit (MIRTK)
+ *
+ * Copyright 2017 Imperial College London
+ * Copyright 2017 Andreas Schuh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mirtk/MeanSquaredDisplacementError.h"
+
+#include "mirtk/Math.h"
+#include "mirtk/ObjectFactory.h"
+
+
+namespace mirtk {
+
+
+// Register energy term with object factory during static initialization
+mirtkAutoRegisterEnergyTermMacro(MeanSquaredDisplacementError);
+
+
+// -----------------------------------------------------------------------------
+MeanSquaredDisplacementError::MeanSquaredDisplacementError(const char *name, double w)
+:
+  DataFidelity(name, w),
+  _TargetTransformation(nullptr),
+  _ExternalDisplacement(nullptr)
+{
+}
+
+// -----------------------------------------------------------------------------
+void MeanSquaredDisplacementError::Initialize()
+{
+  // Initialize base class
+  DataFidelity::Initialize();
+  if (_TargetTransformation == nullptr) return;
+
+  // Check required parameters
+  if (!_Domain) {
+    if (_ExternalDisplacement) {
+      _Domain = _ExternalDisplacement->Attributes();
+    } else {
+      Throw(ERR_LogicError, __FUNCTION__, "Finite regular grid domain not set!");
+    }
+  }
+
+  // Evaluate target displacement field
+  _TargetDisplacement.Initialize(_Domain, 3);
+  _TargetTransformation->Displacement(_TargetDisplacement);
+  if (_ExternalDisplacement) {
+    if (!_ExternalDisplacement->Attributes().EqualInSpace(_Domain)) {
+      Throw(ERR_InvalidArgument, __FUNCTION__, "Externally managed displacement field must have same spatial attributes as domain on which error is evaluated!");
+    }
+    if (_ExternalDisplacement->T() != 3) {
+      Throw(ERR_InvalidArgument, __FUNCTION__, "Externally managed displacement field must have 3 components/channels!");
+    }
+  }
+
+  // Allocate memory for cached displacement fields
+  _NonParametricGradient.Initialize(_Domain, 3);
+  if (Transformation()->RequiresCachingOfDisplacements() && !_ExternalDisplacement) {
+    _CurrentDisplacement.Initialize(_Domain, 3);
+  }
+}
+
+// -----------------------------------------------------------------------------
+void MeanSquaredDisplacementError::Update(bool gradient)
+{
+  // Update base class
+  DataFidelity::Update(gradient);
+  if (_TargetTransformation == nullptr) return;
+
+  // Update transformation displacements
+  if (Transformation()->RequiresCachingOfDisplacements() && !_ExternalDisplacement) {
+    Transformation()->Displacement(_CurrentDisplacement);
+  }
+}
+
+// -----------------------------------------------------------------------------
+double MeanSquaredDisplacementError::Evaluate()
+{
+  if (_TargetTransformation == nullptr) {
+    return 0.;
+  }
+
+  double error = 0.;
+  if (_ExternalDisplacement || !_CurrentDisplacement.IsEmpty()) {
+
+    const DisplacementImageType *currentdisplacement = _ExternalDisplacement;
+    if (currentdisplacement == nullptr) {
+      currentdisplacement = &_CurrentDisplacement;
+    }
+
+    if (currentdisplacement->X() != _TargetDisplacement.X() ||
+        currentdisplacement->Y() != _TargetDisplacement.Y() ||
+        currentdisplacement->Z() != _TargetDisplacement.Z()) {
+      Throw(ERR_LogicError, __FUNCTION__, "Displacement fields have differing size!");
+    }
+
+    Point q1, q2;
+    for (int k = 0; k < _TargetDisplacement.Z(); ++k)
+    for (int j = 0; j < _TargetDisplacement.Y(); ++j)
+    for (int i = 0; i < _TargetDisplacement.X(); ++i) {
+      q1._x = currentdisplacement->Get(i, j, k, 0);
+      q1._y = currentdisplacement->Get(i, j, k, 1);
+      q1._z = currentdisplacement->Get(i, j, k, 2);
+      q2._x = _TargetDisplacement(i, j, k, 0);
+      q2._y = _TargetDisplacement(i, j, k, 1);
+      q2._z = _TargetDisplacement(i, j, k, 2);
+      error += q1.Distance(q2);
+    }
+
+  } else {
+
+    Point p, q1, q2;
+    for (int k = 0; k < _TargetDisplacement.Z(); ++k)
+    for (int j = 0; j < _TargetDisplacement.Y(); ++j)
+    for (int i = 0; i < _TargetDisplacement.X(); ++i) {
+      p = Point(i, j, k);
+      _TargetDisplacement.ImageToWorld(p);
+      q1 = p, Transformation()->Transform(q1);
+      q2._x = p._x + _TargetDisplacement(i, j, k, 0);
+      q2._y = p._y + _TargetDisplacement(i, j, k, 1);
+      q2._z = p._z + _TargetDisplacement(i, j, k, 2);
+      error += q1.Distance(q2);
+    }
+
+  }
+  error /= _Domain.NumberOfSpatialPoints();
+  return error;
+}
+
+// -----------------------------------------------------------------------------
+void MeanSquaredDisplacementError::EvaluateGradient(double *gradient, double step, double weight)
+{
+  if (_TargetTransformation == nullptr) return;
+
+  if (_ExternalDisplacement || !_CurrentDisplacement.IsEmpty()) {
+
+    const DisplacementImageType *currentdisplacement = _ExternalDisplacement;
+    if (currentdisplacement == nullptr) {
+      currentdisplacement = &_CurrentDisplacement;
+    }
+
+    if (currentdisplacement->X() != _TargetDisplacement.X() ||
+        currentdisplacement->Y() != _TargetDisplacement.Y() ||
+        currentdisplacement->Z() != _TargetDisplacement.Z()) {
+      Throw(ERR_LogicError, __FUNCTION__, "Displacement fields have differing size!");
+    }
+
+    Point q1, q2;
+    for (int k = 0; k < _TargetDisplacement.Z(); ++k)
+    for (int j = 0; j < _TargetDisplacement.Y(); ++j)
+    for (int i = 0; i < _TargetDisplacement.X(); ++i) {
+      q1._x = currentdisplacement->Get(i, j, k, 0);
+      q1._y = currentdisplacement->Get(i, j, k, 1);
+      q1._z = currentdisplacement->Get(i, j, k, 2);
+      q2._x = _TargetDisplacement(i, j, k, 0);
+      q2._y = _TargetDisplacement(i, j, k, 1);
+      q2._z = _TargetDisplacement(i, j, k, 2);
+      _NonParametricGradient(i, j, k, 0) = 2. * static_cast<GradientType>(q1._x - q2._x);
+      _NonParametricGradient(i, j, k, 1) = 2. * static_cast<GradientType>(q1._y - q2._y);
+      _NonParametricGradient(i, j, k, 2) = 2. * static_cast<GradientType>(q1._z - q2._z);
+    }
+
+  } else {
+
+    Point p, q1, q2;
+    for (int k = 0; k < _TargetDisplacement.Z(); ++k)
+    for (int j = 0; j < _TargetDisplacement.Y(); ++j)
+    for (int i = 0; i < _TargetDisplacement.X(); ++i) {
+      p = Point(i, j, k);
+      _TargetDisplacement.ImageToWorld(p);
+      q1 = p, Transformation()->Transform(q1);
+      q2._x = p._x + _TargetDisplacement(i, j, k, 0);
+      q2._y = p._y + _TargetDisplacement(i, j, k, 1);
+      q2._z = p._z + _TargetDisplacement(i, j, k, 2);
+      _NonParametricGradient(i, j, k, 0) = 2. * static_cast<GradientType>(q1._x - q2._x);
+      _NonParametricGradient(i, j, k, 1) = 2. * static_cast<GradientType>(q1._y - q2._y);
+      _NonParametricGradient(i, j, k, 2) = 2. * static_cast<GradientType>(q1._z - q2._z);
+    }
+
+  }
+  _NonParametricGradient /= _Domain.NumberOfSpatialPoints();
+
+  const double t0 = _Domain._torigin;
+  _NonParametricGradient.PutTOrigin(t0); // TODO: Set actual source time?
+  Transformation()->ParametricGradient(&_NonParametricGradient, gradient, nullptr, t0, weight);
+}
+
+
+} // namespace mirtk

--- a/Modules/Registration/src/RegistrationEnergy.cc
+++ b/Modules/Registration/src/RegistrationEnergy.cc
@@ -178,8 +178,10 @@ void RegistrationEnergy::Initialize()
 
   // Initialize energy terms
   for (size_t i = 0; i < _Term.size(); ++i) {
-    _Term[i]->Transformation(_Transformation);
-    _Term[i]->Initialize();
+    if (IsActive(i)) {
+      _Term[i]->Transformation(_Transformation);
+      _Term[i]->Initialize();
+    }
   }
 
   // Adjust weight of sparsity constraint
@@ -245,7 +247,7 @@ bool RegistrationEnergy::Empty() const
 // -----------------------------------------------------------------------------
 bool RegistrationEnergy::IsActive(int i) const
 {
-  return _Term[i]->Weight() != 0.;
+  return !AreEqual(_Term[i]->Weight(), 0.);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Transformation/src/FreeFormTransformation.cc
+++ b/Modules/Transformation/src/FreeFormTransformation.cc
@@ -660,7 +660,8 @@ double FreeFormTransformation::ApproximateAsNew(const Transformation *t, int nit
 double FreeFormTransformation
 ::ApproximateAsNew(const ImageAttributes &domain, double *dx, double *dy, double *dz, int niter, double max_error)
 {
-  if ((_dt && domain == _attr) || (!_dt && domain.EqualInSpace(_attr))) {
+  bool ignore_time = (AreEqual(domain._dt, 0.) || domain._t == 1) && (AreEqual(_dt, 0.) || _t == 1);
+  if ((!ignore_time && domain == _attr) || (ignore_time && domain.EqualInSpace(_attr))) {
     this->Interpolate(dx, dy, dz);
     return .0; // No approximation error at lattice/control points
   }


### PR DESCRIPTION
The `MeanSquaredDisplacementError` can be used to constrain the transformation to resemble another such as a mean longitudinal deformation or a approximated composed transformation.