### PR TITLE
enh: Create separate average for each segmentation label [Applications]

### DIFF
--- a/Applications/src/average-images.cc
+++ b/Applications/src/average-images.cc
@@ -70,7 +70,7 @@ void PrintHelp(const char* name)
   cout << "Required arguments:\n";
   cout << "  <output>\n";
   cout << "      Voxel-wise average image. When the :option:`-label` is used multiple times,\n";
-  cout << "      one <output> file name can be given for each resulting probabilistic segmentation.\n";
+  cout << "      a unique file path is created for each fuzzy output segmentation.\n";
   cout << "\n";
   cout << "Input options:\n";
   cout << "  -image <file> [<w>]\n";

--- a/Applications/src/average-images.cc
+++ b/Applications/src/average-images.cc
@@ -141,7 +141,7 @@ void PrintHelp(const char* name)
   cout << "      This option can be given multiple times to create more than one average\n";
   cout << "      image for each segment. When only one <output> file name is given, it is\n";
   cout << "      modified to include the index of the segment corresponding to the order\n";
-  cout << "      of the -label(s) options. Otherwise, specify a different output <path> for\n";
+  cout << "      of the -label(s) options. Otherwise, specify a different output <path>\n";
   cout << "      as argument. A suffix corresponding to the respective label is appended to\n";
   cout << "      the output file path before the file name extension. When no argument is given\n";
   cout << "      the <output> path is used.\n";


### PR DESCRIPTION
* Fix parsing of positional arguments.
* Create a separate probability map (average) for each label of multiple hard segmentations.

```
mirtk average-images prob_%02d.nii.gz seg1.nii.gz seg2.nii.gz seg3.nii.gz... -labels
```