### PR TITLE
enh: Replace ‘_’ in command option kwargs by ‘-‘, add onexit and onerror [Applications]

### DIFF
--- a/Applications/lib/python/mirtk/__init__.py.in
+++ b/Applications/lib/python/mirtk/__init__.py.in
@@ -70,9 +70,11 @@ class Module(ModuleType):
 
     def __getattr__(self, name):
         """Get method for execution of named MIRTK command."""
+        if name == 'subprocess':
+            return subprocess
         if len(name) == 0 or name[0] == '_':
             return ModuleType.__getattribute__(self, name)
-        elif name in ["path", "run", "call", "check_call", "check_output"]:
+        if name in ["path", "run", "call", "check_call", "check_output"]:
             return getattr(subprocess, name)
         if not subprocess.path(name, quiet=True):
             command = name.replace('_', '-')

--- a/Applications/lib/python/mirtk/atlas/spatiotemporal.py
+++ b/Applications/lib/python/mirtk/atlas/spatiotemporal.py
@@ -157,7 +157,7 @@ class SpatioTemporalAtlas(object):
             try:
                 if self.verbose > 1:
                     sys.stdout.write("\n\n")
-                mirtk.run(command, args=args, opts=opts, verbose=self.verbose - 1, threads=threads, exit_on_error=self.exit_on_error)
+                mirtk.run(command, args=args, opts=opts, showcmd=(self.verbose > 1), threads=threads, onexit='exit' if self.exit_on_error else 'throw')
             finally:
                 os.chdir(prevdir)
 
@@ -1462,7 +1462,7 @@ class SpatioTemporalAtlas(object):
         if not channel:
             channel = self.channel
         imgs = [self.template(int(idx), channel=channel) for idx in i]
-        mirtk.run("view", opts={"target": imgs})
+        mirtk.run("view", target=imgs)
 
     def rmtemp(self):
         """Delete temporary files.

--- a/Applications/lib/python/mirtk/subprocess.py.in
+++ b/Applications/lib/python/mirtk/subprocess.py.in
@@ -158,8 +158,33 @@ def check_output(argv, verbose=0, code='utf-8'):
 
 
 # ----------------------------------------------------------------------------
-def run(cmd, *args, **kwargs): 
+def run(cmd, *args, **kwargs):
     """Execute MIRTK command and throw exception or exit on error.
+
+    This function calls the specified MIRTK command with the given positional
+    and option arguments (keyword arguments prepended by single dash, '-').
+    The 'onexit' and 'onexit' keyword arguments define the return value and
+    the error handling when the subprocess returns a non-zero exit code.
+    By default, this function behaves identical to check_call, i.e., throws
+    and exception when the command failed and does not return a value otherwise.
+
+    Arguments
+    ---------
+
+    onexit: str
+        Defines action to take when command subprocess finished.
+        - 'none': Always return None, even when process failed when onerror='return'
+        - 'output': Return standard output of command instead of printing it
+        - 'returncode': Return exit code of command. When onerror is not 'return',
+          this always returns 0 indicating successful execution of the command.
+    onerror: str
+        - 'return': Return value specified by 'onexit' even when command failed.
+        - 'throw': Throw CalledProcessError when command failed.
+        - 'exit': Exit this process (sys.exit) with exit command of failed command.
+
+
+    Deprecated
+    ----------
 
     This convenience wrapper for check_call throws a subprocess.CalledProcessError 
     when the command returned a non-zero exit code when exit_on_error=False.
@@ -168,11 +193,30 @@ def run(cmd, *args, **kwargs):
     using sys.exit with the return code of the executed command.
 
     """
+    if "exit_on_error" in kwargs and "onerror" in kwargs:
+        raise ValueError("Deprecated keyword argument 'exit_on_error' given together with new 'onerror' argument!")
     workdir = kwargs.get("workdir", None)
     verbose = kwargs.get("verbose", 0)
     threads = kwargs.get("threads", 0)
-    exit_on_error = kwargs.get("exit_on_error", False)
-    remove_kwargs(kwargs, ["workdir", "verbose", "threads", "exit_on_error"])
+    onerror = kwargs.get("onerror", "exit" if kwargs.get("exit_on_error", False) else "throw")
+    if onerror is None:
+        onerror = 'return'
+    else:
+        onerror = onerror.lower()
+        if onerror not in ('return', 'throw', 'exit'):
+            raise ValueError("Invalid 'onerror={}' argument! Must be 'return', 'throw', or 'exit'.".format(onerror))
+    onexit = kwargs.get("onexit", None)
+    if onexit is None:
+        onexit = 'none'
+    else:
+        onexit = onexit.lower()
+        if onexit in ('code', 'exit_code', 'return_code'):
+            onexit = 'returncode'
+        if onexit in ('stdout', 'return_stdout', 'return_output'):
+            onexit = 'output'
+        if onexit not in ('none', 'output', 'returncode'):
+            raise ValueError("Invalid 'onexit={}' argument! Must be 'none', 'returncode', 'output' or alternatives thereof.".format(onexit))
+    remove_kwargs(kwargs, ["workdir", "verbose", "threads", "onexit", "onerror", "exit_on_error"])
     # command arguments
     argv = [cmd]
     argv.extend(args)
@@ -204,22 +248,29 @@ def run(cmd, *args, **kwargs):
                 argv.extend(flatten(arg))
     # add options given as kwargs
     for opt, arg in kwargs.items():
+        opt = opt.replace('_', '-')
         if not opt.startswith('-'):
             opt = '-' + opt
         argv.append(opt)
         if not arg is None:
             argv.extend(flatten(arg))
     # add -threads option
-    if threads > 0 and not "threads" in opts:
+    if threads > 0 and not 'threads' in opts:
         argv.extend(['-threads', str(threads)])
     # execute command
+    retval = None
     prevdir = os.getcwd()
     if workdir:
         os.chdir(workdir)
     try:
-        check_call(argv, verbose=verbose)
+        if onexit == 'output':
+            retval = check_output(argv, verbose=verbose)
+        else:
+            check_call(argv, verbose=verbose)
+            if onexit == 'returncode':
+                retval = 0
     except subprocess.CalledProcessError as e:
-        if exit_on_error:
+        if onerror == 'exit':
             sys.stdout.flush()
             sys.stderr.write("\n")
             sys.stderr.write("Command: ")
@@ -229,6 +280,10 @@ def run(cmd, *args, **kwargs):
             sys.stderr.write("\nTraceback (most recent call last):\n")
             traceback.print_stack()
             sys.exit(e.returncode)
-        raise e
+        elif onerror == 'throw':
+            raise e
+        if onexit == 'returncode':
+            retval = e.returncode
     finally:
         os.chdir(prevdir)
+    return retval

--- a/Applications/lib/python/mirtk/subprocess.py.in
+++ b/Applications/lib/python/mirtk/subprocess.py.in
@@ -1,8 +1,8 @@
 ##############################################################################
 # Medical Image Registration ToolKit (MIRTK)
 #
-# Copyright 2016 Imperial College London
-# Copyright 2016 Andreas Schuh
+# Copyright 2016-2017 Imperial College London
+# Copyright 2016-2017 Andreas Schuh
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import subprocess
 
 from collections import OrderedDict
 
+
 # ============================================================================
 # configuration
 # ============================================================================
@@ -44,6 +45,13 @@ libexec_dir = os.path.realpath(os.path.join(__dir__, '@LIBEXEC_DIR@'))
 
 if sys.platform.startswith('win'): libexec_ext = ['.exe', '.cmd', '.bat']
 else:                              libexec_ext = ['']
+
+# default values for kwargs of run function
+showcmd = False
+workdir = None
+threads = 0
+onerror = 'throw'
+onexit = None
 
 # ============================================================================
 # command execution
@@ -193,19 +201,23 @@ def run(cmd, *args, **kwargs):
     using sys.exit with the return code of the executed command.
 
     """
+    default = globals()
     if "exit_on_error" in kwargs and "onerror" in kwargs:
         raise ValueError("Deprecated keyword argument 'exit_on_error' given together with new 'onerror' argument!")
-    workdir = kwargs.get("workdir", None)
-    verbose = kwargs.get("verbose", 0)
-    threads = kwargs.get("threads", 0)
-    onerror = kwargs.get("onerror", "exit" if kwargs.get("exit_on_error", False) else "throw")
+    showcmd = kwargs.get("showcmd", default["showcmd"])
+    workdir = kwargs.get("workdir", default["workdir"])
+    threads = kwargs.get("threads", default["threads"])
+    if "exit_on_error" in kwargs:
+        onerror = kwargs.get("onerror", "exit" if kwargs.get("exit_on_error", False) else "throw")
+    else:
+        onerror = kwargs.get("onerror", default["onerror"])
     if onerror is None:
         onerror = 'return'
     else:
         onerror = onerror.lower()
         if onerror not in ('return', 'throw', 'exit'):
             raise ValueError("Invalid 'onerror={}' argument! Must be 'return', 'throw', or 'exit'.".format(onerror))
-    onexit = kwargs.get("onexit", None)
+    onexit = kwargs.get("onexit", default["onexit"])
     if onexit is None:
         onexit = 'none'
     else:
@@ -216,7 +228,7 @@ def run(cmd, *args, **kwargs):
             onexit = 'output'
         if onexit not in ('none', 'output', 'returncode'):
             raise ValueError("Invalid 'onexit={}' argument! Must be 'none', 'returncode', 'output' or alternatives thereof.".format(onexit))
-    remove_kwargs(kwargs, ["workdir", "verbose", "threads", "onexit", "onerror", "exit_on_error"])
+    remove_kwargs(kwargs, ["showcmd", "workdir", "threads", "onexit", "onerror", "exit_on_error"])
     # command arguments
     argv = [cmd]
     argv.extend(args)
@@ -264,9 +276,9 @@ def run(cmd, *args, **kwargs):
         os.chdir(workdir)
     try:
         if onexit == 'output':
-            retval = check_output(argv, verbose=verbose)
+            retval = check_output(argv, verbose=1 if showcmd else 0)
         else:
-            check_call(argv, verbose=verbose)
+            check_call(argv, verbose=1 if showcmd else 0)
             if onexit == 'returncode':
                 retval = 0
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
- Specify command options with dashes as kwargs using underscores instead.
- Add `onexit` kwarg which enables return of exit code or command output.
- Add `onerror` kwarg with more options than the now deprecated `exit_on_error` switch.
- Fix availability of `mirtk.subprocess` when using `import mirtk` (fixup for #613).

```python
import sys
import mirtk

output = mirtk.info("image.nii.gz", showcmd=True, onerror='exit', onexit='output')
mirtk.register("foo.nii.gz", "bar.nii.gz", onerror=None)  # ignore error, return None anyways
exit_code = mirtk.register("foo.nii.gz", "bar.nii.gz", onerror='none', onexit='returncode')
if exit_code != 0:
    sys.stderr.write("Command failed!")
    sys.exit(42)
```