### PR TITLE
fix: extract-image-region -split output file paths

### DIFF
--- a/Applications/src/extract-image-region.cc
+++ b/Applications/src/extract-image-region.cc
@@ -424,7 +424,7 @@ int main(int argc, char **argv)
     }
     if (pos == end) {
       const int dims[] = {out->X(), out->Y(), out->Z(), out->T()};
-      auto name = FileName(output_path);
+      auto name = FilePrefix(output_path);
       auto ext  = Extension(output_path);
       string fmt = "%03d";
       if      (dims[split] <  10) fmt = "%d";

--- a/Modules/Common/include/mirtk/Path.h
+++ b/Modules/Common/include/mirtk/Path.h
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2017 Imperial College London
+ * Copyright 2013-2017 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,6 +72,12 @@ string FileName(const char *, ExtensionMode = EXT_Default);
 
 /// Get file name of file path excl. file extension
 string FileName(const string &, ExtensionMode = EXT_Default);
+
+/// Get file path excl. file extension
+string FilePrefix(const char *, ExtensionMode = EXT_Default);
+
+/// Get file path excl. file extension
+string FilePrefix(const string &, ExtensionMode = EXT_Default);
 
 
 } // namespace mirtk

--- a/Modules/Common/src/Path.cc
+++ b/Modules/Common/src/Path.cc
@@ -1,8 +1,8 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2013-2015 Imperial College London
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2017 Imperial College London
+ * Copyright 2013-2017 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,6 +137,19 @@ string FileName(const char *path, ExtensionMode mode)
 string FileName(const string &path, ExtensionMode mode)
 {
   return FileName(path.c_str(), mode);
+}
+
+// -----------------------------------------------------------------------------
+string FilePrefix(const char *path, ExtensionMode mode)
+{
+  return FilePrefix(string(path), mode);
+}
+
+// -----------------------------------------------------------------------------
+string FilePrefix(const string &path, ExtensionMode mode)
+{
+  string ext = Extension(path, mode);
+  return path.substr(0, path.length() - ext.length());
 }
 
 


### PR DESCRIPTION
The `FileName` function discards the directory path. Use new `FilePrefix` function to get the full output file path without extension.

Fixes for #624.