### PR TITLE
enh: register -output and -background options

### DIFF
--- a/Modules/Registration/include/mirtk/GenericRegistrationFilter.h
+++ b/Modules/Registration/include/mirtk/GenericRegistrationFilter.h
@@ -515,6 +515,9 @@ public:
   /// Get extrapolation mode of n-th input image or default mode, respectively
   enum ExtrapolationMode ExtrapolationMode(int = -1) const;
 
+  /// Get background value of n-th input image (after registration done)
+  double BackgroundValue(int) const;
+
   // ---------------------------------------------------------------------------
   // Input simplicial complexes (points, curves, surfaces, tetrahedral meshes)
 

--- a/Modules/Registration/include/mirtk/GenericRegistrationFilter.h
+++ b/Modules/Registration/include/mirtk/GenericRegistrationFilter.h
@@ -504,7 +504,7 @@ public:
   void InterpolationMode(int, enum InterpolationMode);
 
   /// Get interpolation mode of n-th input image or default mode, respectively
-  enum InterpolationMode InterpolationMode(int = -1);
+  enum InterpolationMode InterpolationMode(int = -1) const;
 
   /// Set common/default extrapolation mode for all input images
   void ExtrapolationMode(enum ExtrapolationMode);
@@ -513,7 +513,7 @@ public:
   void ExtrapolationMode(int, enum ExtrapolationMode);
 
   /// Get extrapolation mode of n-th input image or default mode, respectively
-  enum ExtrapolationMode ExtrapolationMode(int = -1);
+  enum ExtrapolationMode ExtrapolationMode(int = -1) const;
 
   // ---------------------------------------------------------------------------
   // Input simplicial complexes (points, curves, surfaces, tetrahedral meshes)

--- a/Modules/Registration/src/GenericRegistrationFilter.cc
+++ b/Modules/Registration/src/GenericRegistrationFilter.cc
@@ -1109,7 +1109,7 @@ void GenericRegistrationFilter::InterpolationMode(int n, enum InterpolationMode 
 }
 
 // -----------------------------------------------------------------------------
-enum InterpolationMode GenericRegistrationFilter::InterpolationMode(int n)
+enum InterpolationMode GenericRegistrationFilter::InterpolationMode(int n) const
 {
   if (n < 0 || static_cast<size_t>(n) >= _InterpolationMode.size() || _InterpolationMode[n] == Interpolation_Default) {
     return _DefaultInterpolationMode;
@@ -1135,7 +1135,7 @@ void GenericRegistrationFilter::ExtrapolationMode(int n, enum ExtrapolationMode 
 }
 
 // -----------------------------------------------------------------------------
-enum ExtrapolationMode GenericRegistrationFilter::ExtrapolationMode(int n)
+enum ExtrapolationMode GenericRegistrationFilter::ExtrapolationMode(int n) const
 {
   if (n < 0 || static_cast<size_t>(n) >= _ExtrapolationMode.size() || _ExtrapolationMode[n] == Extrapolation_Default) {
     return _DefaultExtrapolationMode;

--- a/Modules/Registration/src/GenericRegistrationFilter.cc
+++ b/Modules/Registration/src/GenericRegistrationFilter.cc
@@ -1144,6 +1144,16 @@ enum ExtrapolationMode GenericRegistrationFilter::ExtrapolationMode(int n) const
   }
 }
 
+// -----------------------------------------------------------------------------
+double GenericRegistrationFilter::BackgroundValue(int n) const
+{
+  if (n < 0 || static_cast<size_t>(n) >= _Background.size()) {
+    return _DefaultBackground;
+  } else {
+    return _Background[n];
+  }
+}
+
 // =============================================================================
 // Input points, lines, and/or surfaces
 // =============================================================================


### PR DESCRIPTION
- Convenience `-output` option of `register` command to write transformed image. Works only for standard pairwise registrations. Otherwise use of `transform-image` is still recommended.
- Add `-background` option to specify `Background value` without `-parin` file.
- Fix constness of `InterpolationMode` and `ExtrapolationMode` getter functions.

Closes #261.