### PR TITLE
enh: aggregate-images 'mode' and 'label-consistency' output [Applications]

### DIFF
--- a/Applications/src/aggregate-images.cc
+++ b/Applications/src/aggregate-images.cc
@@ -383,6 +383,7 @@ int main(int argc, char **argv)
     FatalError("Invalid aggregation mode: " << POSARG(1));
   }
 
+  const char        *mask_name     = nullptr;
   const char        *output_name   = nullptr;
   ImageDataType      dtype         = MIRTK_VOXEL_UNKNOWN;
   NormalizationMode  normalization = Normalization_None;
@@ -394,6 +395,7 @@ int main(int argc, char **argv)
 
   for (ALL_OPTIONS) {
     if (OPTION("-output")) output_name = ARGUMENT;
+    else if (OPTION("-mask")) mask_name = ARGUMENT;
     else if (OPTION("-dtype") || OPTION("-datatype")) {
       PARSE_ARGUMENT(dtype);
     }
@@ -523,6 +525,15 @@ int main(int argc, char **argv)
           }
         }
       }
+    }
+  }
+  if (mask_name) {
+    BinaryImage mask(mask_name);
+    if (mask.Attributes() != output.Attributes()) {
+      FatalError("Mask has different attributes!");
+    }
+    for (int vox = 0; vox < nvox; ++vox) {
+      if (mask(vox) == BinaryPixel(0)) output(vox) = bg;
     }
   }
   output.PutBackgroundValueAsDouble(bg);

--- a/Modules/Image/include/mirtk/Histogram1D.h
+++ b/Modules/Image/include/mirtk/Histogram1D.h
@@ -184,6 +184,12 @@ public:
   /// Smooth histogram
   void Smooth();
 
+  /// Return smallest modal value
+  double Mode() const;
+
+  /// Return sorted modal values
+  Array<double> Modes() const;
+
   /// Calculate mean
   double Mean() const;
 

--- a/Modules/Image/src/Histogram1D.cc
+++ b/Modules/Image/src/Histogram1D.cc
@@ -21,6 +21,7 @@
 
 #include "mirtk/Math.h"
 #include "mirtk/Memory.h"
+#include "mirtk/Algorithm.h"
 
 #include "mirtk/CommonExport.h"
 
@@ -252,6 +253,54 @@ void Histogram1D<HistogramType>::Smooth()
   // Replace histogram by smoothed version
   Deallocate(_bins);
   _bins = bins;
+}
+
+// -----------------------------------------------------------------------------
+template <class HistogramType>
+double Histogram1D<HistogramType>::Mode() const
+{
+  if (_nsamp > 0) {
+    HistogramType max_value = 0;
+    for (int i = 0; i < _nbins; ++i) {
+      max_value = max(max_value, _bins[i]);
+    }
+    for (int i = 0; i < _nbins; ++i) {
+      if (_bins[i] >= max_value) {
+        return this->BinToVal(i);
+      }
+    }
+  } else {
+    if (debug) {
+      cerr << "Histogram1D::Mode: No samples in Histogram" << endl;
+    }
+  }
+  return NaN;
+}
+
+// -----------------------------------------------------------------------------
+template <class HistogramType>
+Array<double> Histogram1D<HistogramType>::Modes() const
+{
+  Array<double> modes;
+  if (_nsamp == 0) {
+    if (debug) {
+      cerr << "Histogram1D::Modes: No samples in Histogram" << endl;
+    }
+    return modes;
+  }
+  HistogramType max_value = 0;
+  for (int i = 0; i < _nbins; ++i) {
+    max_value = max(max_value, _bins[i]);
+  }
+  modes.reserve(10);
+  for (int i = 0; i < _nbins; ++i) {
+    if (_bins[i] >= max_value) {
+      modes.push_back(this->BinToVal(i));
+    }
+  }
+  modes.shrink_to_fit();
+  Sort(modes);
+  return modes;
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
New `aggregate-images` options:
- `-mask` to restrict output to the given foreground region.
- `mode` to output smallest voxel-wise histogram mode.
- `label-consistency` to output voxel-wise mean pair-wise DSC.
- output `-datatype` option.