### PR TITLE
fix: Travis CI missing CMake MODULE_*=ON arguments

### DIFF
--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -56,7 +56,7 @@ fi
 
 cmake_args=
 for module in ${modules[@]}; do
-  cmake_args=(${config[@]} -D MODULE_${module}=ON)
+  cmake_args=(${cmake_args[@]} -D MODULE_${module}=ON)
 done
 
 mkdir Build && cd Build


### PR DESCRIPTION
A mistake in the `travis.sh` script used to configure the CI build caused not all modules to be built.