### PR TITLE
enh: Split ‘Energy function’ over multiple lines using ’…’ [Registration]

### DIFF
--- a/Applications/src/register.cc
+++ b/Applications/src/register.cc
@@ -114,12 +114,12 @@ void PrintHelp(const char* name)
   cout << "  registered with one another is determined by an energy function. This energy function is formulated in\n";
   cout << "  a simplified math expression using MATLAB-style indexing for the individual input files, i.e.,\n";
   cout << "\n";
-  cout << "  Energy function =      SIM[Image dissimilarity](I(1), I(2:end) o T)\n";
-  cout << "                  +      PDM[Point set distance](T o P(1), P(2:end))\n";
-  cout << "                  + 1e-3 BE [Bending energy](T)\n";
-  cout << "                  +    0 TP [Topology preservation](T)\n";
-  cout << "                  +    0 VP [Volume preservation](T)\n";
-  cout << "                  +    0 JAC[Jacobian penalty](T)\n";
+  cout << "  Energy function =      SIM[Image dissimilarity](I(1), I(2:end) o T)...\n";
+  cout << "                  +      PDM[Point set distance](T o P(1), P(2:end))...\n";
+  cout << "                  + 1e-3 BE [Bending energy](T)...\n";
+  cout << "                  +    0 TP [Topology preservation](T)...\n";
+  cout << "                  +    0 VP [Volume preservation](T)...\n";
+  cout << "                  +    0 JAC[Jacobian penalty](T)...\n";
   cout << "                  +    0 Sparsity(T)\n";
   cout << "\n";
   cout << "  where only energy terms with non-zero weights are active during the registration.\n";


### PR DESCRIPTION
Split `Energy function` over multiple lines using MATLAB style line continuation, e.g.,
```
Energy function = SIM[Image dissimilarity](I(1), I(2) o T)...
                + .001 BE[Bending energy](T)...
                + 0 TP[Topology preservation](T)...
                + 0 VP[Volume preservation](T)
```