### PR TITLE
fix: Case insensitive string comparison function iequal [Common]

### DIFF
--- a/Modules/Common/include/mirtk/String.h
+++ b/Modules/Common/include/mirtk/String.h
@@ -61,7 +61,7 @@ inline bool iequal(char const *a, char const *b)
     if (tolower(*a) != tolower(*b)) return false;
     ++a, ++b;
   }
-  return false;
+  return !(*a || *b);
 }
 
 /// Case insensitive string comparison


### PR DESCRIPTION
Fixes case insensitive comparison of strings using `iequal` function. Return value was always `false`. This caused unrecognized registration parameter values such as `Integration method` because `iequal` is used in some `FromString` implementations.