### PR TITLE
travis: Reduce macOS jobs, cache VTK installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,18 +16,27 @@ env:
   - WITH_CCACHE=ON    # speed up MIRTK build itself using ccache
   - WITH_ARPACK=OFF   # requires time consuming build of gcc on macOS
   - WITH_UMFPACK=OFF  # ARPACK & UMFPACK dependencies come in pairs
-  - WITH_TBB=ON
-  - WITH_FLANN=ON
+  - WITH_TBB=ON       # build with TBB is always recommended
+  - WITH_FLANN=ON     # build with FLANN is optional, but requires only little extra build time
   matrix:
-  - WITH_VTK=OFF
-  - WITH_VTK=ON
+  - WITH_VTK=OFF      # make sure that MIRTK can be build fine without VTK
+  - WITH_VTK=ON       # test build with all moduldes, including those using VTK
 
 matrix:
   exclude:
+  # in order to reduce number of jobs to wait for, test only main compilers used on each OS
   - os: linux
     compiler: clang
   - os: osx
     compiler: g++
+  # travis-ci.org has low capacity for macOS jobs, thus reduce number of macOS jobs to
+  # only the essential ones. With the following, we only need to wait for one macOS job.
+  # Because on macOS usually a very recent VTK version is installed with Homebrew,
+  # it is more interesting to build with VTK on macOS than on Ubuntu. When the GCC build
+  # without VTK on Ubuntu succeeds, chances are very high it also builts fine on macOS.
+  - os: osx
+    compiler: clang
+    env: WITH_VTK=OFF
 
 cache:
   ccache: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ os:
 
 env:
   global:
+  # versions of VTK for each OS
+  # - On Ubuntu, use default version installed by apt-get
+  # - On macOS, build recent VTK version from sources and cache installation
+  - LINUX_VTK_VERSION=6.0.0
+  - MACOS_VTK_VERSION=8.0.0
   - WITH_CCACHE=ON    # speed up MIRTK build itself using ccache
   - WITH_ARPACK=OFF   # requires time consuming build of gcc on macOS
   - WITH_UMFPACK=OFF  # ARPACK & UMFPACK dependencies come in pairs
@@ -41,9 +46,16 @@ matrix:
 cache:
   ccache: true
   timeout: 1000
+  directories:
+  - $HOME/VTK-$LINUX_VTK_VERSION
+  - $HOME/VTK-$MACOS_VTK_VERSION
 
-before_install: Scripts/install_depends.sh
-script:         Scripts/travis.sh
+before_install:
+  - . Scripts/install_depends.sh  # sourcing should enable export of env variables
+  - cd $TRAVIS_BUILD_DIR          # working directory may have been changed
+
+script:
+  - Scripts/travis.sh
 
 notifications:
   email: false

--- a/Scripts/install_depends.sh
+++ b/Scripts/install_depends.sh
@@ -22,7 +22,12 @@ WITH_VTK=`norm_option_value "$WITH_VTK" OFF`
 WITH_TBB=`norm_option_value "$WITH_TBB" ON`
 WITH_FLANN=`norm_option_value "$WITH_FLANN" ON`
 WITH_CCACHE=`norm_option_value "$WITH_CCACHE" OFF`
+BUILD_DEPS_WITH_CCACHE=`norm_option_value "$BUILD_DEPS_WITH_CCACHE" OFF`
+FORCE_REBUILD_DEPS=`norm_option_value "$FORCE_REBUILD_DEPS" OFF`
 
+
+# ------------------------------------------------------------------------------
+# Auxiliary variables and functions
 if [ $TRAVIS = ON ]; then
   os="$TRAVIS_OS_NAME"
 else
@@ -33,8 +38,17 @@ else
   }
 fi
 
+run()
+{
+  echo "> $@"
+  "$@"
+}
+
+
+# ------------------------------------------------------------------------------
 # install pre-requisites on Ubuntu
 if [ $os = linux ] || [ $os = Linux ]; then
+  cpu_cores=$(grep -c ^processor /proc/cpuinfo)
 
   deps=( \
     freeglut3-dev \
@@ -44,49 +58,65 @@ if [ $os = linux ] || [ $os = Linux ]; then
     libnifti-dev \
     libpng12-dev \
   )
-  [ $TESTING      = OFF ] || deps=(${deps[@]} libgtest-dev)
-  [ $WITH_TBB     = OFF ] || deps=(${deps[@]} libtbb-dev)
-  [ $WITH_FLANN   = OFF ] || deps=(${deps[@]} libflann-dev)
-  [ $WITH_VTK     = OFF ] || deps=(${deps[@]} libvtk6-dev)
-  [ $WITH_ARPACK  = OFF ] || deps=(${deps[@]} libarpack2-dev)
-  [ $WITH_UMFPACK = OFF ] || {
+
+  [ $TESTING     = OFF ] || deps=(${deps[@]} libgtest-dev)
+  [ $WITH_TBB    = OFF ] || deps=(${deps[@]} libtbb-dev)
+  [ $WITH_FLANN  = OFF ] || deps=(${deps[@]} libflann-dev)
+  [ $WITH_ARPACK = OFF ] || deps=(${deps[@]} libarpack2-dev)
+
+  if [ $WITH_UMFPACK = ON ]; then
     # see https://bugs.launchpad.net/ubuntu/+source/suitesparse/+bug/1333214
     sudo add-apt-repository -y ppa:bzindovic/suitesparse-bugfix-1319687
     deps=(${deps[@]} libsuitesparse-dev)
-  }
+  fi
+
+  if [ $WITH_VTK = ON ]; then
+    if [ -n "$LINUX_VTK_VERSION" ]; then
+      VTK_VERSION="$LINUX_VTK_VERSION"
+    fi
+    if [ -z "$VTK_VERSION" ] || [ $VTK_VERSION = '6.0.0' ]; then
+      deps=(${deps[@]} libvtk6-dev)
+      VTK_VERSION=''
+    fi
+  fi
 
   sudo apt-get update -qq
   sudo apt-get install -y --no-install-recommends ${deps[@]}
 
   if [ $TESTING = ON ]; then
-    mkdir "$HOME/gtest-build" && cd "$HOME/gtest-build"
-    cmake /usr/src/gtest && make
-    sudo mv -f libgtest.a libgtest_main.a /usr/lib
-    rm -rf "$HOME/gtest-build"
+    # libgtest-dev only install source files
+    mkdir /tmp/gtest-build && cd /tmp/gtest-build
+    run cmake /usr/src/gtest
+    run make -j $cpu_cores
+    run sudo mv -f libgtest.a libgtest_main.a /usr/lib
+    cd
+    [ $TRAVIS = ON ] || rm -rf /tmp/gtest-build
   fi
+fi
 
+
+# ------------------------------------------------------------------------------
 # install pre-requisites on OS X
-elif [ $os = osx ] || [ $os = Darwin ]; then
+if [ $os = osx ] || [ $os = Darwin ]; then
+  cpu_cores=$(sysctl -n hw.ncpu)
 
   brew_install()
   {
     for dep in $@; do
       if $(brew ls --version $dep &> /dev/null) ; then
         brew unlink $dep && brew link $dep
-      elif [[ $dep == arpack ]]; then
-        travis_wait brew install $dep
       else
         brew install $dep
       fi
     done
   }
 
-  brew update
+  brew update > /dev/null
   brew tap homebrew/science
-  brew_install eigen flann tbb
   if [ $WITH_CCACHE = ON ]; then
     brew_install ccache
   fi
+  brew_install eigen flann tbb
   if [ $WITH_ARPACK = ON ]; then
     brew_install arpack
   fi
@@ -94,26 +124,117 @@ elif [ $os = osx ] || [ $os = Darwin ]; then
     brew_install suite-sparse
   fi
   if [ $WITH_VTK = ON ]; then
-    brew_install vtk
-  fi
-  if [ $TESTING = ON ]; then
-    cleanup_gtest_source='OFF'
-    if [ -d "$HOME/gtest-source" ]; then
-      if [ $TRAVIS = ON ]; then
-        # directory has been restored from cache
-        cd "$HOME/gtest-source" && git update
-      fi
-    else
-      git clone --depth=1 https://github.com/google/googletest.git "$HOME/gtest-source"
-      cleanup_gtest_source='ON'
+    VTK_VERSION="$MACOS_VTK_VERSION"
+    if [ -z "$VTK_VERSION" ]; then
+      echo "Installing VTK using Homebrew"
+      brew_install vtk --without-python
     fi
-    mkdir "$HOME/gtest-build" && cd "$HOME/gtest-build"
-    cmake -DCMAKE_CXX_FLAGS=-std=c++11 -DBUILD_GMOCK=OFF -DBUILD_GTEST=ON ../gtest-source && make
-    sudo make install
-    if [ $cleanup_gtest_source = ON ]; then
-      rm -rf "$HOME/gtest-source"
-    fi
-    rm -rf "$HOME/gtest-build"
   fi
 
+  # download, build, and install gtest
+  if [ $TESTING = ON ]; then
+    run git clone --depth=1 https://github.com/google/googletest.git /tmp/gtest-source
+    mkdir /tmp/gtest-build && cd /tmp/gtest-build
+    run cmake -DCMAKE_CXX_FLAGS=-std=c++11 -DBUILD_GMOCK=OFF -DBUILD_GTEST=ON ../gtest-source
+    run make -j $cpu_cores
+    run sudo make install
+    cd
+    [ $TRAVIS = ON ] || rm -rf /tmp/gtest-build /tmp/gtest-source
+  fi
+fi
+
+
+# ------------------------------------------------------------------------------
+# Install specific VTK version from source
+if [ $WITH_VTK = ON ] && [ -n "$VTK_VERSION" ]; then
+  vtk_prefix="${VTK_PREFIX:-$HOME/VTK-$VTK_VERSION}"
+  # build configuration
+  cmake_args=(
+    -DCMAKE_INSTALL_PREFIX="$vtk_prefix"
+    -DCMAKE_BUILD_TYPE=Release
+  )
+  # pre-requisites to use system installations
+  if [ $os = osx ] || [ $os = Darwin ]; then
+    brew_install hdf5 netcdf jpeg libpng libtiff lz4
+    cmake_args=("${cmake_args[@]}"
+      -DVTK_USE_SYSTEM_HDF5=ON
+      -DVTK_USE_SYSTEM_EXPAT=ON
+      -DVTK_USE_SYSTEM_LIBXML2=ON
+      -DVTK_USE_SYSTEM_ZLIB=ON
+      -DVTK_USE_SYSTEM_NETCDF=ON
+      -DVTK_USE_SYSTEM_JPEG=ON
+      -DVTK_USE_SYSTEM_PNG=ON
+      -DVTK_USE_SYSTEM_TIFF=ON
+      -DVTK_USE_SYSTEM_LIBRARIES=ON
+    )
+  fi
+  if [ $FORCE_REBUILD_DEPS = OFF ] && [ -d "$vtk_prefix/lib/cmake/vtk-${VTK_VERSION%.*}" ]; then
+    # use previously cached VTK installation
+    echo "Using cached VTK $VTK_VERSION installation in $vtk_prefix"
+  else
+    # whether to remove downloaded sources and build directory after installation
+    if [ $TRAVIS = ON ]; then
+      cleanup_vtk_build=OFF
+    else
+      cleanup_vtk_build=ON
+    fi
+    # custom build instead of Homebrew to take advantage of caching of minimal build
+    cd /tmp
+    echo "Downloading VTK $VTK_VERSION..."
+    run curl -O "http://www.vtk.org/files/release/${VTK_VERSION%.*}/VTK-${VTK_VERSION}.tar.gz"
+    run tar -xzf "VTK-${VTK_VERSION}.tar.gz"
+    mkdir "VTK-${VTK_VERSION}/Build" && cd "VTK-${VTK_VERSION}/Build"
+    echo "Configuring VTK $VTK_VERSION..."
+    cmake_args=("${cmake_args[@]}"
+      -DVTK_Group_StandAlone=OFF
+      -DVTK_Group_Rendering=OFF
+      -DModule_vtkCommonCore=ON
+      -DModule_vtkCommonDataModel=ON
+      -DModule_vtkCommonExecutionModel=ON
+      -DModule_vtkFiltersCore=ON
+      -DModule_vtkFiltersHybrid=ON
+      -DModule_vtkFiltersFlowPaths=ON
+      -DModule_vtkFiltersGeneral=ON
+      -DModule_vtkFiltersGeometry=ON
+      -DModule_vtkFiltersParallel=ON
+      -DModule_vtkFiltersModeling=ON
+      -DModule_vtkImagingStencil=ON
+      -DModule_vtkIOLegacy=ON
+      -DModule_vtkIOXML=ON
+      -DModule_vtkIOGeometry=ON
+      -DModule_vtkIOPLY=ON
+      -DModule_vtkIOXML=ON
+    )
+    if [ $WITH_CCACHE = ON ] && [ $BUILD_DEPS_WITH_CCACHE = ON ]; then
+      cc_compiler=''
+      cxx_compiler=''
+      launcher=`which ccache`
+      [ -z "$CC"  ] || cc_compiler=`which $CC`
+      [ -z "$CXX" ] || cc_compiler=`which $CXX`
+      if [ "$cc_compiler" = "${cc_compiler/ccache/}" ]; then
+        echo "Using $launcher as C compiler launcher"
+        cmake_args=("${cmake_args[@]}"
+          -DCMAKE_C_COMPILER_LAUNCHER="$launcher"
+        )
+      fi
+      if [ "$cxx_compiler" = "${cxx_compiler/ccache/}" ]; then
+        echo "Using $launcher as C++ compiler launcher"
+        cmake_args=("${cmake_args[@]}"
+          -DCMAKE_CXX_COMPILER_LAUNCHER="$launcher"
+        )
+      fi
+    fi
+    run cmake "${cmake_args[@]}" ..
+    echo "Configuring VTK $VTK_VERSION... done"
+    echo "Building VTK $VTK_VERSION..."
+    run make -j $cpu_cores
+    echo "Building VTK $VTK_VERSION... done"
+    echo "Installing VTK $VTK_VERSION..."
+    run sudo make install
+    echo "Installing VTK $VTK_VERSION... done"
+    cd
+    [ $TRAVIS = ON ] || rm -rf "/tmp/VTK-${VTK_VERSION}"
+  fi
+  mkdir -p "$HOME/.cmake/packages/VTK"
+  echo "$vtk_prefix/lib/cmake/vtk-${VTK_VERSION%.*}" > "$HOME/.cmake/packages/VTK/VTK-$VTK_VERSION"
 fi

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -81,5 +81,5 @@ run cmake -D CMAKE_INSTALL_PREFIX=$HOME/local \
       ${cmake_args[@]} \
       ..
 
-make -j $cpu_cores
+run make -j $cpu_cores
 [ $TESTING = OFF ] || make test


### PR DESCRIPTION
- Reduce number of Travis CI macOS builds to one to avoid having to wait for two jobs to wait for each CI build given that `travis-ci.org` has lower capacity for macOS jobs. Only one build without VTK on Ubuntu should be sufficient to ensure everything works fine when `WITH_VTK=OFF`.
- Build only required VTK modules from source on macOS. Cache custom installation.