### PR TITLE
enh: Make AppImage from Travis CI build

### DIFF
--- a/.bintray.yml
+++ b/.bintray.yml
@@ -1,0 +1,37 @@
+{
+    "package": {
+        "name": "MIRTK",
+        "repo": "AppImages",
+        "subject": "schuhschuh",
+        "desc": "Medical Image Registration ToolKit",
+        "website_url": "https://mirtk.github.io",
+        "issue_tracker_url": "https://github.com/BioMedIA/MIRTK/issues",
+        "vcs_url": "https://github.com/BioMedIA/MIRTK.git",
+        "licenses": ["Apache-2.0"],
+        "labels": [
+            "BioMedIA",
+            "MIRTK",
+            "medical imaging",
+            "image registration",
+            "cortical surface reconstruction",
+            "brain atlas construction"
+        ],
+        "public_download_numbers": false,
+        "public_stats": false
+    },
+    "version": {
+        "name": "master",
+        "desc": "AppImage of MIRTK master HEAD deployed by Travis CI build",
+        "gpgSign": true
+    },
+    "files": [
+        {
+            "includePattern": "Deploy/(.*\\.AppImage)",
+            "uploadPattern": "$1",
+            "matrixParams": {
+                "override": 1
+            }
+        }
+    ],
+    "publish": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ compiler:
   - g++
   - clang
 
+git:
+  depth: 10
+
 os:
   - linux
   - osx
@@ -47,15 +50,44 @@ cache:
   ccache: true
   timeout: 1000
   directories:
-  - $HOME/VTK-$LINUX_VTK_VERSION
-  - $HOME/VTK-$MACOS_VTK_VERSION
+  - "$HOME/VTK-$LINUX_VTK_VERSION"
+  - "$HOME/VTK-$MACOS_VTK_VERSION"
 
 before_install:
   - . Scripts/install_depends.sh  # sourcing should enable export of env variables
   - cd $TRAVIS_BUILD_DIR          # working directory may have been changed
 
+install: true
+
 script:
   - Scripts/travis.sh
+
+after_success:
+  - if [ "$AppImage_BUILD" = ON ] && [ "$(git rev-parse --abbrev-ref HEAD)" = "master" ] && [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$WITH_VTK" = ON ]; then
+      Scripts/make_appimage.sh;
+      export AppImage_DEPLOY=ON;
+    else
+      export AppImage_DEPLOY=OFF;
+    fi
+
+deploy:
+  - provider: bintray
+    skip_cleanup: true
+    user: "schuhschuh"
+    key:
+      secure: "ZppKEFWcfVwcO93ciA/zU5ThGLkveY/9fnEH4VyTZyYlnVuL+6R6G3BAalhgZLIdNLpmtMd057laqhupPYqt2c4KClRWuhg7pKisCzpZptUWHLgMq3hl2AKGpxMgWrwktVPR2lIpTG6UaQEZ6MUG+NscPUp2OlMwk4Kog2s/Vjr2qkkK51/reZBKz4K0mHmFuIhW7cUkebWCn81CgRLoIX1fiHo22hDvbIvZA/WH8UcyucR3znBjVaWSniXk70TMUyH6uDhx0sX+nml/JDd8UcIZsZm3wBxam39TzviTcyuY/YyK3TkPOOhWe9jutyVnOHwMbQSiI+Av+XjnlKI7DsBNvuMFA+ULcaHqozXgEFC87BrjeyBPq3Y95czsK11OWAB6xo/LIMONmhCSrybBG6ZuRi8c/FDuVlGhdaoixK3KjxD+JkB0twFSXA4ITKTAHPRrZHkgWiM0qFwL4KM1an86s4n8k8pdsN3HA61WoNR3k6WCZkOSrZ3mwi9IHaNN/Mh1jIYBDroBwNdAK0bCVXHgI0iFIdt7VU9K3ZeVoB//vdaG6qcVSkEXlcdTuzuhaD8fAuCnO1muv4FFz3+K6GX1Kc0rRWGqUlWRnOqCV1bG/g7fJnY+CeuZgkFzBlPyVtXa6gA1McHS21YzR7GprP9PLT6zxN0dvf457er8hyM="
+    file: ".bintray.yml"
+    on:
+      branch: master
+      condition: "$AppImage_DEPLOY = ON"
+  - provider: releases
+    skip_cleanup: true
+    api_key:
+      secure: "AQD/827hwRqb7Dihl+X3w2WBqGY+JpVcdfm28FEcxNF70WnjCis8V0OHACZ7VIGZHZbcyw33278wJoPwKPm7D1pu3+G++hP7PPLE7JhHJbj6oU7WTqJuvTjSc7F0DkUmXyttMPRpocCU0m3pbJXNhY4oqrYwEQJNtQbqbnYRPV958YR104bWji5VhmtB6Gsp3L7kfjvEAjinHAEDQXybO4/ZVSn+/5MycvE/qTk20NZedsa3rusdmrRAR79CwPBkg0zQhbV4qT0+K1COF1pw/35kyZ22x+mzG5wO+3n2NxrmKo4X3V1awipP+JEFFCsZti1joKxJ9IQo6OFfTPIDpqZQIuvlGr3/1K+iKuGq2OqiXFCdOoHnLBYvVxnr7uToaSMM9kqowevGc5fea2sV3YDvx7EIWJSJiCe5Ee8sWnSDLYJVoSY9ykmx6vRxPJ0iaUjLLajvPenapZOvQZRdZrIX1eFFZqXBB3HQzlbSG/PdjAVDY2KzOuOkXU5Rsaztj8FZgcvWk1U4mqYon+Hol30oGM6u+ZpiOEQclBQe0lUgFUbJv+na0cOoT2LLH0l6ZyifJtUIcfi4ZMAR8vRVAm63gQMX/PPaojXegWrVhS3KWSXyDqHNnFyTuwrnLKH7FWrpEkmaPann1i+LowukaMnizTaQjMM+JgVkBhhdwgo="
+    file: "Deploy/*.AppImage"
+    file_glob: true
+    on:
+      tags: true
 
 notifications:
   email: false

--- a/Documentation/static/logo.svg
+++ b/Documentation/static/logo.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<svg width="64" height="64" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <!-- Created with SVG-edit - http://svg-edit.googlecode.com/ -->
+ <title>MIRTK Logo</title>
+ <g>
+  <title>Layer 1</title>
+  <text stroke="#000000" transform="matrix(0.6918124234252134,0,0,0.6918124234252134,3.456280213998445,6.169464005938251) " xml:space="preserve" text-anchor="middle" font-family="Monospace" font-size="24" id="svg_1" y="43.506246" x="39.806898" stroke-width="0" fill="#0000ff">MIRTK</text>
+ </g>
+</svg>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 Medical Image Registration ToolKit
 ==================================
 
+[![Linux AppImage](https://api.bintray.com/packages/schuhschuh/AppImages/MIRTK/images/download.svg?version=master)](https://bintray.com/schuhschuh/AppImages/MIRTK/master#files)
+&nbsp;
+[![Docker Image](https://images.microbadger.com/badges/image/biomedia/mirtk.svg)](https://microbadger.com/#/images/biomedia/mirtk)
+&nbsp;
 [![Travis CI status](https://travis-ci.org/BioMedIA/MIRTK.svg?branch=master)](https://travis-ci.org/BioMedIA/MIRTK)
 &nbsp;
 [![AppVeyor status](https://ci.appveyor.com/api/projects/status/f4ef923d1h9lo9pm/branch/master?svg=true)](https://ci.appveyor.com/project/schuhschuh/mirtk/branch/master)
-&nbsp;
-[![Docker Image](https://images.microbadger.com/badges/image/biomedia/mirtk.svg)](https://microbadger.com/#/images/biomedia/mirtk)
 &nbsp;
 [![Join the chat at https://gitter.im/BioMedIA/MIRTK](https://badges.gitter.im/BioMedIA/MIRTK.svg)](https://gitter.im/BioMedIA/MIRTK?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -42,4 +44,5 @@ Citation and acknowledgements
 -----------------------------
 
 In the event you found the MIRTK useful, please consider giving appropriate credit to the software.
-See the [publications list](https://mirtk.github.io/publications.html).
+
+See the [publications list](https://mirtk.github.io/publications.html) for suitable citations.

--- a/Scripts/install_depends.sh
+++ b/Scripts/install_depends.sh
@@ -59,9 +59,9 @@ if [ $os = linux ] || [ $os = Linux ]; then
     libpng12-dev \
   )
 
-  [ $TESTING     = OFF ] || deps=(${deps[@]} libgtest-dev)
-  [ $WITH_TBB    = OFF ] || deps=(${deps[@]} libtbb-dev)
-  [ $WITH_FLANN  = OFF ] || deps=(${deps[@]} libflann-dev)
+  [ $TESTING = OFF ] || deps=(${deps[@]} libgtest-dev)
+  [ $WITH_TBB = OFF ] || deps=(${deps[@]} libtbb-dev)
+  [ $WITH_FLANN = OFF ] || deps=(${deps[@]} libflann-dev)
   [ $WITH_ARPACK = OFF ] || deps=(${deps[@]} libarpack2-dev)
 
   if [ $WITH_UMFPACK = ON ]; then

--- a/Scripts/make_appimage.sh
+++ b/Scripts/make_appimage.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+set -e
+
+########################################################################
+# Package the binaries built on Travis CI as an AppImage
+#
+# For more information, see http://appimage.org/
+########################################################################
+
+# Output something before any command can fail (cf. 'set -e')
+# If this is the only output in build log, use 'set -ex' above
+echo "Creating AppImage"
+echo
+
+norm_option_value()
+{
+  if [ "$1" = on ] || [ "$1" = ON ] || [ "$1" = yes ] || [ "$1" = YES ] || [ "$1" = y ] || [ "$1" = Y ] || [ "$1" = 1 ] || [ "$1" = true ] || [ "$1" = TRUE ]; then
+    echo ON
+  elif [ "$1" = off ] || [ "$1" = OFF ] || [ "$1" = no ] || [ "$1" = NO ] || [ "$1" = n ] || [ "$1" = N ] || [ "$1" = 0 ] || [ "$1" = false ] || [ "$1" = FALSE ]; then
+    echo OFF
+  elif [ -n "$2" ]; then
+    echo "$2"
+  else
+    echo OFF
+  fi
+}
+
+TRAVIS=`norm_option_value "$TRAVIS" OFF`
+WITH_VTK=`norm_option_value "$WITH_VTK" OFF`
+TRANSFER=`norm_option_value "$TRANSFER_AppImage" OFF`
+AppImage_LATEST=`norm_option_value "$AppImage_LATEST" OFF`
+PYTHON="/usr/bin/env python"  # target system Python interpreter
+
+if [ $TRAVIS = ON ]; then
+  sudo apt-get install -y tree
+  cd "$TRAVIS_BUILD_DIR/Build"
+  OUTDIR="$TRAVIS_BUILD_DIR/Deploy"
+else
+  OUTDIR="$(cd "$(dirname "$BASH_SOURCE")/.." && pwd)/Deploy"
+fi
+
+APP='MIRTK'
+LOWERAPP=${APP,,}
+VERSION=$(git describe --tags --exact-match --abbrev=0 HEAD 2> /dev/null || true)
+if [ -n "$VERSION" ]; then
+  RELEASE="$VERSION"
+else
+  VERSION=$(git rev-parse --short HEAD)
+  if [ $AppImage_LATEST = ON ]; then
+    RELEASE="latest"  # overwrite previous "latest" BinTray AppImage
+  else
+    RELEASE="$VERSION"
+  fi
+fi
+APPDIR="/tmp/$APP/$APP.AppDir"
+export ARCH=$(arch)
+
+echo "Name:    $APP"
+echo "Version: $VERSION"
+echo "Release: $RELEASE"
+echo "Arch:    $ARCH"
+echo
+echo "Populating AppDir..."
+make install DESTDIR="$APPDIR"
+
+cd "$APPDIR/.."
+wget -q https://github.com/probonopd/AppImages/raw/master/functions.sh -O ./functions.sh
+. ./functions.sh
+cd "$APPDIR"
+
+########################################################################
+# Copy in dependencies that may not be available on all target systems
+########################################################################
+
+if [ $WITH_VTK = ON ] && [ -n "$VTK_VERSION" ]; then
+  export LD_LIBRARY_PATH="${VTK_PREFIX:-$HOME/VTK-$VTK_VERSION}/lib:$LD_LIBRARY_PATH"
+fi
+copy_deps
+move_lib
+
+########################################################################
+# Delete stuff that should not go into the AppImage
+########################################################################
+
+# Delete dangerous libraries
+# See https://github.com/probonopd/AppImages/blob/master/excludelist
+delete_blacklisted
+
+if [ -d usr/lib/$ARCH-linux-gnu ]; then
+  mv usr/lib/$ARCH-linux-gnu/* usr/lib/
+  rmdir usr/lib/$ARCH-linux-gnu
+fi
+
+if [ -d usr/lib/mirtk ]; then
+  mv usr/lib/mirtk/* usr/lib/
+  rmdir usr/lib/mirtk
+  sed -i s:lib/mirtk:lib:g usr/bin/mirtk
+fi
+
+rm -f usr/bin/uninstall-mirtk || true
+rm -rf usr/include || true
+rm -rf usr/lib/cmake || true
+rm -rf usr/doc || true
+rm -rf usr/share || true
+rmdir usr/lib64 || true
+
+find . -name *.so -or -name *.so.* -exec strip {} \;
+for f in $(find . -type f -executable -exec file -- {} \; | grep ELF | cut -d: -f1); do
+  strip "$f"
+done
+
+########################################################################
+# Fix she-bang interpreter specifications
+########################################################################
+
+for f in $(grep -rl '^#!.*python' usr); do
+  echo -n "$f: replace '$(head -n1 "$f")'"
+  sed -i'' "s:#!.*python:#!$PYTHON:" "$f"
+  echo " by '$(head -n1 "$f")'"
+done
+
+########################################################################
+# Write custom AppRun script
+########################################################################
+
+cp "$TRAVIS_BUILD_DIR/Documentation/static/logo.svg" "$APP.svg"
+
+cat -- > "$APP.desktop" <<EOF
+[Desktop Entry]
+Version=1.0
+Name=$APP
+Icon=$APP
+Comment=Medical Image Registration ToolKit ($VERSION)
+Exec=$PYTHON usr/bin/mirtk
+Terminal=true
+Type=Application
+Categories=Development
+EOF
+
+cat -- > "AppRun" <<EOF
+#!/bin/bash
+APPDIR="\$(dirname "\$(readlink -f "\$BASH_SOURCE")")"
+export LD_LIBRARY_PATH="\$APPDIR/usr/lib:\$LD_LIBRARY_PATH"
+$PYTHON "\$APPDIR/usr/bin/mirtk" "\$@"
+EOF
+chmod a+x AppRun
+
+echo "Populating AppDir... done:"
+tree -a || true
+
+########################################################################
+# Now packaging AppDir as an AppImage
+########################################################################
+
+echo
+echo "Generating AppImage..."
+cd "$APPDIR/.."
+GLIBC_VERSION=$(glibc_needed)
+APPIMAGE="$APP-$RELEASE-$ARCH"
+[ -z "$GLIBC_VERSION" ] || APPIMAGE="$APPIMAGE-glibc$GLIBC_VERSION"
+APPIMAGE="$APPIMAGE.AppImage"
+mkdir -p "$OUTDIR"
+wget "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-${ARCH}.AppImage"
+chmod a+x appimagetool-${ARCH}.AppImage
+rm -f "$OUTDIR/$APPIMAGE" 2> /dev/null || true
+./appimagetool-${ARCH}.AppImage -n -v "$APPDIR" "$OUTDIR/$APPIMAGE"
+
+echo "Generating AppImage... done"
+
+########################################################################
+# Clean up
+########################################################################
+
+if [ $TRAVIS = OFF ]; then
+  rm -rf "$APPDIR" "/tmp/$APP" || true
+fi
+
+########################################################################
+# Upload AppImage
+########################################################################
+
+if [ $TRANSFER = ON ]; then
+  echo
+  echo "Transferring AppImage ..."
+  transfer "$OUTDIR/$APPIMAGE"
+  echo
+  echo "Transferring AppImage... done"
+fi
+
+cat -- <<EOF
+
+You can test the AppImage using a Docker container, e.g., a fresh Ubuntu installation.
+
+# Without extracting the AppImage using FUSE
+(Not recommended, see https://github.com/AppImage/AppImageKit/wiki/FUSE#docker)
+
+Pull and run Docker container with necessary privileges for FUSE:
+> docker run --rm -it --privileged=true --cap-add MKNOD --cap-add SYS_ADMIN --device /dev/fuse ubuntu
+
+Inside the Docker container run:
+> URL="Copy and paste MIRTK AppImage transfer.sh, bintray.com, or github.com URL here"
+> apt-get update && apt-get install -y sshfs wget python
+> wget -O mirtk "\$URL" && chmod a+x mirtk
+> ./mirtk -h
+
+# Extracting the AppImage and calling squashfs-root/AppRun
+
+Pull and run Docker container:
+> docker run --rm -it ubuntu
+
+Inside the Docker container run:
+> URL="Copy and paste MIRTK AppImage transfer.sh, bintray.com, or github.com URL here"
+> apt-get update && apt-get install -y wget python
+> wget -O MIRTK.AppImage "\$URL" && chmod a+x MIRTK.AppImage
+> ./MIRTK.AppImage --appimage-extract
+> ./squashfs-root/AppRun -h
+EOF

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -60,7 +60,8 @@ for module in ${modules[@]}; do
 done
 
 mkdir Build && cd Build
-run cmake -D CMAKE_INSTALL_PREFIX=$HOME/local \
+run cmake \
+      -D CMAKE_INSTALL_PREFIX=/usr \
       -D CMAKE_BUILD_TYPE=Release \
       -D BUILD_SHARED_LIBS=ON \
       -D BUILD_APPLICATIONS=ON \


### PR DESCRIPTION
The AppImage created from the latest master `HEAD` is deployed automatically to [bintray.com](https://bintray.com/schuhschuh/AppImages/MIRTK/master#files). When the commit is tagged, the AppImage is uploaded to the tagged release on GitHub.

Example use on Linux:
```
wget -O mirtk https://bintray.com/schuhschuh/AppImages/download_file?file_path=MIRTK-latest-x86_64-glibc2.14.AppImage
chmod a+x mirtk
./mirtk -h
./mirtk register -version
./mirtk construct-atlas -h
```
Hence, the `mirtk` AppImage acts like a ELF binary that simply can perform all the MIRTK commands. The only requirement at this moment is a Python installation. May include it at some point in the AppImage, but I guess that won't be necessary.

Closes #221.