### PR TITLE
fix: Parsing of parameters in ImageSimilarity::Set [Registration]

### DIFF
--- a/Modules/Registration/src/ImageSimilarity.cc
+++ b/Modules/Registration/src/ImageSimilarity.cc
@@ -421,8 +421,7 @@ void ImageSimilarity::Initialize()
 // -----------------------------------------------------------------------------
 bool ImageSimilarity::SetWithoutPrefix(const char *param, const char *value)
 {
-
-  if (strcmp(param, "Foreground") == 0 || strcmp(param, "Foreground region")) {
+  if (strcmp(param, "Foreground") == 0 || strcmp(param, "Foreground region") == 0) {
     return FromString(value, _Foreground);
   }
   if (strcmp(param, "Approximate gradient") == 0) {
@@ -470,7 +469,6 @@ bool ImageSimilarity::SetWithoutPrefix(const char *param, const char *value)
     _Source->MaxGradientMagnitude(norm);
     return true;
   }
-
   return DataFidelity::SetWithoutPrefix(param, value);
 }
 


### PR DESCRIPTION
Bug introduced with one of the recent PRs. The one adding the "Image similarity foreground" parameter. In particular [this line/commit](https://github.com/BioMedIA/MIRTK/pull/538/commits/435f67f0d25f78445e4b18ce576362b8bc5d6de8#diff-2f8cc55d0dff18cc4a495480f877384fR424) of PR #538.