### PR TITLE
fix: Triangle-triangle intersection test

### DIFF
--- a/Modules/PointSet/src/SurfaceCollisions.cc
+++ b/Modules/PointSet/src/SurfaceCollisions.cc
@@ -296,10 +296,6 @@ public:
               //       or one edge of the first triangle intersects an edge of
               //       the second triangle.
             }
-            // TODO: Re-implement using own function of mirtk::Triangle,
-            //       re-using already computed normals and b values.
-            //       Also to not use this "private" function of the
-            //       vtkIntersectionPolyDataFilter.
             else if (Triangle::TriangleTriangleIntersection(tri1[0], tri1[1], tri1[2],
                                                             tri2[0], tri2[1], tri2[2],
                                                             coplanar, p1, p2)) {
@@ -399,8 +395,7 @@ public:
   /// Find collision and self-intersections
   static void Run(SurfaceCollisions  *filter,
                   IntersectionsArray *intersections,
-                  CollisionsArray    *collisions,
-                  bool                fast = false)
+                  CollisionsArray    *collisions)
   {
     vtkDataArray *radius = filter->GetRadiusArray();
     vtkSmartPointer<vtkAbstractPointLocator> locator;

--- a/Modules/PointSet/src/Triangle.cc
+++ b/Modules/PointSet/src/Triangle.cc
@@ -230,7 +230,9 @@ bool Triangle
                                        const_cast<double *>(c2),
                                        coplanar, p1, p2) != 0;
   #else
-    double surfaceid[2], tol = 0.;
+    // Tolerance value must not be close to zero
+    // See https://gitlab.kitware.com/vtk/vtk/issues/17012
+    double surfaceid[2], tol = 1e-6;
     return vtkIntersectionPolyDataFilter
         ::TriangleTriangleIntersection(const_cast<double *>(a1),
                                        const_cast<double *>(b1),


### PR DESCRIPTION
Segfault caused by changes of `vtkIntersectionPolyDataFilter::TriangleTriangleIntersection` which requires a tolerance value >0 (1e-9 was not large enough for cortical meshes either).

See also upstream bug report for VTK>=7.1 [here](https://gitlab.kitware.com/vtk/vtk/issues/17012).