### PR TITLE
fix: Histogram1D and Histogram2D Read/Write magic string “irtk” prefix [Image]

### DIFF
--- a/Modules/Image/src/Histogram1D.cc
+++ b/Modules/Image/src/Histogram1D.cc
@@ -99,7 +99,7 @@ Histogram1D<HistogramType>::Histogram1D(const char *filename)
   }
   char buffer[255];
   from >> buffer;
-  if (strcmp(buffer, "Histogram1D") != 0) {
+  if (strcmp(buffer, "irtkHistogram1D") != 0) {
     cerr << "Histogram1D::Read: Invalid format" << endl;
     exit(1);
   }
@@ -405,7 +405,7 @@ void Histogram1D<HistogramType>::Write(const char *filename) const
     cerr << "Histogram1D::Write: Can't open file " << filename << endl;
     exit(1);
   }
-  to << "Histogram1D\n";
+  to << "irtkHistogram1D\n";
   to << _nbins << " " << _nsamp << " " << _min << " " << _max << " " << _width << "\n";
   for (int i = 0; i < _nbins; ++i) to << _bins[i] << "\n";
   to.close();

--- a/Modules/Image/src/Histogram2D.cc
+++ b/Modules/Image/src/Histogram2D.cc
@@ -929,7 +929,7 @@ void Histogram2D<HistogramType>::Read(const char *filename)
   }
 
   from >> buffer;
-  if (strcmp(buffer, "Histogram2D") != 0) {
+  if (strcmp(buffer, "irtkHistogram2D") != 0) {
     cerr << "Histogram2D<HistogramType>::Read: Invalid format" << endl;
     exit(1);
   }
@@ -968,7 +968,7 @@ void Histogram2D<HistogramType>::Write(const char *filename) const
     cerr << "Histogram2D<HistogramType>::Write: Can't open file " << filename << endl;
     exit(1);
   }
-  to << "Histogram2D\n";
+  to << "irtkHistogram2D\n";
   to << _nbins_x << " "
      << _nbins_y << " "
      << _nsamp << " "


### PR DESCRIPTION
Closes #334.