### PR TITLE
fix: Replace she-bang with license information in ‘spatiotemporal’

### DIFF
--- a/Applications/lib/python/mirtk/atlas/spatiotemporal.py
+++ b/Applications/lib/python/mirtk/atlas/spatiotemporal.py
@@ -1,4 +1,21 @@
-#!/usr/bin/python
+##############################################################################
+# Medical Image Registration ToolKit (MIRTK)
+#
+# Copyright 2017 Imperial College London
+# Copyright 2017 Andreas Schuh
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##############################################################################
 
 import os
 import sys


### PR DESCRIPTION
Python module should not have a she-bang as it's not executable. Instead, insert license information as comment.