### PR TITLE
fix: Use underscores instead of dashes in ‘mirtk.<command>’ call [Applications]

### DIFF
--- a/Applications/lib/python/mirtk/__init__.py.in
+++ b/Applications/lib/python/mirtk/__init__.py.in
@@ -74,6 +74,12 @@ class Module(ModuleType):
             return ModuleType.__getattribute__(self, name)
         elif name in ["path", "run", "call", "check_call", "check_output"]:
             return getattr(subprocess, name)
+        if not subprocess.path(name, quiet=True):
+            command = name.replace('_', '-')
+            if subprocess.path(command, quiet=True):
+                name = command
+            else:
+                return ModuleType.__getattribute__(self, name)
         def run(*args, **kwargs):
             return subprocess.run(name, *args, **kwargs)
         setattr(self, name, run)


### PR DESCRIPTION
Fixup for #613.

- Enables calling also commands that have a dash (`-`) in their name.
- Implicitly checks existence of command binary using `mirtk.subprocess.path`.