### PR TITLE
enh: Include 'view' binary in AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,11 @@ env:
   - WITH_UMFPACK=OFF  # ARPACK & UMFPACK dependencies come in pairs
   - WITH_TBB=ON       # build with TBB is always recommended
   - WITH_FLANN=ON     # build with FLANN is optional, but requires only little extra build time
+  # build and deployment of AppImage for Linux
+  - AppImage_BUILD=${AppImage_BUILD:-ON}
+  - AppImage_BRANCH=${AppImage_BRANCH:-master}
+  - AppImage_VIEWER=${AppImage_VIEWER:-OFF}
+  - AppImage_LATEST=${AppImage_LATEST:-ON}
   matrix:
   - WITH_VTK=OFF      # make sure that MIRTK can be build fine without VTK
   - WITH_VTK=ON       # test build with all moduldes, including those using VTK
@@ -63,7 +68,7 @@ script:
   - Scripts/travis.sh
 
 after_success:
-  - if [ "$AppImage_BUILD" = ON ] && [ "$TRAVIS_REPO_SLUG" = "BioMedIA/MIRTK" ] && [ "$TRAVIS_BRANCH" = master ] && [ "$TRAVIS_PULL_REQUEST" = false ] && [ "$TRAVIS_OS_NAME" = linux ] && [ "$WITH_VTK" = ON ]; then
+  - if [ "$AppImage_BUILD" = ON ] && [ "$TRAVIS_REPO_SLUG" = "BioMedIA/MIRTK" ] && [ "$TRAVIS_BRANCH" = "$AppImage_BRANCH" ] && [ "$TRAVIS_PULL_REQUEST" = false ] && [ "$TRAVIS_OS_NAME" = linux ] && [ "$WITH_VTK" = ON ]; then
       export AppImage_BINTRAY=ON;
     else
       export AppImage_BINTRAY=OFF;

--- a/Scripts/install_mirtk_appimage.sh
+++ b/Scripts/install_mirtk_appimage.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+WITH_VIEWER=true
+INSTALL_PREFIX="/usr/local"
+SUDO='sudo'  # set to empty string if prefix is writable by $USER
+
+APPIMAGE="$1"
+if [ -z "$APPIMAGE" ]; then
+  GLIBC_VERSION="$(ldd --version | head -n1 | rev | cut -d' ' -f1 | rev)"
+  GLIBC_VERSION_MAJOR="${GLIBC_VERSION/.*}"
+  GLIBC_VERSION_MINOR="${GLIBC_VERSION/*.}"
+  if [ $GLIBC_VERSION_MAJOR -lt 2 ] || [ $GLIBC_VERSION_MAJOR -eq 2 -a $GLIBC_VERSION_MINOR -lt 14 ]; then
+    cat -- 2>&1 <<EOF
+Your glibc version is $GLIBC_VERSION, but at least version 2.14 is required!
+Consider building MIRTK from source code or use the Docker container.
+See also: http://mirtk.github.io/getstarted.html#install-the-software
+EOF
+    exit 1
+  elif [ $WITH_VIEWER != true ] || [ $GLIBC_VERSION_MAJOR -eq 2 -a $GLIBC_VERSION_MINOR -eq 14 ]; then
+    APPIMAGE=MIRTK-latest-x86_64-glibc2.14.AppImage
+  else
+    APPIMAGE=MIRTK+view-latest-x86_64-glibc2.15.AppImage
+  fi
+else
+  name="$(basename "$APPIMAGE")"
+  if [ "${name:0:5}" != MIRTK -o "${name//*.}" != AppImage ]; then
+    echo "Provided AppImage file must be named MIRTK*.AppImage!" 2>&1
+    exit 1
+  fi
+  if [ ! -f "$APPIMAGE" -a "$APPIMAGE" != "$name" ]; then
+    echo "Specified AppImage file does not exist!" 2>&1
+    echo "To download an AppImage from bintray.com, specify file name only!" 2>&1
+    exit 1
+  fi
+fi
+
+if [ -f "$APPIMAGE" ]; then
+  cp "$APPIMAGE" /tmp/mirtk
+elif [ $(which wget 2> /dev/null) ]; then
+  wget -O /tmp/mirtk https://bintray.com/schuhschuh/AppImages/download_file?file_path=$APPIMAGE
+elif [ $(which curl 2> /dev/null) ]; then
+  curl -o /tmp/mirtk https://bintray.com/schuhschuh/AppImages/download_file?file_path=$APPIMAGE
+else
+  cat -- <<EOF
+Neither wget nor curl is installed!
+Download the following file and call this script with downloaded file as argument:
+https://bintray.com/schuhschuh/AppImages/download_file?file_path=MIRTK-latest-x86_64-glibc$GLIBC_MINIMUM.AppImage
+EOF
+fi
+
+chmod a+x /tmp/mirtk && $SUDO cp /tmp/mirtk "$INSTALL_PREFIX/bin/mirtk" && rm -f /tmp/mirtk


### PR DESCRIPTION
Include the pre-built `view` binary from https://bintray.com/schuhschuh/generic/MIRTKViewer in AppImage deployed by Travis CI build.