### PR TITLE
fix: Default t0 argument of Transformation functions, average-images [Transformation]

### DIFF
--- a/Applications/src/average-images.cc
+++ b/Applications/src/average-images.cc
@@ -445,7 +445,7 @@ bool Add(AverageImage &average, WeightImage *norm, InputImage &image,
     }
     if (cache) {
       const double t  = average.GetTOrigin();
-      const double t0 = -1.;
+      const double t0 = NaN;
       disp.Initialize(average.Attributes(), 3);
       // Note: Input transformation is from image to average!
       for (int n = ndofs - 1; n >= 0; --n) {

--- a/Modules/Transformation/include/mirtk/BSplineFreeFormTransformation3D.h
+++ b/Modules/Transformation/include/mirtk/BSplineFreeFormTransformation3D.h
@@ -240,7 +240,7 @@ public:
   // Point transformation
 
   /// Transforms a single point using the local transformation component only
-  virtual void LocalTransform(double &, double &, double &, double = 0, double = -1) const;
+  virtual void LocalTransform(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Whether this transformation implements a more efficient update of a given
   /// displacement field given the desired change of a transformation parameter
@@ -267,13 +267,13 @@ public:
   using FreeFormTransformation3D::JacobianDOFs;
 
   /// Calculates the Jacobian of the transformation w.r.t either control point displacements or velocities
-  virtual void FFDJacobianWorld(Matrix &, double, double, double, double = 0, double = -1) const;
+  virtual void FFDJacobianWorld(Matrix &, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the local transformation w.r.t world coordinates
-  virtual void LocalJacobian(Matrix &, double, double, double, double = 0, double = -1) const;
+  virtual void LocalJacobian(Matrix &, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Hessian for each component of the local transformation w.r.t world coordinates
-  virtual void LocalHessian(Matrix [3], double, double, double, double = 0, double = -1) const;
+  virtual void LocalHessian(Matrix [3], double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t. the parameters of a control point
   virtual void JacobianDOFs(double [3], int, int, int, double, double, double) const;
@@ -282,7 +282,7 @@ public:
   virtual void JacobianDetDerivative(Matrix *, int, int, int) const;
 
   /// Calculates the derivative of the Jacobian of the transformation (w.r.t. world coordinates) w.r.t. a transformation parameter
-  virtual void DeriveJacobianWrtDOF(Matrix &, int, double, double, double, double = 0, double = -1) const;
+  virtual void DeriveJacobianWrtDOF(Matrix &, int, double, double, double, double = 0, double = NaN) const;
 
   // ---------------------------------------------------------------------------
   // Properties
@@ -291,13 +291,13 @@ public:
   virtual int KernelSize() const;
 
   /// Calculates the bending energy of the transformation
-  virtual double BendingEnergy(double, double, double, double = 0, double = -1, bool = true) const;
+  virtual double BendingEnergy(double, double, double, double = 0, double = NaN, bool = true) const;
 
   /// Approximates the bending energy on the control point lattice
   virtual double BendingEnergy(bool = false, bool = true) const;
 
   /// Approximates the bending energy on the specified discrete domain
-  virtual double BendingEnergy(const ImageAttributes &, double = -1, bool = true) const;
+  virtual double BendingEnergy(const ImageAttributes &, double = NaN, bool = true) const;
 
   /// Approximates and adds the gradient of the bending energy on the control point
   /// lattice w.r.t the transformation parameters using the given weight

--- a/Modules/Transformation/include/mirtk/BSplineFreeFormTransformation4D.h
+++ b/Modules/Transformation/include/mirtk/BSplineFreeFormTransformation4D.h
@@ -212,7 +212,7 @@ public:
   // Point transformation
 
   /// Transforms a single point using the local transformation component only
-  virtual void LocalTransform(double &, double &, double &, double, double = -1) const;
+  virtual void LocalTransform(double &, double &, double &, double, double = NaN) const;
 
   // ---------------------------------------------------------------------------
   // Derivatives
@@ -222,26 +222,26 @@ public:
   using FreeFormTransformation4D::ParametricGradient;
 
   /// Calculates the Jacobian of the local transformation w.r.t world coordinates
-  virtual void LocalJacobian(Matrix &, double, double, double, double, double = -1) const;
+  virtual void LocalJacobian(Matrix &, double, double, double, double, double = NaN) const;
 
   /// Calculates the Hessian for each component of the local transformation w.r.t world coordinates
-  virtual void LocalHessian(Matrix [3], double, double, double, double, double = -1) const;
+  virtual void LocalHessian(Matrix [3], double, double, double, double, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t the transformation parameters
-  virtual void JacobianDOFs(Matrix &, int, int, int, int, double, double, double, double, double = -1) const;
+  virtual void JacobianDOFs(Matrix &, int, int, int, int, double, double, double, double, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t the transformation parameters
-  virtual void JacobianDOFs(double [3], int, int, int, int, double, double, double, double, double = -1) const;
+  virtual void JacobianDOFs(double [3], int, int, int, int, double, double, double, double, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t the transformation parameters
-  virtual void JacobianDOFs(TransformationJacobian &, double, double, double, double, double = -1) const;
+  virtual void JacobianDOFs(TransformationJacobian &, double, double, double, double, double = NaN) const;
 
   /// Applies the chain rule to convert spatial non-parametric gradient
   /// to a gradient w.r.t the parameters of this transformation
   virtual void ParametricGradient(const GenericImage<double> *, double *,
                                   const WorldCoordsImage *,
                                   const WorldCoordsImage *,
-                                  double = -1, double = 1.0) const;
+                                  double = NaN, double = 1.0) const;
 
   // ---------------------------------------------------------------------------
   // Properties
@@ -251,13 +251,13 @@ public:
   virtual int KernelSize() const;
 
   /// Calculates the bending of the transformation
-  virtual double BendingEnergy(double, double, double, double = 0, double = -1, bool = true) const;
+  virtual double BendingEnergy(double, double, double, double = 0, double = NaN, bool = true) const;
 
   /// Approximates the bending energy on the control point lattice
   virtual double BendingEnergy(bool = false, bool = true) const;
 
   /// Approximates the bending energy on the specified discrete domain
-  virtual double BendingEnergy(const ImageAttributes &, double = -1, bool = true) const;
+  virtual double BendingEnergy(const ImageAttributes &, double = NaN, bool = true) const;
 
   /// Approximates the gradient of the bending energy on the control point
   /// lattice w.r.t the transformation parameters and adds it with the given weight

--- a/Modules/Transformation/include/mirtk/BSplineFreeFormTransformationSV.h
+++ b/Modules/Transformation/include/mirtk/BSplineFreeFormTransformationSV.h
@@ -339,10 +339,10 @@ public:
   virtual bool RequiresCachingOfDisplacements() const;
 
   /// Transforms a single point using the local transformation component only
-  virtual void LocalTransform(double &, double &, double &, double = 0, double = -1) const;
+  virtual void LocalTransform(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the inverse of the local transformation only
-  virtual bool LocalInverse(double &, double &, double &, double = 0, double = -1) const;
+  virtual bool LocalInverse(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Get stationary velocity field
   void Velocity(GenericImage<float> &) const;
@@ -357,7 +357,7 @@ public:
   ///            added to the current displacements. Therefore, set the input
   ///            displacements to zero if only interested in the displacements of
   ///            this transformation at the voxel positions.
-  virtual void Displacement(GenericImage<double> &, double, double = -1,
+  virtual void Displacement(GenericImage<double> &, double, double = NaN,
                             const WorldCoordsImage * = NULL) const;
   
   /// Calculates the displacement vectors for a whole image domain
@@ -367,7 +367,7 @@ public:
   ///            added to the current displacements. Therefore, set the input
   ///            displacements to zero if only interested in the displacements of
   ///            this transformation at the voxel positions.
-  virtual void Displacement(GenericImage<float> &, double, double = -1,
+  virtual void Displacement(GenericImage<float> &, double, double = NaN,
                             const WorldCoordsImage * = NULL) const;
 
   /// Calculates the inverse displacement vectors for a whole image domain
@@ -379,7 +379,7 @@ public:
   ///            this transformation at the voxel positions.
   ///
   /// \returns Always zero.
-  virtual int InverseDisplacement(GenericImage<double> &, double, double = -1,
+  virtual int InverseDisplacement(GenericImage<double> &, double, double = NaN,
                                   const WorldCoordsImage * = NULL) const;
 
   /// Calculates the inverse displacement vectors for a whole image domain
@@ -391,7 +391,7 @@ public:
   ///            this transformation at the voxel positions.
   ///
   /// \returns Always zero.
-  virtual int InverseDisplacement(GenericImage<float> &, double, double = -1,
+  virtual int InverseDisplacement(GenericImage<float> &, double, double = NaN,
                                   const WorldCoordsImage * = NULL) const;
 
   // ---------------------------------------------------------------------------
@@ -401,13 +401,13 @@ public:
   using BSplineFreeFormTransformation3D::ParametricGradient;
 
   /// Calculates the Jacobian of the local transformation w.r.t world coordinates
-  virtual void LocalJacobian(Matrix &, double, double, double, double = 0, double = -1) const;
+  virtual void LocalJacobian(Matrix &, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Hessian for each component of the local transformation w.r.t world coordinates
-  virtual void LocalHessian(Matrix [3], double, double, double, double = 0, double = -1) const;
+  virtual void LocalHessian(Matrix [3], double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t a control point
-  virtual void JacobianDOFs(Matrix &, int, double, double, double, double = 0, double = -1) const;
+  virtual void JacobianDOFs(Matrix &, int, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t a transformation parameters
   ///
@@ -416,10 +416,10 @@ public:
   ///            w.r.t. the specified transformation parameter (not control point).
   ///            This is in accordance to the Transformation::JacobianDOFs
   ///            definition, which is violated, however, by most other FFDs.
-  virtual void JacobianDOFs(double [3], int, double, double, double, double = 0, double = -1) const;
+  virtual void JacobianDOFs(double [3], int, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t the transformation parameters
-  virtual void JacobianDOFs(TransformationJacobian &, double, double, double, double = 0, double = -1) const;
+  virtual void JacobianDOFs(TransformationJacobian &, double, double, double, double = 0, double = NaN) const;
 
 protected:
 
@@ -770,7 +770,7 @@ inline bool BSplineFreeFormTransformationSV::RequiresCachingOfDisplacements() co
 inline double BSplineFreeFormTransformationSV::UpperIntegrationLimit(double t, double t0) const
 {
   double T = t - t0;
-  return T ? T : _T; // if zero, return cross-sectional interval _T instead
+  return !IsNaN(T) && !AreEqual(T, 0.) ? T : _T; // if zero/NaN, return cross-sectional interval _T instead
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Transformation/include/mirtk/FreeFormTransformation.h
+++ b/Modules/Transformation/include/mirtk/FreeFormTransformation.h
@@ -593,16 +593,16 @@ public:
   using Transformation::Inverse;
 
   /// Transforms a single point using the global transformation component only
-  virtual void GlobalTransform(double &, double &, double &, double = 0, double = -1) const;
+  virtual void GlobalTransform(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point
-  virtual void Transform(double &, double &, double &, double = 0, double = -1) const;
+  virtual void Transform(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the inverse of the global transformation only
-  virtual void GlobalInverse(double &, double &, double &, double = 0, double = -1) const;
+  virtual void GlobalInverse(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the inverse of the transformation
-  virtual bool Inverse(double &, double &, double &, double = 0, double = -1) const;
+  virtual bool Inverse(double &, double &, double &, double = 0, double = NaN) const;
 
   // ---------------------------------------------------------------------------
   // Derivatives
@@ -640,25 +640,25 @@ public:
   void HessianToWorld(Matrix [3]) const;
 
   /// Calculates the Jacobian of the transformation w.r.t either control point displacements or velocities
-  virtual void FFDJacobianWorld(Matrix &, double, double, double, double = 0, double = -1) const;
+  virtual void FFDJacobianWorld(Matrix &, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the global transformation w.r.t world coordinates
-  virtual void GlobalJacobian(Matrix &, double, double, double, double = 0, double = -1) const;
+  virtual void GlobalJacobian(Matrix &, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t world coordinates
-  virtual void Jacobian(Matrix &, double, double, double, double = 0, double = -1) const;
+  virtual void Jacobian(Matrix &, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Hessian for each component of the global transformation w.r.t world coordinates
-  virtual void GlobalHessian(Matrix [3], double, double, double, double = 0, double = -1) const;
+  virtual void GlobalHessian(Matrix [3], double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Hessian for each component of the transformation w.r.t world coordinates
-  virtual void Hessian(Matrix [3], double, double, double, double = 0, double = -1) const;
+  virtual void Hessian(Matrix [3], double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t the transformation parameters of a control point
-  virtual void JacobianDOFs(Matrix &, int, double, double, double, double = 0, double = -1) const;
+  virtual void JacobianDOFs(Matrix &, int, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t the transformation parameters
-  virtual void JacobianDOFs(TransformationJacobian &, double, double, double, double = 0, double = -1) const;
+  virtual void JacobianDOFs(TransformationJacobian &, double, double, double, double = 0, double = NaN) const;
 
   /// Applies the chain rule to convert spatial non-parametric gradient
   /// to a gradient w.r.t the parameters of this transformation.
@@ -678,12 +678,12 @@ public:
   virtual void ParametricGradient(const GenericImage<double> *, double *,
                                   const WorldCoordsImage *,
                                   const WorldCoordsImage *,
-                                  double = -1, double = 1) const;
+                                  double = NaN, double = 1) const;
 
   /// Applies the chain rule to convert point-wise non-parametric gradient
   /// to a gradient w.r.t the parameters of this transformation.
   virtual void ParametricGradient(const PointSet &, const Vector3D<double> *,
-                                  double *, double = 0, double = -1, double = 1) const;
+                                  double *, double = 0, double = NaN, double = 1) const;
 
   // ---------------------------------------------------------------------------
   // Properties
@@ -692,13 +692,13 @@ public:
   static double Bending3D(const Matrix [3]);
 
   /// Calculates the bending of the transformation
-  virtual double BendingEnergy(double, double, double, double = 0, double = -1, bool = true) const;
+  virtual double BendingEnergy(double, double, double, double = 0, double = NaN, bool = true) const;
 
   /// Approximates the bending energy on the control point lattice
   virtual double BendingEnergy(bool = false, bool = true) const;
 
   /// Approximates the bending energy on the specified discrete domain
-  virtual double BendingEnergy(const ImageAttributes &attr, double = -1, bool = true) const;
+  virtual double BendingEnergy(const ImageAttributes &attr, double = NaN, bool = true) const;
 
   /// Approximates the gradient of the bending energy on the control point
   /// lattice w.r.t the transformation parameters and adds it with the given weight

--- a/Modules/Transformation/include/mirtk/FreeFormTransformation3D.h
+++ b/Modules/Transformation/include/mirtk/FreeFormTransformation3D.h
@@ -81,25 +81,25 @@ public:
   virtual void JacobianDOFs(Matrix &, int, int, int, double, double, double) const;
 
   /// Calculates the Jacobian of the transformation w.r.t a control point
-  virtual void JacobianDOFs(Matrix &, int, double, double, double, double = 0, double = -1) const;
+  virtual void JacobianDOFs(Matrix &, int, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t a control point
   virtual void JacobianDOFs(double [3], int, int, int, double, double, double) const;
 
   /// Calculates the Jacobian of the transformation w.r.t a transformation parameter
-  virtual void JacobianDOFs(double [3], int, double, double, double, double = 0, double = -1) const;
+  virtual void JacobianDOFs(double [3], int, double, double, double, double = 0, double = NaN) const;
 
   /// Applies the chain rule to convert spatial non-parametric gradient
   /// to a gradient w.r.t the parameters of this transformation
   virtual void ParametricGradient(const GenericImage<double> *, double *,
                                   const WorldCoordsImage *,
                                   const WorldCoordsImage *,
-                                  double = -1, double = 1) const;
+                                  double = NaN, double = 1) const;
 
   /// Applies the chain rule to convert point-wise non-parametric gradient
   /// to a gradient w.r.t the parameters of this transformation.
   virtual void ParametricGradient(const PointSet &, const Vector3D<double> *,
-                                  double *, double = 0, double = -1, double = 1) const;
+                                  double *, double = 0, double = NaN, double = 1) const;
 
   // ---------------------------------------------------------------------------
   // I/O

--- a/Modules/Transformation/include/mirtk/FreeFormTransformation4D.h
+++ b/Modules/Transformation/include/mirtk/FreeFormTransformation4D.h
@@ -66,16 +66,16 @@ public:
 
   /// Calculates the Jacobian of the transformation w.r.t a control point
   virtual void JacobianDOFs(Matrix &, int, int, int, int,
-                            double, double, double, double, double = -1) const;
+                            double, double, double, double, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t a control point
-  virtual void JacobianDOFs(Matrix &, int, double, double, double, double, double = -1) const;
+  virtual void JacobianDOFs(Matrix &, int, double, double, double, double, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t a control point
-  virtual void JacobianDOFs(double [3], int, int, int, int, double, double, double, double, double = -1) const;
+  virtual void JacobianDOFs(double [3], int, int, int, int, double, double, double, double, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t a transformation parameter
-  virtual void JacobianDOFs(double [3], int, double, double, double, double, double = -1) const;
+  virtual void JacobianDOFs(double [3], int, double, double, double, double, double = NaN) const;
 
   /// Applies the chain rule to convert spatial non-parametric gradient
   /// to a gradient w.r.t the parameters of this transformation
@@ -89,7 +89,7 @@ public:
   virtual void ParametricGradient(const GenericImage<double> *, double *,
                                   const WorldCoordsImage *,
                                   const WorldCoordsImage *,
-                                  double = -1, double = 1) const;
+                                  double = NaN, double = 1) const;
 
   // ---------------------------------------------------------------------------
   // I/O

--- a/Modules/Transformation/include/mirtk/LinearFreeFormTransformation3D.h
+++ b/Modules/Transformation/include/mirtk/LinearFreeFormTransformation3D.h
@@ -135,10 +135,10 @@ public:
   // Point transformation
 
   /// Transforms a single point using the local transformation only
-  virtual void LocalTransform(double &, double &, double &, double = 0, double = -1) const;
+  virtual void LocalTransform(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the inverse of the local transformation only
-  virtual bool LocalInverse(double &, double &, double &, double = 0, double = -1) const;
+  virtual bool LocalInverse(double &, double &, double &, double = 0, double = NaN) const;
 
   // ---------------------------------------------------------------------------
   // Derivatives
@@ -146,7 +146,7 @@ public:
   using FreeFormTransformation3D::JacobianDOFs;
 
   /// Calculates the Jacobian of the local transformation w.r.t world coordinates
-  virtual void LocalJacobian(Matrix &, double, double, double, double = 0, double = -1) const;
+  virtual void LocalJacobian(Matrix &, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t the transformation parameters
   virtual void JacobianDOFs(double [3], int, int, int, double, double, double) const;

--- a/Modules/Transformation/include/mirtk/LinearFreeFormTransformation4D.h
+++ b/Modules/Transformation/include/mirtk/LinearFreeFormTransformation4D.h
@@ -158,7 +158,7 @@ public:
   using FreeFormTransformation4D::JacobianDOFs;
 
   /// Calculates the Jacobian of the local transformation w.r.t world coordinates
-  virtual void LocalJacobian(Matrix &, double, double, double, double, double = -1) const;
+  virtual void LocalJacobian(Matrix &, double, double, double, double, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t the transformation parameters
   virtual void JacobianDOFs(double [3], int, int, int, int, double, double, double, double) const;
@@ -182,7 +182,7 @@ public:
 
   /// Approximates the gradient of the bending energy on the control point
   /// lattice w.r.t the transformation parameters and adds it with the given weight
-  virtual void BendingEnergyGradient(double *, double = -1, bool = false, bool = true) const;
+  virtual void BendingEnergyGradient(double *, double = NaN, bool = false, bool = true) const;
 
   // ---------------------------------------------------------------------------
   // I/O

--- a/Modules/Transformation/include/mirtk/MultiLevelFreeFormTransformation.h
+++ b/Modules/Transformation/include/mirtk/MultiLevelFreeFormTransformation.h
@@ -166,10 +166,10 @@ public:
   using MultiLevelTransformation::InverseDisplacement;
 
   /// Transforms a single point using the local transformation component only
-  virtual void LocalTransform(int, int, double &, double &, double &, double = 0, double = -1) const;
+  virtual void LocalTransform(int, int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point
-  virtual void Transform(int, int, double &, double &, double &, double = 0, double = -1) const;
+  virtual void Transform(int, int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Calculates the displacement vectors for a whole image domain
   ///
@@ -178,7 +178,7 @@ public:
   ///            added to the current displacements. Therefore, set the input
   ///            displacements to zero if only interested in the displacements of
   ///            this transformation at the voxel positions.
-  virtual void Displacement(int, int, GenericImage<double> &, double, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual void Displacement(int, int, GenericImage<double> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the displacement vectors for a whole image domain
   ///
@@ -187,7 +187,7 @@ public:
   ///            added to the current displacements. Therefore, set the input
   ///            displacements to zero if only interested in the displacements of
   ///            this transformation at the voxel positions.
-  virtual void Displacement(int, int, GenericImage<float> &, double, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual void Displacement(int, int, GenericImage<float> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Whether this transformation implements a more efficient update of a given
   /// displacement field given the desired change of a transformation parameter
@@ -215,7 +215,7 @@ public:
   ///            this transformation at the voxel positions.
   ///
   /// \returns Number of points for which transformation is non-invertible.
-  virtual int InverseDisplacement(int, int, GenericImage<double> &, double, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual int InverseDisplacement(int, int, GenericImage<double> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the inverse displacement vectors for a whole image domain
   ///
@@ -226,7 +226,7 @@ public:
   ///            this transformation at the voxel positions.
   ///
   /// \returns Number of points for which transformation is non-invertible.
-  virtual int InverseDisplacement(int, int, GenericImage<float> &, double, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual int InverseDisplacement(int, int, GenericImage<float> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   // ---------------------------------------------------------------------------
   // Derivatives
@@ -239,13 +239,13 @@ public:
   using MultiLevelTransformation::DeriveJacobianWrtDOF;
 
   /// Calculates the Jacobian of the transformation w.r.t world coordinates
-  virtual void Jacobian(int, int, Matrix &, double, double, double, double = 0, double = -1) const;
+  virtual void Jacobian(int, int, Matrix &, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Hessian for each component of the transformation w.r.t world coordinates
-  virtual void Hessian(int, int, Matrix [3], double, double, double, double = 0, double = -1) const;
+  virtual void Hessian(int, int, Matrix [3], double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the derivative of the Jacobian of the transformation (w.r.t. world coordinates) w.r.t. a transformation parameter
-  virtual void DeriveJacobianWrtDOF(Matrix &, int, double, double, double, double = 0, double = -1) const;
+  virtual void DeriveJacobianWrtDOF(Matrix &, int, double, double, double, double = 0, double = NaN) const;
 
   /// Applies the chain rule to convert spatial non-parametric gradient
   /// to a gradient w.r.t the parameters of this transformation.
@@ -265,12 +265,12 @@ public:
   virtual void ParametricGradient(const GenericImage<double> *, double *,
                                   const WorldCoordsImage * = NULL,
                                   const WorldCoordsImage * = NULL,
-                                  double = -1, double = 1) const;
+                                  double = NaN, double = 1) const;
 
   /// Applies the chain rule to convert point-wise non-parametric gradient
   /// to a gradient w.r.t the parameters of this transformation.
   virtual void ParametricGradient(const PointSet &, const Vector3D<double> *,
-                                  double *, double = 0, double = -1, double = 1) const;
+                                  double *, double = 0, double = NaN, double = 1) const;
 
   // ---------------------------------------------------------------------------
   // I/O

--- a/Modules/Transformation/include/mirtk/MultiLevelStationaryVelocityTransformation.h
+++ b/Modules/Transformation/include/mirtk/MultiLevelStationaryVelocityTransformation.h
@@ -203,10 +203,10 @@ public:
 
 
   /// Transforms a single point
-  virtual void Transform(int, int, double &, double &, double &, double = 0, double = 1) const;
+  virtual void Transform(int, int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the inverse of the transformation
-  virtual bool Inverse(int, int, double &, double &, double &, double = 0, double = 1) const;
+  virtual bool Inverse(int, int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Calculates the displacement vectors for a whole image domain
   ///
@@ -215,7 +215,7 @@ public:
   ///            added to the current displacements. Therefore, set the input
   ///            displacements to zero if only interested in the displacements of
   ///            this transformation at the voxel positions.
-  virtual void Displacement(int, int, GenericImage<double> &, double, double = 1, const WorldCoordsImage * = NULL) const;
+  virtual void Displacement(int, int, GenericImage<double> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the displacement vectors for a whole image domain
   ///
@@ -224,7 +224,7 @@ public:
   ///            added to the current displacements. Therefore, set the input
   ///            displacements to zero if only interested in the displacements of
   ///            this transformation at the voxel positions.
-  virtual void Displacement(int, int, GenericImage<float> &, double, double = 1, const WorldCoordsImage * = NULL) const;
+  virtual void Displacement(int, int, GenericImage<float> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the inverse displacement vectors for a whole image domain
   ///
@@ -235,7 +235,7 @@ public:
   ///            this transformation at the voxel positions.
   ///
   /// \returns Always zero.
-  virtual int InverseDisplacement(int, int, GenericImage<double> &, double, double = 1, const WorldCoordsImage * = NULL) const;
+  virtual int InverseDisplacement(int, int, GenericImage<double> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the inverse displacement vectors for a whole image domain
   ///
@@ -246,7 +246,7 @@ public:
   ///            this transformation at the voxel positions.
   ///
   /// \returns Always zero.
-  virtual int InverseDisplacement(int, int, GenericImage<float> &, double, double = 1, const WorldCoordsImage * = NULL) const;
+  virtual int InverseDisplacement(int, int, GenericImage<float> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   // ---------------------------------------------------------------------------
   // Derivatives
@@ -268,7 +268,7 @@ public:
   virtual void ParametricGradient(const GenericImage<double> *, double *,
                                   const WorldCoordsImage *,
                                   const WorldCoordsImage *,
-                                  double = 1, double = 1) const;
+                                  double = NaN, double = 1) const;
 
   // ---------------------------------------------------------------------------
   // I/O

--- a/Modules/Transformation/include/mirtk/MultiLevelTransformation.h
+++ b/Modules/Transformation/include/mirtk/MultiLevelTransformation.h
@@ -326,70 +326,61 @@ public:
   virtual bool RequiresCachingOfDisplacements() const;
 
   /// Transforms a single point using the global transformation component only
-  virtual void GlobalTransform(double &, double &, double &, double = 0, double = -1) const;
+  virtual void GlobalTransform(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the local transformation component only
-  virtual void LocalTransform(int, int, double &, double &, double &, double = 0, double = -1) const;
+  virtual void LocalTransform(int, int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the local transformation component only
-  virtual void LocalTransform(int, double &, double &, double &, double = 0, double = -1) const;
+  virtual void LocalTransform(int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the local transformation component only
-  virtual void LocalTransform(double &, double &, double &, double = 0, double = -1) const;
+  virtual void LocalTransform(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point
-  virtual void Transform(int, int, double &, double &, double &, double = 0, double = -1) const = 0;
+  virtual void Transform(int, int, double &, double &, double &, double = 0, double = NaN) const = 0;
 
   /// Transforms a single point
-  virtual void Transform(int, double &, double &, double &, double = 0, double = -1) const;
+  virtual void Transform(int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point
-  virtual void Transform(double &, double &, double &, double = 0, double = -1) const;
+  virtual void Transform(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point
-  virtual void Transform(int, int, Point &, double = 0, double = -1) const;
+  virtual void Transform(int, int, Point &, double = 0, double = NaN) const;
 
   /// Transforms a single point
-  virtual void Transform(int, Point &, double = 0, double = -1) const;
+  virtual void Transform(int, Point &, double = 0, double = NaN) const;
 
   /// Transforms a set of points
-  virtual void Transform(int, int, PointSet &, double = 0, double = -1) const;
+  virtual void Transform(int, int, PointSet &, double = 0, double = NaN) const;
 
   /// Transforms a set of points
-  virtual void Transform(int, PointSet &, double = 0, double = -1) const;
+  virtual void Transform(int, PointSet &, double = 0, double = NaN) const;
 
   /// Calculates the displacement of a single point using the local transformation component only
-  virtual void LocalDisplacement(int, int, double &, double &, double &, double = 0, double = -1) const;
+  virtual void LocalDisplacement(int, int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Calculates the displacement of a single point using the local transformation component only
-  virtual void LocalDisplacement(int, double &, double &, double &, double = 0, double = -1) const;
+  virtual void LocalDisplacement(int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Calculates the displacement of a single point
-  virtual void Displacement(int, int, double &, double &, double &, double = 0, double = -1) const;
+  virtual void Displacement(int, int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Calculates the displacement of a single point
-  virtual void Displacement(int, double &, double &, double &, double = 0, double = -1) const;
+  virtual void Displacement(int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Calculates the displacement vectors for a whole image domain
-  virtual void Displacement(int, int, GenericImage<double> &, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual void Displacement(int, int, GenericImage<double> &, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the displacement vectors for a whole image domain
-  virtual void Displacement(int, int, GenericImage<float> &, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual void Displacement(int, int, GenericImage<float> &, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the displacement vectors for a whole image domain
-  virtual void Displacement(int, GenericImage<double> &, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual void Displacement(int, GenericImage<double> &, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the displacement vectors for a whole image domain
-  virtual void Displacement(int, GenericImage<float> &, double = -1, const WorldCoordsImage * = NULL) const;
-
-  /// Calculates the displacement vectors for a whole image domain
-  ///
-  /// \attention The displacements are computed at the positions after applying the
-  ///            current displacements at each voxel. These displacements are then
-  ///            added to the current displacements. Therefore, set the input
-  ///            displacements to zero if only interested in the displacements of
-  ///            this transformation at the voxel positions.
-  virtual void Displacement(int, int, GenericImage<double> &, double, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual void Displacement(int, GenericImage<float> &, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the displacement vectors for a whole image domain
   ///
@@ -398,7 +389,7 @@ public:
   ///            added to the current displacements. Therefore, set the input
   ///            displacements to zero if only interested in the displacements of
   ///            this transformation at the voxel positions.
-  virtual void Displacement(int, int, GenericImage<float> &, double, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual void Displacement(int, int, GenericImage<double> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the displacement vectors for a whole image domain
   ///
@@ -407,7 +398,7 @@ public:
   ///            added to the current displacements. Therefore, set the input
   ///            displacements to zero if only interested in the displacements of
   ///            this transformation at the voxel positions.
-  virtual void Displacement(int, GenericImage<double> &, double, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual void Displacement(int, int, GenericImage<float> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the displacement vectors for a whole image domain
   ///
@@ -416,7 +407,7 @@ public:
   ///            added to the current displacements. Therefore, set the input
   ///            displacements to zero if only interested in the displacements of
   ///            this transformation at the voxel positions.
-  virtual void Displacement(int, GenericImage<float> &, double, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual void Displacement(int, GenericImage<double> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the displacement vectors for a whole image domain
   ///
@@ -425,7 +416,7 @@ public:
   ///            added to the current displacements. Therefore, set the input
   ///            displacements to zero if only interested in the displacements of
   ///            this transformation at the voxel positions.
-  virtual void Displacement(GenericImage<double> &, double, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual void Displacement(int, GenericImage<float> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the displacement vectors for a whole image domain
   ///
@@ -434,40 +425,49 @@ public:
   ///            added to the current displacements. Therefore, set the input
   ///            displacements to zero if only interested in the displacements of
   ///            this transformation at the voxel positions.
-  virtual void Displacement(GenericImage<float> &, double, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual void Displacement(GenericImage<double> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
+
+  /// Calculates the displacement vectors for a whole image domain
+  ///
+  /// \attention The displacements are computed at the positions after applying the
+  ///            current displacements at each voxel. These displacements are then
+  ///            added to the current displacements. Therefore, set the input
+  ///            displacements to zero if only interested in the displacements of
+  ///            this transformation at the voxel positions.
+  virtual void Displacement(GenericImage<float> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Transforms a single point using the inverse of the global transformation only
-  virtual void GlobalInverse(double &, double &, double &, double = 0, double = -1) const;
+  virtual void GlobalInverse(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the inverse of the local transformation only
-  virtual bool LocalInverse(int, int, double &, double &, double &, double = 0, double = -1) const;
+  virtual bool LocalInverse(int, int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the inverse of the local transformation only
-  virtual bool LocalInverse(int, double &, double &, double &, double = 0, double = -1) const;
+  virtual bool LocalInverse(int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the inverse of the local transformation only
-  virtual bool LocalInverse(double &, double &, double &, double = 0, double = -1) const;
+  virtual bool LocalInverse(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the inverse of the transformation
-  virtual bool Inverse(int, int, double &, double &, double &, double = 0, double = -1) const;
+  virtual bool Inverse(int, int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the inverse of the transformation
-  virtual bool Inverse(int, double &, double &, double &, double = 0, double = -1) const;
+  virtual bool Inverse(int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the inverse of the transformation
-  virtual bool Inverse(double &, double &, double &, double = 0, double = -1) const;
+  virtual bool Inverse(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Calculates the displacement of a single point using the inverse of the local transformation only
-  virtual bool LocalInverseDisplacement(int, int, double &, double &, double &, double = 0, double = -1) const;
+  virtual bool LocalInverseDisplacement(int, int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Calculates the displacement of a single point using the inverse of the local transformation only
-  virtual bool LocalInverseDisplacement(int, double &, double &, double &, double = 0, double = -1) const;
+  virtual bool LocalInverseDisplacement(int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Calculates the displacement of a single point using the inverse of the transformation
-  virtual bool InverseDisplacement(int, int, double &, double &, double &, double = 0, double = -1) const;
+  virtual bool InverseDisplacement(int, int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Calculates the displacement of a single point using the inverse of the transformation
-  virtual bool InverseDisplacement(int, double &, double &, double &, double = 0, double = -1) const;
+  virtual bool InverseDisplacement(int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Calculates the inverse displacement vectors for a whole image domain
   ///
@@ -478,7 +478,7 @@ public:
   ///            this transformation at the voxel positions.
   ///
   /// \returns Number of points at which transformation is non-invertible.
-  virtual int InverseDisplacement(int, int, GenericImage<double> &, double, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual int InverseDisplacement(int, int, GenericImage<double> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the inverse displacement vectors for a whole image domain
   ///
@@ -489,7 +489,7 @@ public:
   ///            this transformation at the voxel positions.
   ///
   /// \returns Number of points at which transformation is non-invertible.
-  virtual int InverseDisplacement(int, int, GenericImage<float> &, double, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual int InverseDisplacement(int, int, GenericImage<float> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the inverse displacement vectors for a whole image domain
   ///
@@ -500,7 +500,7 @@ public:
   ///            this transformation at the voxel positions.
   ///
   /// \returns Number of points at which transformation is non-invertible.
-  virtual int InverseDisplacement(int, GenericImage<double> &, double, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual int InverseDisplacement(int, GenericImage<double> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the inverse displacement vectors for a whole image domain
   ///
@@ -511,7 +511,7 @@ public:
   ///            this transformation at the voxel positions.
   ///
   /// \returns Number of points at which transformation is non-invertible.
-  virtual int InverseDisplacement(int, GenericImage<float> &, double, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual int InverseDisplacement(int, GenericImage<float> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the inverse displacement vectors for a whole image domain
   ///
@@ -522,7 +522,7 @@ public:
   ///            this transformation at the voxel positions.
   ///
   /// \returns Number of points at which transformation is non-invertible.
-  virtual int InverseDisplacement(GenericImage<double> &, double, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual int InverseDisplacement(GenericImage<double> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the inverse displacement vectors for a whole image domain
   ///
@@ -533,7 +533,7 @@ public:
   ///            this transformation at the voxel positions.
   ///
   /// \returns Number of points at which transformation is non-invertible.
-  virtual int InverseDisplacement(GenericImage<float> &, double, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual int InverseDisplacement(GenericImage<float> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   // ---------------------------------------------------------------------------
   // Derivatives
@@ -544,67 +544,67 @@ public:
   using Transformation::Jacobian;
 
   /// Calculates the Jacobian of the global transformation w.r.t world coordinates
-  virtual void GlobalJacobian(Matrix &, double, double, double, double = 0, double = -1) const;
+  virtual void GlobalJacobian(Matrix &, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the local transformation w.r.t world coordinates
-  virtual void LocalJacobian(int, Matrix &, double, double, double, double = 0, double = -1) const;
+  virtual void LocalJacobian(int, Matrix &, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the local transformation w.r.t world coordinates
-  virtual void LocalJacobian(Matrix &, double, double, double, double = 0, double = -1) const;
+  virtual void LocalJacobian(Matrix &, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t world coordinates
-  virtual void Jacobian(int, int, Matrix &, double, double, double, double = 0, double = -1) const;
+  virtual void Jacobian(int, int, Matrix &, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t world coordinates
-  virtual void Jacobian(int, Matrix &, double, double, double, double = 0, double = -1) const;
+  virtual void Jacobian(int, Matrix &, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t world coordinates
-  virtual void Jacobian(Matrix &, double, double, double, double = 0, double = -1) const;
+  virtual void Jacobian(Matrix &, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the determinant of the Jacobian of the local transformation w.r.t world coordinates
-  virtual double LocalJacobian(int, double, double, double, double = 0, double = -1) const;
+  virtual double LocalJacobian(int, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the determinant of the Jacobian of the transformation w.r.t world coordinates
-  virtual double Jacobian(int, int, double, double, double, double = 0, double = -1) const;
+  virtual double Jacobian(int, int, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the determinant of the Jacobian of the transformation w.r.t world coordinates
-  virtual double Jacobian(int, double, double, double, double = 0, double = -1) const;
+  virtual double Jacobian(int, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Hessian for each component of the global transformation w.r.t world coordinates
-  virtual void GlobalHessian(Matrix [3], double, double, double, double = 0, double = -1) const;
+  virtual void GlobalHessian(Matrix [3], double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Hessian for each component of the local transformation w.r.t world coordinates
-  virtual void LocalHessian(int, Matrix [3], double, double, double, double = 0, double = -1) const;
+  virtual void LocalHessian(int, Matrix [3], double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Hessian for each component of the local transformation w.r.t world coordinates
-  virtual void LocalHessian(Matrix [3], double, double, double, double = 0, double = -1) const;
+  virtual void LocalHessian(Matrix [3], double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Hessian for each component of the transformation w.r.t world coordinates
-  virtual void Hessian(int, int, Matrix [3], double, double, double, double = 0, double = -1) const;
+  virtual void Hessian(int, int, Matrix [3], double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Hessian for each component of the transformation w.r.t world coordinates
-  virtual void Hessian(int, Matrix [3], double, double, double, double = 0, double = -1) const;
+  virtual void Hessian(int, Matrix [3], double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Hessian for each component of the transformation w.r.t world coordinates
-  virtual void Hessian(Matrix [3], double, double, double, double = 0, double = -1) const;
+  virtual void Hessian(Matrix [3], double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t the transformation parameters
-  virtual void JacobianDOFs(double [3], int, double, double, double, double = 0, double = -1) const;
+  virtual void JacobianDOFs(double [3], int, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the derivative of the Jacobian of the transformation (w.r.t. world coordinates) w.r.t. a transformation parameter
-  virtual void DeriveJacobianWrtDOF(Matrix &, int, double, double, double, double = 0, double = -1) const;
+  virtual void DeriveJacobianWrtDOF(Matrix &, int, double, double, double, double = 0, double = NaN) const;
 
   // ---------------------------------------------------------------------------
   // Properties
 
   /// Calculates the bending energy of the transformation
-  virtual double BendingEnergy(int, int, double, double, double, double = 0, double = -1, bool = true) const;
+  virtual double BendingEnergy(int, int, double, double, double, double = 0, double = NaN, bool = true) const;
 
   /// Calculates the bending energy of the transformation
-  virtual double BendingEnergy(int, double, double, double, double = 0, double = -1, bool = true) const;
+  virtual double BendingEnergy(int, double, double, double, double = 0, double = NaN, bool = true) const;
 
   /// Calculates the bending energy of the transformation
-  virtual double BendingEnergy(double, double, double, double = 0, double = -1, bool = true) const;
+  virtual double BendingEnergy(double, double, double, double = 0, double = NaN, bool = true) const;
 
   // ---------------------------------------------------------------------------
   // I/O

--- a/Modules/Transformation/include/mirtk/PartialBSplineFreeFormTransformationSV.h
+++ b/Modules/Transformation/include/mirtk/PartialBSplineFreeFormTransformationSV.h
@@ -139,22 +139,22 @@ public:
   virtual bool RequiresCachingOfDisplacements() const;
 
   /// Transforms a single point using the global transformation component only
-  virtual void GlobalTransform(double &, double &, double &, double = 0, double = 1) const;
+  virtual void GlobalTransform(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the local transformation component only
-  virtual void LocalTransform(double &, double &, double &, double = 0, double = 1) const;
+  virtual void LocalTransform(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point
-  virtual void Transform(double &, double &, double &, double = 0, double = 1) const;
+  virtual void Transform(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the inverse of the global transformation only
-  virtual void GlobalInverse(double &, double &, double &, double = 0, double = 1) const;
+  virtual void GlobalInverse(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the inverse of the local transformation only
-  virtual bool LocalInverse(double &, double &, double &, double = 0, double = 1) const;
+  virtual bool LocalInverse(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the inverse of the transformation
-  virtual bool Inverse(double &, double &, double &, double = 0, double = 1) const;
+  virtual bool Inverse(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Calculates the displacement vectors for a whole image domain
   ///
@@ -163,7 +163,7 @@ public:
   ///            added to the current displacements. Therefore, set the input
   ///            displacements to zero if only interested in the displacements of
   ///            this transformation at the voxel positions.
-  virtual void Displacement(GenericImage<double> &, double, double = 1, const WorldCoordsImage * = NULL) const;
+  virtual void Displacement(GenericImage<double> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the displacement vectors for a whole image domain
   ///
@@ -172,7 +172,7 @@ public:
   ///            added to the current displacements. Therefore, set the input
   ///            displacements to zero if only interested in the displacements of
   ///            this transformation at the voxel positions.
-  virtual void Displacement(GenericImage<float> &, double, double = 1, const WorldCoordsImage * = NULL) const;
+  virtual void Displacement(GenericImage<float> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the inverse displacement vectors for a whole image domain
   ///
@@ -183,7 +183,7 @@ public:
   ///            this transformation at the voxel positions.
   ///
   /// \returns Always zero.
-  virtual int InverseDisplacement(GenericImage<double> &, double, double = 1, const WorldCoordsImage * = NULL) const;
+  virtual int InverseDisplacement(GenericImage<double> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the inverse displacement vectors for a whole image domain
   ///
@@ -194,7 +194,7 @@ public:
   ///            this transformation at the voxel positions.
   ///
   /// \returns Always zero.
-  virtual int InverseDisplacement(GenericImage<float> &, double, double = 1, const WorldCoordsImage * = NULL) const;
+  virtual int InverseDisplacement(GenericImage<float> &, double, double = NaN, const WorldCoordsImage * = NULL) const;
 
   // ---------------------------------------------------------------------------
   // Derivatives
@@ -204,32 +204,32 @@ public:
   using Transformation::Jacobian;
 
   /// Calculates the Jacobian of the global transformation w.r.t world coordinates
-  virtual void GlobalJacobian(Matrix &, double, double, double, double = 0, double = 1) const;
+  virtual void GlobalJacobian(Matrix &, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the local transformation w.r.t world coordinates
-  virtual void LocalJacobian(Matrix &, double, double, double, double = 0, double = 1) const;
+  virtual void LocalJacobian(Matrix &, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t world coordinates
-  virtual void Jacobian(Matrix &, double, double, double, double = 0, double = 1) const;
+  virtual void Jacobian(Matrix &, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Hessian for each component of the global transformation w.r.t world coordinates
-  virtual void GlobalHessian(Matrix [3], double, double, double, double = 0, double = 1) const;
+  virtual void GlobalHessian(Matrix [3], double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Hessian for each component of the local transformation w.r.t world coordinates
-  virtual void LocalHessian(Matrix [3], double, double, double, double = 0, double = 1) const;
+  virtual void LocalHessian(Matrix [3], double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Hessian for each component of the transformation w.r.t world coordinates
-  virtual void Hessian(Matrix [3], double, double, double, double = 0, double = 1) const;
+  virtual void Hessian(Matrix [3], double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t the transformation parameters
-  virtual void JacobianDOFs(double [3], int, double, double, double, double = 0, double = 1) const;
+  virtual void JacobianDOFs(double [3], int, double, double, double, double = 0, double = NaN) const;
 
   /// Applies the chain rule to convert spatial non-parametric gradient
   /// to a gradient w.r.t the parameters of this transformation.
   virtual void ParametricGradient(const GenericImage<double> *, double *,
                                   const WorldCoordsImage *,
                                   const WorldCoordsImage *,
-                                  double = 1, double = 1) const;
+                                  double = NaN, double = 1) const;
 
 
   /// Applies the chain rule to convert spatial non-parametric gradient

--- a/Modules/Transformation/include/mirtk/PartialMultiLevelStationaryVelocityTransformation.h
+++ b/Modules/Transformation/include/mirtk/PartialMultiLevelStationaryVelocityTransformation.h
@@ -175,22 +175,22 @@ public:
   virtual bool RequiresCachingOfDisplacements() const;
 
   /// Transforms a single point using the global transformation component only
-  virtual void GlobalTransform(double &, double &, double &, double = 0, double = 1) const;
+  virtual void GlobalTransform(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the local transformation component only
-  virtual void LocalTransform(int, int, double &, double &, double &, double = 0, double = 1) const;
+  virtual void LocalTransform(int, int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point
-  virtual void Transform(int, int, double &, double &, double &, double = 0, double = 1) const;
+  virtual void Transform(int, int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the inverse of the global transformation only
-  virtual void GlobalInverse(double &, double &, double &, double = 0, double = 1) const;
+  virtual void GlobalInverse(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the inverse of the local transformation only
-  virtual bool LocalInverse(int, int, double &, double &, double &, double = 0, double = 1) const;
+  virtual bool LocalInverse(int, int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the inverse of the transformation
-  virtual bool Inverse(int, int, double &, double &, double &, double = 0, double = 1) const;
+  virtual bool Inverse(int, int, double &, double &, double &, double = 0, double = NaN) const;
 
   /// Calculates the displacement vectors for a whole image domain
   ///
@@ -241,7 +241,7 @@ public:
   virtual void ParametricGradient(const GenericImage<double> *, double *,
                                   const WorldCoordsImage *,
                                   const WorldCoordsImage *,
-                                  double = 1, double = 1) const;
+                                  double = NaN, double = 1) const;
 
 
   /// Applies the chain rule to convert spatial non-parametric gradient

--- a/Modules/Transformation/include/mirtk/Transformation.h
+++ b/Modules/Transformation/include/mirtk/Transformation.h
@@ -332,37 +332,37 @@ public:
   virtual bool RequiresCachingOfDisplacements() const;
 
   /// Transforms a single point using the global transformation component only
-  virtual void GlobalTransform(double &, double &, double &, double = 0, double = -1) const = 0;
+  virtual void GlobalTransform(double &, double &, double &, double = 0, double = NaN) const = 0;
 
   /// Transforms a single point using the local transformation component only
-  virtual void LocalTransform(double &, double &, double &, double = 0, double = -1) const = 0;
+  virtual void LocalTransform(double &, double &, double &, double = 0, double = NaN) const = 0;
 
   /// Transforms a single point
-  virtual void Transform(double &, double &, double &, double = 0, double = -1) const = 0;
+  virtual void Transform(double &, double &, double &, double = 0, double = NaN) const = 0;
 
   /// Transforms a single point
-  virtual void Transform(Point &, double = 0, double = -1) const;
+  virtual void Transform(Point &, double = 0, double = NaN) const;
 
   /// Transforms a set of points
-  virtual void Transform(PointSet &, double = 0, double = -1) const;
+  virtual void Transform(PointSet &, double = 0, double = NaN) const;
 
   /// Transforms a set of points
-  virtual void Transform(int, double *, double *, double *, double = 0, double = -1) const;
+  virtual void Transform(int, double *, double *, double *, double = 0, double = NaN) const;
 
   /// Transforms a set of points
-  virtual void Transform(int, double *, double *, double *, const double *, double = -1) const;
+  virtual void Transform(int, double *, double *, double *, const double *, double = NaN) const;
 
   /// Transforms world coordinates of image voxels
-  virtual void Transform(WorldCoordsImage &, double = -1) const;
+  virtual void Transform(WorldCoordsImage &, double = NaN) const;
 
   /// Calculates the displacement of a single point using the global transformation component only
-  virtual void GlobalDisplacement(double &, double &, double &, double = 0, double = -1) const;
+  virtual void GlobalDisplacement(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Calculates the displacement of a single point using the local transformation component only
-  virtual void LocalDisplacement(double &, double &, double &, double = 0, double = -1) const;
+  virtual void LocalDisplacement(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Calculates the displacement of a single point
-  virtual void Displacement(double &, double &, double &, double = 0, double = -1) const;
+  virtual void Displacement(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Calculates the displacement at specified lattice points
   ///
@@ -374,10 +374,10 @@ public:
   virtual void Displacement(const ImageAttributes &, double *, double *, double *) const;
 
   /// Calculates the displacement vectors for a whole image domain
-  virtual void Displacement(GenericImage<double> &, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual void Displacement(GenericImage<double> &, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the displacement vectors for a whole image domain
-  virtual void Displacement(GenericImage<float> &, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual void Displacement(GenericImage<float> &, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the displacement vectors for a whole image domain
   ///
@@ -411,34 +411,34 @@ public:
   /// \param[in]     i2w Pre-computed world coordinates.
   virtual void DisplacementAfterDOFChange(int dof, double dv,
                                           GenericImage<double> &dx,
-                                          double t, double t0 = -1,
+                                          double t, double t0 = NaN,
                                           const WorldCoordsImage *i2w = NULL) const;
 
   /// Transforms a single point using the inverse of the global transformation only
-  virtual void GlobalInverse(double &, double &, double &, double = 0, double = -1) const;
+  virtual void GlobalInverse(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the inverse of the local transformation only
-  virtual bool LocalInverse(double &, double &, double &, double = 0, double = -1) const;
+  virtual bool LocalInverse(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the inverse of the transformation
-  virtual bool Inverse(double &, double &, double &, double = 0, double = -1) const;
+  virtual bool Inverse(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Transforms a single point using the inverse of the transformation
-  virtual bool Inverse(Point &, double = 0, double = -1) const;
+  virtual bool Inverse(Point &, double = 0, double = NaN) const;
 
   /// Transforms a set of points using the inverse of the transformation
   ///
   /// \returns Number of points at which transformation is non-invertible.
-  virtual int Inverse(PointSet &, double = 0, double = -1) const;
+  virtual int Inverse(PointSet &, double = 0, double = NaN) const;
 
   /// Calculates the displacement of a single point using the inverse of the global transformation only
-  virtual void GlobalInverseDisplacement(double &, double &, double &, double = 0, double = -1) const;
+  virtual void GlobalInverseDisplacement(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Calculates the displacement of a single point using the inverse of the local transformation only
-  virtual bool LocalInverseDisplacement(double &, double &, double &, double = 0, double = -1) const;
+  virtual bool LocalInverseDisplacement(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Calculates the displacement of a single point using the inverse of the transformation
-  virtual bool InverseDisplacement(double &, double &, double &, double = 0, double = -1) const;
+  virtual bool InverseDisplacement(double &, double &, double &, double = 0, double = NaN) const;
 
   /// Calculates the inverse displacement at specified lattice points
   ///
@@ -454,12 +454,12 @@ public:
   /// Calculates the inverse displacement vectors for a whole image domain
   ///
   /// \returns Number of points at which transformation is non-invertible.
-  virtual int InverseDisplacement(GenericImage<double> &, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual int InverseDisplacement(GenericImage<double> &, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the inverse displacement vectors for a whole image domain
   ///
   /// \returns Number of points at which transformation is non-invertible.
-  virtual int InverseDisplacement(GenericImage<float> &, double = -1, const WorldCoordsImage * = NULL) const;
+  virtual int InverseDisplacement(GenericImage<float> &, double = NaN, const WorldCoordsImage * = NULL) const;
 
   /// Calculates the inverse displacement vectors for a whole image domain
   ///
@@ -487,37 +487,37 @@ public:
   // Derivatives
 
   /// Calculates the Jacobian of the global transformation w.r.t world coordinates
-  virtual void GlobalJacobian(Matrix &, double, double, double, double = 0, double = -1) const;
+  virtual void GlobalJacobian(Matrix &, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the local transformation w.r.t world coordinates
-  virtual void LocalJacobian(Matrix &, double, double, double, double = 0, double = -1) const;
+  virtual void LocalJacobian(Matrix &, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t world coordinates
-  virtual void Jacobian(Matrix &, double, double, double, double = 0, double = -1) const;
+  virtual void Jacobian(Matrix &, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the determinant of the Jacobian of the global transformation w.r.t world coordinates
-  virtual double GlobalJacobian(double, double, double, double = 0, double = -1) const;
+  virtual double GlobalJacobian(double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the determinant of the Jacobian of the local transformation w.r.t world coordinates
-  virtual double LocalJacobian(double, double, double, double = 0, double = -1) const;
+  virtual double LocalJacobian(double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the determinant of the Jacobian of the transformation w.r.t world coordinates
-  virtual double Jacobian(double, double, double, double = 0, double = -1) const;
+  virtual double Jacobian(double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Hessian for each component of the global transformation w.r.t world coordinates
-  virtual void GlobalHessian(Matrix [3], double, double, double, double = 0, double = -1) const;
+  virtual void GlobalHessian(Matrix [3], double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Hessian for each component of the local transformation w.r.t world coordinates
-  virtual void LocalHessian(Matrix [3], double, double, double, double = 0, double = -1) const;
+  virtual void LocalHessian(Matrix [3], double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Hessian for each component of the transformation w.r.t world coordinates
-  virtual void Hessian(Matrix [3], double, double, double, double = 0, double = -1) const;
+  virtual void Hessian(Matrix [3], double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the Jacobian of the transformation w.r.t a transformation parameter
-  virtual void JacobianDOFs(double [3], int, double, double, double, double = 0, double = -1) const;
+  virtual void JacobianDOFs(double [3], int, double, double, double, double = 0, double = NaN) const;
 
   /// Calculates the derivative of the Jacobian of the transformation (w.r.t. world coordinates) w.r.t. a transformation parameter
-  virtual void DeriveJacobianWrtDOF(Matrix &, int, double, double, double, double = 0, double = -1) const;
+  virtual void DeriveJacobianWrtDOF(Matrix &, int, double, double, double, double = 0, double = NaN) const;
 
   /// Applies the chain rule to convert spatial non-parametric gradient
   /// to a gradient w.r.t the parameters of this transformation.
@@ -537,18 +537,18 @@ public:
   virtual void ParametricGradient(const GenericImage<double> *, double *,
                                   const WorldCoordsImage *,
                                   const WorldCoordsImage *,
-                                  double = -1, double = 1) const;
+                                  double = NaN, double = 1) const;
 
   /// Applies the chain rule to convert spatial non-parametric gradient
   /// to a gradient w.r.t the parameters of this transformation.
   void ParametricGradient(const GenericImage<double> *, double *,
                           const WorldCoordsImage *,
-                          double = -1, double = 1) const;
+                          double = NaN, double = 1) const;
 
   /// Applies the chain rule to convert spatial non-parametric gradient
   /// to a gradient w.r.t the parameters of this transformation.
   void ParametricGradient(const GenericImage<double> *, double *,
-                          double = -1, double = 1) const;
+                          double = NaN, double = 1) const;
 
   /// Applies the chain rule to convert spatial non-parametric gradient
   /// to a gradient w.r.t the parameters of this transformation.
@@ -571,7 +571,7 @@ public:
   /// Applies the chain rule to convert point-wise non-parametric gradient
   /// to a gradient w.r.t the parameters of this transformation.
   virtual void ParametricGradient(const PointSet &, const Vector3D<double> *,
-                                  double *, double = 0, double = -1, double = 1) const;
+                                  double *, double = 0, double = NaN, double = 1) const;
 
   // ---------------------------------------------------------------------------
   // I/O


### PR DESCRIPTION
For a SV FFD, when `t0` is not specified explicitly, it should be integrated over the default cross-sectional time interval. Setting `t0 = -1` doesn't allow us to identify if it was specified or not as time values can be negative. Thus, use NaN instead.