### PR TITLE
fix: Negative Jacobian values caused by upsampling [Image]

### DIFF
--- a/Applications/src/evaluate-jacobian.cc
+++ b/Applications/src/evaluate-jacobian.cc
@@ -95,7 +95,7 @@ struct JacobianImpl : public VoxelReduction
 {
   GreyImage            *_image;
   BaseImage            *_jacobian;
-  BinaryImage          * _mask;
+  BinaryImage          *_mask;
   int                   _nvox;
   const Transformation *_dof;
   double               _t, _t0;


### PR DESCRIPTION
Negative Jacobian determinants reported by `evaluate-jacobian` for a SV FFD with `FastSS` integration method is due to the final upscaling step (not sure why... B-spline interpolator issue?).