### PR TITLE
fix: SS gradient computation in SV FFD [Transformation]

### DIFF
--- a/Modules/Transformation/src/BSplineFreeFormTransformationSV.cc
+++ b/Modules/Transformation/src/BSplineFreeFormTransformationSV.cc
@@ -1619,7 +1619,7 @@ void BSplineFreeFormTransformationSV
     ParallelForEachVoxel(in, &dv, &dv, mul);
 
     // Multiply resulting vectors by derivative of v w.r.t. the DoFs
-    BSplineFreeFormTransformation3D::ParametricGradient(&dv, out, wc, t0, w);
+    BSplineFreeFormTransformation3D::ParametricGradient(&dv, out, i2w, wc, t0, w);
     MIRTK_DEBUG_TIMING(2, "parametric gradient computation (SS)");
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes endless recursion due to virtual function call in SV FFD gradient computation with `Integration method = SS` and `No. of BCH terms = 0`.