### PR TITLE
fix: Parsing of register -par option arguments [Applications]

### DIFF
--- a/Applications/src/register.cc
+++ b/Applications/src/register.cc
@@ -742,7 +742,9 @@ int main(int argc, char **argv)
     }
     // Parameter
     else if (OPTION("-par")) {
-      Insert(params, ARGUMENT, ARGUMENT);
+      const char *param = ARGUMENT;
+      const char *value = ARGUMENT;
+      Insert(params, param, value);
     }
     else if (OPTION("-parin" )) {
       parin_name = ARGUMENT;


### PR DESCRIPTION
Fix bug introduced again [here](https://github.com/BioMedIA/MIRTK/commit/b8d210a5450f4bc22d2415e3be9044f1ea7f2353#diff-bf53896b53093aeb978e90d17b3524d5R723) as part of PR #508.