### PR TITLE
fix: Interpolation with padding by default [Transformation]

### DIFF
--- a/Applications/src/register.cc
+++ b/Applications/src/register.cc
@@ -230,7 +230,7 @@ void PrintHelp(const char* name)
   cout << "      standard deviation, full width at half maximum, or full width at tenth maximum,\n";
   cout << "      respectively. The default is a box window with uniform weights for each voxel.\n";
   cout << "  -interp, -interpolation <mode>\n";
-  cout << "      \"Image interpolation\" mode. (default: \"Fast linear\")\n";
+  cout << "      \"Image interpolation\" mode. (default: \"Fast linear [with padding]\")\n";
   cout << "  -extrap, -extrapolation <mode>\n";
   cout << "      \"Image extrapolation\" mode. (default: \"Default\" for used interpolation mode)\n";
   cout << "  -levels <from> [<to>]\n";

--- a/Modules/Image/include/mirtk/InterpolationMode.h
+++ b/Modules/Image/include/mirtk/InterpolationMode.h
@@ -100,6 +100,20 @@ inline InterpolationMode InterpolationWithoutPadding(InterpolationMode m)
 }
 
 // ----------------------------------------------------------------------------
+/// Whether interpolation mode is "with padding"
+inline bool IsInterpolationWithPadding(InterpolationMode m)
+{
+  return InterpolationWithPadding(m) == m;
+}
+
+// ----------------------------------------------------------------------------
+/// Whether interpolation mode is "without padding"
+inline bool IsInterpolationWithoutPadding(InterpolationMode m)
+{
+  return InterpolationWithoutPadding(m) == m;
+}
+
+// ----------------------------------------------------------------------------
 template <>
 inline string ToString(const InterpolationMode &m, int w, char c, bool left)
 {

--- a/Modules/Transformation/include/mirtk/RegisteredImage.h
+++ b/Modules/Transformation/include/mirtk/RegisteredImage.h
@@ -210,6 +210,12 @@ public:
   /// Destructor
   ~RegisteredImage();
 
+  /// Get interpolation mode
+  ///
+  /// When _InterpolationMode is Interpolation_Default, this function returns
+  /// the respective default interpolation mode with or without padding.
+  enum InterpolationMode GetInterpolationMode() const;
+
   // ---------------------------------------------------------------------------
   // Channels
 


### PR DESCRIPTION
When the user specifies a `Background value`, the default interpolation mode used by `RegisteredImage` to resample the input image given the current transformation estimate is "with padding". This also includes a fix of the background value in the pre-computed transformed first and second order derivatives, which is now `NaN` instead of 0.

When the user chooses `Interpolation mode = Linear` or any other interpolation "without padding", the pre-computed derivatives, including the optional previous Gaussian smoothing, is done without considering the background value, i.e., across foreground/background boundary. Only when the interpolation mode is "with padding", the background is excluded from these steps.

Normally it is advisable to exclude the background, i.e., to use a "with padding" interpolation mode when a background value is given to avoid artificial and strong transformed source image gradients at the boundary of the image foreground.

Hence, the new default interpolation is "with padding" when background value is set.

**Note:** Setting `Downsample images with padding = No` will cause the `InitializePyramid` function of the `GenericRegistrationFilter` to not set a background value for the images in the pyramid. The background value is then only used to crop the images and for the computation of the centers of mass of the image foreground. See [here](https://github.com/BioMedIA/MIRTK/blob/1d1f014c78fdfd7f31423a1b242ab1f462d62b3b/Modules/Registration/src/GenericRegistrationFilter.cc#L2978) (if code hasn't changed since).