### PR TITLE
enh: Conjugate gradient of data fidelity terms only [Registration]

### DIFF
--- a/Modules/Numerics/include/mirtk/ConjugateGradientDescent.h
+++ b/Modules/Numerics/include/mirtk/ConjugateGradientDescent.h
@@ -43,6 +43,12 @@ class ConjugateGradientDescent : public GradientDescent
   /// gradient descent is converged. Call Run after setting ConjugateGradientOff.
   mirtkPublicAttributeMacro(bool, UseConjugateGradient);
 
+  /// Whether to compute conjugate gradient of total energy gradient
+  ///
+  /// When disabled, only the gradient of the data fidelity term is conjugated
+  /// before adding the gradient of the model constraint term.
+  mirtkPublicAttributeMacro(bool, ConjugateTotalGradient);
+
 protected:
 
   double *_g;
@@ -69,13 +75,30 @@ public:
   virtual ~ConjugateGradientDescent();
 
   // ---------------------------------------------------------------------------
+  // Parameters
+  using GradientDescent::Parameter;
+
+  /// Set parameter value from string
+  virtual bool Set(const char *, const char *);
+
+  /// Get parameters as key/value as string map
+  virtual ParameterList Parameter() const;
+
+  // ---------------------------------------------------------------------------
   // Optimization
 
   /// Reset conjugate gradient to objective function gradient
   void ResetConjugateGradient();
 
-  /// Enable conjugation of objective function gradient
+  /// Enable conjugation of data fidelity gradient
   void ConjugateGradientOn();
+
+  /// Enable conjugation of objective function gradient
+  void ConjugateTotalGradientOn();
+
+  /// Disable conjugation of objective function gradient
+  /// When conjugation was enabled before, the data fidelity gradient is still conjugated
+  void ConjugateTotalGradientOff();
 
   /// Disable conjugation of objective function gradient
   void ConjugateGradientOff();
@@ -104,13 +127,26 @@ protected:
 inline void ConjugateGradientDescent::ResetConjugateGradient()
 {
   // Set g[0] to NaN to indicate that vectors _g and _h are uninitialized
-  if (_g) _g[0] = numeric_limits<double>::quiet_NaN();
+  if (_g) _g[0] = NaN;
 }
 
 // -----------------------------------------------------------------------------
 inline void ConjugateGradientDescent::ConjugateGradientOn()
 {
   this->UseConjugateGradient(true);
+}
+
+// -----------------------------------------------------------------------------
+inline void ConjugateGradientDescent::ConjugateTotalGradientOn()
+{
+  this->UseConjugateGradient(true);
+  this->ConjugateTotalGradient(true);
+}
+
+// -----------------------------------------------------------------------------
+inline void ConjugateGradientDescent::ConjugateTotalGradientOff()
+{
+  this->ConjugateTotalGradient(false);
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Numerics/include/mirtk/ObjectiveFunction.h
+++ b/Modules/Numerics/include/mirtk/ObjectiveFunction.h
@@ -119,13 +119,39 @@ public:
   /// Evaluate objective function value
   virtual double Value() = 0;
 
+  /// Evaluate data fidelity gradient of objective function w.r.t its DoFs
+  ///
+  /// \param[in]  step    Step length for finite differences.
+  /// \param[out] dx      Data fidelity gradient of objective function.
+  /// \param[out] sgn_chg Whether function parameter value is allowed to
+  ///                     change sign when stepping along the computed gradient.
+  virtual void DataFidelityGradient(double *dx, double step = .0, bool *sgn_chg = nullptr);
+
+  /// Add model constraint gradient of objective function w.r.t its DoFs
+  ///
+  /// \param[in]  step    Step length for finite differences.
+  /// \param[out] dx      Gradient of objective function, e.g., either initialised to zero or
+  ///                     the data fidelity gradient computed beforehand using DataFidelityGradient.
+  /// \param[out] sgn_chg Whether function parameter value is allowed to
+  ///                     change sign when stepping along the computed gradient.
+  virtual void AddConstraintGradient(double *dx, double step = .0, bool *sgn_chg = nullptr);
+
   /// Evaluate gradient of objective function w.r.t its DoFs
+  ///
+  /// When the data fidelity and/or gradient of model constraints need to be
+  /// evaluated separately, use the following code instead:
+  /// \code
+  /// double *gradient;        // allocate with number of DoFs
+  /// ObjectiveFunction *func; // pointer to objective function instance
+  /// func->DataFideltiyGradient(gradient);
+  /// func->AddConstraintGradient(gradient);
+  /// \endcode
   ///
   /// \param[in]  step    Step length for finite differences.
   /// \param[out] dx      Gradient of objective function.
   /// \param[out] sgn_chg Whether function parameter value is allowed to
   ///                     change sign when stepping along the computed gradient.
-  virtual void Gradient(double *dx, double step = .0, bool *sgn_chg = NULL) = 0;
+  virtual void Gradient(double *dx, double step = .0, bool *sgn_chg = nullptr) = 0;
 
   /// Compute norm of gradient of objective function
   ///
@@ -187,6 +213,19 @@ inline bool ObjectiveFunction::Upgrade()
 inline void ObjectiveFunction::GradientStep(const double *, double &, double &) const
 {
   // By default, step length range chosen by user/optimizer
+}
+
+// -----------------------------------------------------------------------------
+inline void ObjectiveFunction::DataFidelityGradient(double *dx, double step, bool *sgn_chg)
+{
+  // By default, objective function is not separated into data fidelity and constraint terms.
+  this->Gradient(dx, step, sgn_chg);
+}
+
+// -----------------------------------------------------------------------------
+inline void ObjectiveFunction::AddConstraintGradient(double *, double, bool *)
+{
+  // By default, already included in DataFidelityGradient
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Numerics/src/ConjugateGradientDescent.cc
+++ b/Modules/Numerics/src/ConjugateGradientDescent.cc
@@ -107,15 +107,8 @@ bool ConjugateGradientDescent::Set(const char *name, const char *value)
 // -----------------------------------------------------------------------------
 ParameterList ConjugateGradientDescent::Parameter() const
 {
-  ParameterList params = LocalOptimizer::Parameter();
-  if (_LineSearch && _LineSearch->Strategy() == _LineSearchStrategy) {
-    Insert(params, _LineSearch->Parameter());
-  }
-  Insert(params, _LineSearchParameter);
+  ParameterList params = GradientDescent::Parameter();
   Insert(params, "Conjugate total energy gradient", _ConjugateTotalGradient);
-  Insert(params, "Maximum no. of restarts",         _NumberOfRestarts);
-  Insert(params, "Maximum no. of failed restarts",  _NumberOfFailedRestarts);
-  Insert(params, "Line search strategy",            _LineSearchStrategy);
   return params;
 }
 

--- a/Modules/Registration/include/mirtk/RegistrationEnergy.h
+++ b/Modules/Registration/include/mirtk/RegistrationEnergy.h
@@ -130,6 +130,9 @@ public:
   /// Whether the n-th energy term is a penalty term
   bool IsConstraint(int) const;
 
+  /// Whether the n-th energy term is a sparsity term
+  bool IsSparsityConstraint(int) const;
+
   /// Number of energy terms
   int NumberOfTerms() const;
 
@@ -250,6 +253,23 @@ public:
   /// Scheme for Difference Measures in Deformable Registration. In ICCV 2011.
   void NormalizeGradient(double *dx);
 
+  /// Evaluate data fidelity gradient of objective function w.r.t its DoFs
+  ///
+  /// \param[in]  step    Step length for finite differences.
+  /// \param[out] dx      Data fidelity gradient of objective function.
+  /// \param[out] sgn_chg Whether function parameter value is allowed to
+  ///                     change sign when stepping along the computed gradient.
+  virtual void DataFidelityGradient(double *dx, double step = .0, bool *sgn_chg = nullptr);
+
+  /// Add model constraint gradient of objective function w.r.t its DoFs
+  ///
+  /// \param[in]  step    Step length for finite differences.
+  /// \param[out] dx      Gradient of objective function, e.g., either initialised to zero or
+  ///                     the data fidelity gradient computed beforehand using DataFidelityGradient.
+  /// \param[out] sgn_chg Whether function parameter value is allowed to
+  ///                     change sign when stepping along the computed gradient.
+  virtual void AddConstraintGradient(double *dx, double step = .0, bool *sgn_chg = nullptr);
+
   /// Evaluate gradient of registration energy
   ///
   /// Note that this gradient need not necessarily correspond to the analytic
@@ -264,7 +284,7 @@ public:
   /// \param[in]  step    Step length for finite differences.
   /// \param[out] sgn_chg Whether function parameter value is allowed to
   ///                     change sign when stepping along the computed gradient.
-  void Gradient(double *dx, double step = .0, bool *sgn_chg = NULL);
+  void Gradient(double *dx, double step = .0, bool *sgn_chg = nullptr);
 
   /// Compute norm of gradient of registration energy
   ///


### PR DESCRIPTION
Adds option `Conjugate total energy gradient` which is `On` by default. When `Off`, only the gradient of the data terms is conjugated before the gradient of the penalty terms are added to this conjugate gradient.