### PR TITLE
fix: Uninitialized _TargetTransformation pointer of GenericRegistrationFilter [Registration]

### DIFF
--- a/Modules/Registration/src/GenericRegistrationFilter.cc
+++ b/Modules/Registration/src/GenericRegistrationFilter.cc
@@ -970,10 +970,11 @@ void GenericRegistrationFilter::Clear()
 // -----------------------------------------------------------------------------
 GenericRegistrationFilter::GenericRegistrationFilter()
 :
-  _InitialGuess  (NULL),
-  _Domain        (NULL),
-  _Transformation(NULL),
-  _Optimizer     (NULL)
+  _InitialGuess(nullptr),
+  _Domain(nullptr),
+  _Transformation(nullptr),
+  _TargetTransformation(nullptr),
+  _Optimizer(nullptr)
 {
   // Bind broadcast method to optimizer events (excl. Start/EndEvent!)
   _EventDelegate.Bind(IterationEvent,                MakeDelegate(this, &Observable::Broadcast));


### PR DESCRIPTION
Fix segfault caused by uninitialised member variable (pointer) of `GenericRegistrationFilter`.