### PR TITLE
fix: Apply affine header transformation

### DIFF
--- a/Modules/Numerics/include/mirtk/Matrix.h
+++ b/Modules/Numerics/include/mirtk/Matrix.h
@@ -1170,9 +1170,7 @@ inline void Transform(const Matrix &m, double  x,  double  y,  double  z,
 /// Muliply point by homogeneous transformation matrix
 inline void Transform(const Matrix &m, double &x, double &y, double &z)
 {
-  double mx, my, mz;
-  Transform(m, x, y, z, mx, my, mz);
-  x = mx, y = my, z = mz;
+  Transform(m, x, y, z, x, y, z);
 }
 
 /// Muliply point by homogeneous transformation matrix
@@ -1181,6 +1179,35 @@ inline Point Transform(const Matrix &m, const Point &p)
   Point p2;
   Transform(m, p._x, p._y, p._z, p2._x, p2._y, p2._z);
   return p2;
+}
+
+/// Muliply vector by 3x3 transformation matrix
+inline void TransformVector(const Matrix &m, double  x,  double  y,  double  z,
+                                             double &mx, double &my, double &mz)
+{
+  mx = m(0, 0) * x + m(0, 1) * y + m(0, 2) * z;
+  my = m(1, 0) * x + m(1, 1) * y + m(1, 2) * z;
+  mz = m(2, 0) * x + m(2, 1) * y + m(2, 2) * z;
+}
+
+/// Muliply vector by 3x3 transformation matrix
+inline void TransformVector(const Matrix &m, double &x, double &y, double &z)
+{
+  TransformVector(m, x, y, z, x, y, z);
+}
+
+/// Muliply vector by 3x3 transformation matrix
+inline void TransformVector(const Matrix &m, Vector &v)
+{
+  TransformVector(m, v(0), v(1), v(2));
+}
+
+/// Muliply vector by 3x3 transformation matrix
+inline Vector TransformVector(const Matrix &m, const Vector &v)
+{
+  Vector u(v);
+  TransformVector(m, u);
+  return u;
 }
 
 /// Construct 4x4 homogeneous coordinate transformation matrix from rigid

--- a/Modules/Numerics/include/mirtk/Point.h
+++ b/Modules/Numerics/include/mirtk/Point.h
@@ -64,10 +64,10 @@ public:
   Point(const Point &);
 
   /// Constructor with Vector
-  Point(const Vector3 &);
+  explicit Point(const Vector3 &);
 
   /// Constructor with Vector
-  Point(const Vector &);
+  explicit Point(const Vector &);
 
   /// Default destructor
   virtual ~Point();

--- a/Modules/Numerics/src/Matrix.cc
+++ b/Modules/Numerics/src/Matrix.cc
@@ -1527,6 +1527,9 @@ void MatrixToAffineParameters(const Matrix &m,
   sxy = atan(tansxy);
   sxz = atan(tansxz);
   syz = atan(tansyz);
+  if (AreEqual(sxy, 0.)) sxy = 0.;
+  if (AreEqual(sxz, 0.)) sxz = 0.;
+  if (AreEqual(syz, 0.)) syz = 0.;
 
   // Now get the rigid transformation parameters.
   // Put the rotation matrix components into the upper left 3x3 submatrix.

--- a/Modules/Transformation/include/mirtk/HomogeneousTransformation.h
+++ b/Modules/Transformation/include/mirtk/HomogeneousTransformation.h
@@ -339,8 +339,20 @@ inline double HomogeneousTransformation::Update(const DOFValue *dx)
 // -----------------------------------------------------------------------------
 inline void HomogeneousTransformation::PutMatrix(const Matrix &matrix)
 {
-  _matrix = matrix;
-  _matrix(3, 0) = _matrix(3, 1) = _matrix(3, 2) = .0, _matrix(3, 3) = 1.0;
+  if (matrix.Rows() == 3 && matrix.Cols() == 3) {
+    for (int c = 0; c < 3; ++c)
+    for (int r = 0; r < 3; ++r) {
+      _matrix(r, c) = matrix(r, c);
+    }
+    for (int r = 0; r < 3; ++r) {
+      _matrix(r, 3) = 0.;
+    }
+  } else if (matrix.Rows() == 4 && matrix.Cols() == 4) {
+    _matrix = matrix;
+  } else {
+    Throw(ERR_InvalidArgument, __FUNCTION__, "Transformation matrix must be 3x3 or 4x4");
+  }
+  _matrix(3, 0) = _matrix(3, 1) = _matrix(3, 2) = 0., _matrix(3, 3) = 1.;
   this->Update(DOFS_MATRIX); // also updates _inverse
 }
 


### PR DESCRIPTION
Image axes had been flipped (opposite sign) after re-applying the `edit-image -reset -dofout`.