### PR TITLE
fix: Default transform-image output -dtype [Applications]

### DIFF
--- a/Applications/src/transform-image.cc
+++ b/Applications/src/transform-image.cc
@@ -622,6 +622,9 @@ int main(int argc, char **argv)
 
     // Read source image
     UniquePtr<BaseImage> source(BaseImage::New(input_name));
+    if (dtype == MIRTK_VOXEL_UNKNOWN) {
+      dtype = static_cast<ImageDataType>(source->GetDataType());
+    }
 
     // Instantiate image interpolator
     UniquePtr<InterpolateImageFunction> interpolator;


### PR DESCRIPTION
One of the recent changes for resampling label images must have introduced this bug. The default output data type of the transformed image should be identical to the input source image, not double.