### PR TITLE
fix: Include Stream.h in Common.h [Common]

### DIFF
--- a/Modules/Common/include/mirtk/Common.h
+++ b/Modules/Common/include/mirtk/Common.h
@@ -61,6 +61,7 @@
 
 // I/O
 #include "mirtk/Indent.h"
+#include "mirtk/Stream.h"
 #include "mirtk/Cfstream.h"
 
 // Testing


### PR DESCRIPTION
This header is included by other headers anyway, but this way it is listed explicitly.