### PR TITLE
enh: Approximate FFD gradient calculations

### DIFF
--- a/Modules/Image/include/mirtk/CubicBSplineConvolution.h
+++ b/Modules/Image/include/mirtk/CubicBSplineConvolution.h
@@ -1,0 +1,112 @@
+/*
+ * Medical Image Registration ToolKit (MIRTK)
+ *
+ * Copyright 2017 Imperial College London
+ * Copyright 2017 Andreas Schuh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MIRTK_CubicBSplineConvolution_H
+#define MIRTK_CubicBSplineConvolution_H
+
+#include "mirtk/SeparableConvolution.h"
+
+
+namespace mirtk {
+
+
+/**
+ * Convolves image with separable cubic B-spline kernel
+ */
+template <class TVoxel>
+class CubicBSplineConvolution : public SeparableConvolution<TVoxel>
+{
+  mirtkInPlaceImageFilterMacro(CubicBSplineConvolution, TVoxel);
+
+protected:
+
+  /// Type of convolution kernels
+  typedef typename SeparableConvolution<TVoxel>::KernelType KernelType;
+
+  /// Radius of cubic B-spline support region along x axis
+  ///
+  /// - r<0: voxel units
+  /// - r=0: no smoothing in x
+  /// - r>0: mm units
+  mirtkAttributeMacro(double, RadiusX);
+
+  /// Radius of cubic B-spline support region along y axis
+  ///
+  /// - r<0: voxel units
+  /// - r=0: no smoothing in y
+  /// - r>0: mm units
+  mirtkAttributeMacro(double, RadiusY);
+
+  /// Radius of cubic B-spline support region along z axis
+  ///
+  /// - r<0: voxel units
+  /// - r=0: no smoothing in z
+  /// - r>0: mm units
+  mirtkAttributeMacro(double, RadiusZ);
+
+  /// Radius of cubic B-spline support region along t axis
+  ///
+  /// - r<0: voxel units
+  /// - r=0: no smoothing in t
+  /// - r>0: mm units
+  mirtkAttributeMacro(double, RadiusT);
+
+protected:
+
+  // Base class setters unused, should not be called by user
+  virtual void KernelX(const KernelType *) {}
+  virtual void KernelY(const KernelType *) {}
+  virtual void KernelZ(const KernelType *) {}
+  virtual void KernelT(const KernelType *) {}
+
+  // Instantiated cubic B-spline kernels
+  UniquePtr<KernelType> _BSplineKernel[4];
+
+  /// Initialize 1D cubic B-spline kernel with radius given in voxel units
+  UniquePtr<KernelType> InitializeKernel(double);
+
+  /// Initialize filter
+  virtual void Initialize();
+
+public:
+
+  /// Constructor
+  CubicBSplineConvolution(double = 2.);
+
+  /// Constructor
+  CubicBSplineConvolution(double, double, double = 0., double = 0.);
+
+  /// Destructor
+  ~CubicBSplineConvolution();
+
+  /// Set isotropic radius of spatial cubic B-spline support region
+  virtual void Radius(double);
+
+  /// Set radius of cubic B-spline support region
+  virtual void Radius(double, double, double = 0., double = 0.);
+
+  /// Kernel size used for a given radius (divided by voxel size)
+  static int KernelSize(double);
+
+};
+
+
+} // namespace mirtk
+
+#endif // MIRTK_CubicBSplineConvolution_H

--- a/Modules/Image/include/mirtk/GaussianBlurring.h
+++ b/Modules/Image/include/mirtk/GaussianBlurring.h
@@ -1,9 +1,9 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2008-2015 Imperial College London
+ * Copyright 2008-2017 Imperial College London
  * Copyright 2008-2013 Daniel Rueckert, Julia Schnabel
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2017 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,7 @@
 #ifndef MIRTK_GaussianBlurring_H
 #define MIRTK_GaussianBlurring_H
 
-#include "mirtk/GenericImage.h"
-#include "mirtk/ImageToImage.h"
+#include "mirtk/SeparableConvolution.h"
 
 
 namespace mirtk {
@@ -42,9 +41,14 @@ namespace mirtk {
  * standard deviation for the Gaussian kernel has been set.
  */
 template <class TVoxel>
-class GaussianBlurring : public ImageToImage<TVoxel>
+class GaussianBlurring : public SeparableConvolution<TVoxel>
 {
   mirtkInPlaceImageFilterMacro(GaussianBlurring, TVoxel);
+
+protected:
+
+  /// Type of convolution kernels
+  typedef typename SeparableConvolution<TVoxel>::KernelType KernelType;
 
   /// Standard deviation of Gaussian kernel in x
   mirtkAttributeMacro(double, SigmaX);
@@ -60,49 +64,37 @@ class GaussianBlurring : public ImageToImage<TVoxel>
 
 protected:
 
-  /// Gaussian convolution kernel
-  GenericImage<RealPixel> *_Kernel;
+  // Base class setters unused, should not be called by user
+  virtual void KernelX(const KernelType *) {}
+  virtual void KernelY(const KernelType *) {}
+  virtual void KernelZ(const KernelType *) {}
+  virtual void KernelT(const KernelType *) {}
+
+  // Instantiated Gaussian kernels
+  UniquePtr<KernelType> _GaussianKernel[4];
+
+  /// Initialize 1D Gaussian kernel with sigma given in voxel units
+  UniquePtr<KernelType> InitializeKernel(double);
 
   /// Initialize filter
   virtual void Initialize();
 
-  /// Initialize 1D Gaussian kernel with sigma given in voxel units
-  virtual void InitializeKernel(double);
-
-  /// Finalize filter
-  virtual void Finalize();
-
 public:
 
   /// Constructor
-  GaussianBlurring(double = 1.0);
+  GaussianBlurring(double = 1.);
 
   /// Constructor
-  GaussianBlurring(double, double, double = .0, double = .0);
+  GaussianBlurring(double, double, double = 0., double = 0.);
 
   /// Destructor
   ~GaussianBlurring();
-
-  /// Run Gaussian blurring
-  virtual void Run();
-
-  /// Run Gaussian blurring along x only
-  virtual void RunX();
-
-  /// Run Gaussian blurring along y only
-  virtual void RunY();
-
-  /// Run Gaussian blurring along z only
-  virtual void RunZ();
-
-  /// Run Gaussian blurring along t only
-  virtual void RunT();
 
   /// Set sigma
   virtual void SetSigma(double);
 
   /// Set sigma
-  virtual void SetSigma(double, double, double = .0, double = .0);
+  virtual void SetSigma(double, double, double = 0., double = 0.);
 
   /// Kernel size used for a given sigma (divided by voxel size)
   static int KernelSize(double);

--- a/Modules/Image/include/mirtk/GaussianBlurringWithPadding.h
+++ b/Modules/Image/include/mirtk/GaussianBlurringWithPadding.h
@@ -1,9 +1,9 @@
 /*
  * Medical Image Registration ToolKit (MIRTK)
  *
- * Copyright 2008-2015 Imperial College London
+ * Copyright 2008-2017 Imperial College London
  * Copyright 2008-2013 Daniel Rueckert, Julia Schnabel
- * Copyright 2013-2015 Andreas Schuh
+ * Copyright 2013-2017 Andreas Schuh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,9 +41,6 @@ class GaussianBlurringWithPadding : public GaussianBlurring<TVoxel>
 {
   mirtkInPlaceImageFilterMacro(GaussianBlurringWithPadding, TVoxel);
 
-  /// Padding value
-  mirtkAttributeMacro(VoxelType, PaddingValue);
-
 public:
 
   /// Constructor
@@ -57,9 +54,6 @@ public:
 
   /// Constructor
   GaussianBlurringWithPadding(double, double, double, double, VoxelType);
-
-  /// Run Gaussian blurring
-  virtual void Run();
 
 };
 

--- a/Modules/Image/include/mirtk/SeparableConvolution.h
+++ b/Modules/Image/include/mirtk/SeparableConvolution.h
@@ -1,0 +1,140 @@
+/*
+ * Medical Image Registration ToolKit (MIRTK)
+ *
+ * Copyright 2017 Imperial College London
+ * Copyright 2017 Andreas Schuh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MIRTK_SeparableConvolution_H
+#define MIRTK_SeparableConvolution_H
+
+#include "mirtk/GenericImage.h"
+#include "mirtk/ImageToImage.h"
+
+
+namespace mirtk {
+
+
+/**
+ * Generic filter for convolution of an image with a separable kernel
+ */
+template <class TVoxel, class TKernel = RealPixel>
+class SeparableConvolution : public ImageToImage<TVoxel>
+{
+  mirtkInPlaceImageFilterMacro(SeparableConvolution, TVoxel);
+
+public:
+
+  /// Type of convolution kernel
+  typedef GenericImage<TKernel> KernelType;
+
+protected:
+
+  /// Convolution kernel along x axis
+  mirtkPublicAggregateMacro(const KernelType, KernelX);
+
+  /// Convolution kernel along y axis
+  mirtkPublicAggregateMacro(const KernelType, KernelY);
+
+  /// Convolution kernel along z axis
+  mirtkPublicAggregateMacro(const KernelType, KernelZ);
+
+  /// Convolution kernel along t axis
+  mirtkPublicAggregateMacro(const KernelType, KernelT);
+
+  /// Whether to normalize kernels
+  mirtkPublicAttributeMacro(bool, Normalize);
+
+  /// Whether to truncate convolution at background specified by image mask
+  ///
+  /// When this option is set and the image has a background mask, unmasked
+  /// values of the convolution sum (i.e., background values) are ignored.
+  mirtkPublicAttributeMacro(bool, UseBackgroundMask);
+
+  /// Whether to truncate convolution at input background value if set
+  ///
+  /// This option is ignored when UseBackgroundMask is set and the image
+  /// has a background mask image set.
+  mirtkPublicAttributeMacro(bool, UseBackgroundValue);
+
+  /// Whether to use padding value
+  ///
+  /// This option is ignored when UseBackgroundMask is set and the image
+  /// has a background mask image set.
+  ///
+  /// When also UseBackground is set, the padding value is used instead
+  /// when the image has a background value set. Otherwise the padding
+  /// value is used when this option is turned on.
+  mirtkPublicAttributeMacro(bool, UsePaddingValue);
+
+  /// Padding value
+  mirtkPublicAttributeMacro(double, PaddingValue);
+
+protected:
+
+  /// Initialize filter
+  virtual void Initialize();
+
+  /// Finalize filter
+  virtual void Finalize();
+
+public:
+
+  /// Constructor
+  ///
+  /// \param[in] k Isotropic 1D convolution kernel.
+  SeparableConvolution(const KernelType *k = nullptr);
+
+  /// Constructor
+  ///
+  /// \param[in] kx Convolution kernel along x axis.
+  /// \param[in] ky Convolution kernel along y axis.
+  /// \param[in] kz Convolution kernel along z axis.
+  /// \param[in] kt Convolution kernel along t axis.
+  SeparableConvolution(const KernelType *kx,
+                       const KernelType *ky,
+                       const KernelType *kz = nullptr,
+                       const KernelType *kt = nullptr);
+
+  /// Destructor
+  ~SeparableConvolution();
+
+  /// Set isotropic convolution kernel for all dimensions
+  void Kernel(const KernelType *);
+
+  /// Check if given kernel is valid
+  bool CheckKernel(const KernelType *) const;
+
+  /// Convolve image
+  virtual void Run();
+
+  /// Convolve image along x only
+  virtual void RunX();
+
+  /// Convolve image along y only
+  virtual void RunY();
+
+  /// Convolve image along z only
+  virtual void RunZ();
+
+  /// Convolve image along t only
+  virtual void RunT();
+
+};
+
+
+} // namespace mirtk
+
+#endif // MIRTK_SeparableConvolution_H

--- a/Modules/Image/src/CMakeLists.txt
+++ b/Modules/Image/src/CMakeLists.txt
@@ -45,6 +45,7 @@ set(HEADERS
   ConstGenericImageIterator.h
   ConstImageIterator.h
   ConvolutionFunction.h
+  CubicBSplineConvolution.h
   CSplineInterpolateImageFunction.h
   CSplineInterpolateImageFunction.hxx
   CSplineInterpolateImageFunction2D.h
@@ -156,6 +157,7 @@ set(HEADERS
   ResamplingWithPadding.h
   ScalarFunctionToImage.h
   ScalingAndSquaring.h
+  SeparableConvolution.h
   ShapeBasedInterpolateImageFunction.h
   SincInterpolateImageFunction.h
   SincInterpolateImageFunction.hxx
@@ -186,6 +188,7 @@ set(SOURCES
   DisplacementToVelocityFieldBCH.cc
   Closing.cc
   ConnectedComponents.cc
+  CubicBSplineConvolution.cc
   Downsampling.cc
   Erosion.cc
   EuclideanDistanceTransform.cc
@@ -215,6 +218,7 @@ set(SOURCES
   ResamplingWithPadding.cc
   ScalarFunctionToImage.cc
   ScalingAndSquaring.cc
+  SeparableConvolution.cc
   ShapeBasedInterpolateImageFunction.cc
   VelocityToDisplacementField.cc
   VelocityToDisplacementFieldEuler.cc

--- a/Modules/Image/src/CubicBSplineConvolution.cc
+++ b/Modules/Image/src/CubicBSplineConvolution.cc
@@ -1,0 +1,144 @@
+/*
+ * Medical Image Registration ToolKit (MIRTK)
+ *
+ * Copyright 2017 Imperial College London
+ * Copyright 2017 Andreas Schuh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mirtk/CubicBSplineConvolution.h"
+
+#include "mirtk/BSpline.h"
+
+
+namespace mirtk {
+
+
+// -----------------------------------------------------------------------------
+template <class VoxelType>
+CubicBSplineConvolution<VoxelType>::CubicBSplineConvolution(double r)
+:
+  CubicBSplineConvolution<VoxelType>::CubicBSplineConvolution(r, r, r, 0.)
+{
+}
+
+// -----------------------------------------------------------------------------
+template <class VoxelType>
+CubicBSplineConvolution<VoxelType>::CubicBSplineConvolution(double rx, double ry, double rz, double rt)
+:
+  _RadiusX(rx),
+  _RadiusY(ry),
+  _RadiusZ(rz),
+  _RadiusT(rt)
+{
+}
+
+// -----------------------------------------------------------------------------
+template <class VoxelType>
+CubicBSplineConvolution<VoxelType>::~CubicBSplineConvolution()
+{
+}
+
+// -----------------------------------------------------------------------------
+template <class VoxelType>
+void CubicBSplineConvolution<VoxelType>::Radius(double r)
+{
+  _RadiusX = _RadiusY = _RadiusZ = r;
+  _RadiusT = 0.;
+}
+
+// -----------------------------------------------------------------------------
+template <class VoxelType>
+void CubicBSplineConvolution<VoxelType>::Radius(double rx, double ry, double rz, double rt)
+{
+  _RadiusX = rx;
+  _RadiusY = ry;
+  _RadiusZ = rz;
+  _RadiusT = rt;
+}
+
+// -----------------------------------------------------------------------------
+template <class VoxelType>
+int CubicBSplineConvolution<VoxelType>::KernelSize(double rv)
+{
+  int r = ifloor(2. * rv);
+  if (r % 2 == 0) ++r;
+  return r;
+}
+
+// -----------------------------------------------------------------------------
+template <class VoxelType>
+UniquePtr<typename CubicBSplineConvolution<VoxelType>::KernelType>
+CubicBSplineConvolution<VoxelType>::InitializeKernel(double rv)
+{
+  UniquePtr<KernelType> kernel(new KernelType(KernelSize(rv), 1, 1));
+
+  double t  = -2.;
+  double dt = 4. / kernel->X();
+  for (int i = 0; i < kernel->X(); ++i, t += dt) {
+    kernel->Put(i, BSpline<typename KernelType::VoxelType>::B(t));
+  }
+
+  return kernel;
+}
+
+// -----------------------------------------------------------------------------
+template <class VoxelType>
+void CubicBSplineConvolution<VoxelType>::Initialize()
+{
+  // Initialize base class
+  SeparableConvolution<VoxelType>::Initialize();
+
+  // Instantiate convolution kernels
+  const ImageType *input  = this->Input();
+  if (!AreEqual(_RadiusX, 0.) && input->X() > 1) {
+    _BSplineKernel[0] = this->InitializeKernel(_RadiusX < 0. ? -_RadiusX : _RadiusX / input->XSize());
+  } else {
+    _BSplineKernel[0].reset();
+  }
+  if (!AreEqual(_RadiusY, 0.) && input->Y() > 1) {
+    _BSplineKernel[1] = this->InitializeKernel(_RadiusY < 0. ? -_RadiusY : _RadiusY / input->YSize());
+  } else {
+    _BSplineKernel[1].reset();
+  }
+  if (!AreEqual(_RadiusZ, 0.) && input->Z() > 1 && !AreEqual(input->ZSize(), 0.)) {
+    _BSplineKernel[2] = this->InitializeKernel(_RadiusZ < 0. ? -_RadiusZ : _RadiusZ / input->ZSize());
+  } else {
+    _BSplineKernel[2].reset();
+  }
+  if (!AreEqual(_RadiusT, 0.) && input->T() > 1 && !AreEqual(input->TSize(), 0.)) {
+    _BSplineKernel[3] = this->InitializeKernel(_RadiusT < 0. ? -_RadiusT : _RadiusT / input->TSize());
+  } else {
+    _BSplineKernel[3].reset();
+  }
+
+  // Set kernels
+  this->_KernelX = _BSplineKernel[0].get();
+  this->_KernelY = _BSplineKernel[1].get();
+  this->_KernelZ = _BSplineKernel[2].get();
+  this->_KernelT = _BSplineKernel[3].get();
+}
+
+// =============================================================================
+// Explicit template instantiations
+// =============================================================================
+
+template class CubicBSplineConvolution<unsigned char>;
+template class CubicBSplineConvolution<short>;
+template class CubicBSplineConvolution<unsigned short>;
+template class CubicBSplineConvolution<float>;
+template class CubicBSplineConvolution<double>;
+
+
+} // namespace mirtk

--- a/Modules/Image/src/GaussianBlurring.cc
+++ b/Modules/Image/src/GaussianBlurring.cc
@@ -21,13 +21,8 @@
 #include "mirtk/GaussianBlurring.h"
 
 #include "mirtk/Math.h"
-#include "mirtk/Memory.h"
-#include "mirtk/GenericImage.h"
-#include "mirtk/ConvolutionFunction.h"
 #include "mirtk/ScalarFunctionToImage.h"
 #include "mirtk/ScalarGaussian.h"
-#include "mirtk/Profiling.h"
-#include "mirtk/Deallocate.h"
 
 
 namespace mirtk {
@@ -37,11 +32,7 @@ namespace mirtk {
 template <class VoxelType>
 GaussianBlurring<VoxelType>::GaussianBlurring(double sigma)
 :
-  _SigmaX(sigma),
-  _SigmaY(sigma),
-  _SigmaZ(sigma),
-  _SigmaT(.0),
-  _Kernel(NULL)
+  GaussianBlurring<VoxelType>::GaussianBlurring(sigma, sigma, sigma, 0.)
 {
 }
 
@@ -52,8 +43,7 @@ GaussianBlurring<VoxelType>::GaussianBlurring(double xsigma, double ysigma, doub
   _SigmaX(xsigma),
   _SigmaY(ysigma),
   _SigmaZ(zsigma),
-  _SigmaT(tsigma),
-  _Kernel(NULL)
+  _SigmaT(tsigma)
 {
 }
 
@@ -61,7 +51,6 @@ GaussianBlurring<VoxelType>::GaussianBlurring(double xsigma, double ysigma, doub
 template <class VoxelType>
 GaussianBlurring<VoxelType>::~GaussianBlurring()
 {
-  Delete(_Kernel);
 }
 
 // -----------------------------------------------------------------------------
@@ -69,7 +58,7 @@ template <class VoxelType>
 void GaussianBlurring<VoxelType>::SetSigma(double sigma)
 {
   _SigmaX = _SigmaY = _SigmaZ = sigma;
-  _SigmaT = .0;
+  _SigmaT = 0.;
 }
 
 // -----------------------------------------------------------------------------
@@ -84,17 +73,6 @@ void GaussianBlurring<VoxelType>::SetSigma(double xsigma, double ysigma, double 
 
 // -----------------------------------------------------------------------------
 template <class VoxelType>
-void GaussianBlurring<VoxelType>::Initialize()
-{
-  // Initialize base class
-  ImageToImage<VoxelType>::Initialize();
-
-  // Instantiate convolution kernel of proper image type
-  _Kernel = new GenericImage<RealPixel>;
-}
-
-// -----------------------------------------------------------------------------
-template <class VoxelType>
 int GaussianBlurring<VoxelType>::KernelSize(double sigma)
 {
   return 2 * ifloor(3.0 * sigma) + 1;
@@ -102,186 +80,59 @@ int GaussianBlurring<VoxelType>::KernelSize(double sigma)
 
 // -----------------------------------------------------------------------------
 template <class VoxelType>
-void GaussianBlurring<VoxelType>::InitializeKernel(double sigma)
+UniquePtr<typename GaussianBlurring<VoxelType>::KernelType>
+GaussianBlurring<VoxelType>::InitializeKernel(double sigma)
 {
   // Create filter kernel for 1D Gaussian function
-  _Kernel->Initialize(KernelSize(sigma), 1, 1);
+  UniquePtr<KernelType> kernel(new KernelType(KernelSize(sigma), 1, 1));
 
   // Create scalar function which corresponds to a 1D Gaussian function
-  ScalarGaussian gaussian(sigma,            .0, .0,  // stddev in x, y, z
-                          _Kernel->X() / 2, .0, .0); // center in x, y, z
+  ScalarGaussian gaussian(sigma,           0., 0.,  // stddev in x, y, z
+                          kernel->X() / 2, 0., 0.); // center in x, y, z
 
   // Convert from scalar function to filter kernel
-  RealPixel *p = _Kernel->Data();
-  for (int i = 0; i < _Kernel->X(); ++i, ++p) {
-    (*p) = gaussian.Evaluate(i);
+  for (int i = 0; i < kernel->X(); ++i) {
+    kernel->PutAsDouble(i, gaussian.Evaluate(i));
   }
+
+  return kernel;
 }
 
 // -----------------------------------------------------------------------------
 template <class VoxelType>
-void GaussianBlurring<VoxelType>::Run()
+void GaussianBlurring<VoxelType>::Initialize()
 {
-  MIRTK_START_TIMING();
+  // Initialize base class
+  SeparableConvolution<VoxelType>::Initialize();
 
-  // Do the initial set up
-  this->Initialize();
-
-  GenericImage<VoxelType> *input  = const_cast<GenericImage<VoxelType> *>(this->Input());
-  GenericImage<VoxelType> *output = this->Output();
-
-  const ImageAttributes &attr = input->Attributes();
-  const int N = (AreEqual(attr._dt, 0.) ? attr._t : 1);
-
-  // Blur along x axis
+  // Instantiate convolution kernels
+  const ImageType *input  = this->Input();
   if (!AreEqual(_SigmaX, 0.) && input->X() > 1) {
-    if (output == this->Input()) output = new GenericImage<VoxelType>(attr);
-    this->InitializeKernel(_SigmaX / input->XSize());
-    for (int n = 0; n < N; ++n) {
-      using ConvolutionFunction::ConvolveInX;
-      ConvolveInX<RealPixel> conv(input, _Kernel->Data(), _Kernel->X(), true, n);
-      ParallelForEachVoxel(attr, input, output, conv);
-    }
-    swap(input, output);
+    _GaussianKernel[0] = this->InitializeKernel(_SigmaX / input->XSize());
+  } else {
+    _GaussianKernel[0].reset();
   }
-
-  // Blur along y axis
   if (!AreEqual(_SigmaY, 0.) && input->Y() > 1) {
-    if (output == this->Input()) output = new GenericImage<VoxelType>(attr);
-    this->InitializeKernel(_SigmaY / input->YSize());
-    for (int n = 0; n < N; ++n) {
-      using ConvolutionFunction::ConvolveInY;
-      ConvolveInY<RealPixel> conv(input, _Kernel->Data(), _Kernel->X(), true, n);
-      ParallelForEachVoxel(attr, input, output, conv);
-    }
-    swap(input, output);
+    _GaussianKernel[1] = this->InitializeKernel(_SigmaY / input->YSize());
+  } else {
+    _GaussianKernel[1].reset();
+  }
+  if (!AreEqual(_SigmaZ, 0.) && input->Z() > 1 && !AreEqual(input->ZSize(), 0.)) {
+    _GaussianKernel[2] = this->InitializeKernel(_SigmaZ / input->ZSize());
+  } else {
+    _GaussianKernel[2].reset();
+  }
+  if (!AreEqual(_SigmaT, 0.) && input->T() > 1 && !AreEqual(input->TSize(), 0.)) {
+    _GaussianKernel[3] = this->InitializeKernel(_SigmaT / input->TSize());
+  } else {
+    _GaussianKernel[3].reset();
   }
 
-  // Blur along z axis
-  if (!AreEqual(_SigmaZ, 0.) && input->Z() > 1) {
-    if (output == this->Input()) output = new GenericImage<VoxelType>(attr);
-    this->InitializeKernel(_SigmaZ / input->ZSize());
-    for (int n = 0; n < N; ++n) {
-      using ConvolutionFunction::ConvolveInZ;
-      ConvolveInZ<RealPixel> conv(input, _Kernel->Data(), _Kernel->X(), true, n);
-      ParallelForEachVoxel(attr, input, output, conv);
-    }
-    swap(input, output);
-  }
-
-  // Blur along t axis
-  if (!AreEqual(_SigmaT, 0.) && input->T() > 1) {
-    if (output == this->Input()) output = new GenericImage<VoxelType>(attr);
-    this->InitializeKernel(_SigmaT / input->TSize());
-    using ConvolutionFunction::ConvolveInT;
-    ConvolveInT<RealPixel> conv(input, _Kernel->Data(), _Kernel->X(), true);
-    ParallelForEachVoxel(attr, input, output, conv);
-    swap(input, output);
-  }
-
-  // Copy result if last output (i.e., after swap input pointer) was not filter
-  // output image and delete possibly additionally allocated image
-  if (input != output) {
-    if (input == this->Output()) {
-      if (output != this->Input()) Delete(output);
-    } else {
-      this->Output()->CopyFrom(input->Data());
-      if (input != this->Input()) Delete(input);
-    }
-  }
-
-  // Do the final cleaning up
-  this->Finalize();
-
-  MIRTK_DEBUG_TIMING(5, this->NameOfClass());
-}
-
-// -----------------------------------------------------------------------------
-template <class VoxelType>
-void GaussianBlurring<VoxelType>::Finalize()
-{
-  // Finalize base class
-  ImageToImage<VoxelType>::Finalize();
-
-  // Copy background information
-  if (this->Input() != this->Output()) {
-    if (this->Input()->HasBackgroundValue()) {
-      this->Output()->PutBackgroundValueAsDouble(this->Input()->GetBackgroundValueAsDouble());
-    }
-    if (this->Input()->HasMask()) {
-      this->Output()->PutMask(new BinaryImage(*this->Input()->GetMask()), true);
-    }
-  }
-
-  // Free convolution kernel
-  Delete(_Kernel);
-}
-
-// -----------------------------------------------------------------------------
-template <class VoxelType>
-void GaussianBlurring<VoxelType>::RunX()
-{
-  const double ysigma = _SigmaY;
-  const double zsigma = _SigmaZ;
-  const double tsigma = _SigmaT;
-
-  _SigmaY = _SigmaZ = _SigmaT = .0;
-  this->Run();
-
-  _SigmaY = ysigma;
-  _SigmaZ = zsigma;
-  _SigmaT = tsigma;
-}
-
-// -----------------------------------------------------------------------------
-template <class VoxelType>
-void GaussianBlurring<VoxelType>::RunY()
-{
-  const double xsigma = _SigmaX;
-  const double zsigma = _SigmaZ;
-  const double tsigma = _SigmaT;
-
-  _SigmaX = _SigmaZ = _SigmaT = .0;
-  this->Run();
-
-  _SigmaX = xsigma;
-  _SigmaZ = zsigma;
-  _SigmaT = tsigma;
-}
-
-// -----------------------------------------------------------------------------
-template <class VoxelType>
-void GaussianBlurring<VoxelType>::RunZ()
-{
-  const double xsigma = _SigmaX;
-  const double ysigma = _SigmaY;
-  const double tsigma = _SigmaT;
-
-  _SigmaX = _SigmaY = _SigmaT = .0;
-  this->Run();
-
-  _SigmaX = xsigma;
-  _SigmaY = ysigma;
-  _SigmaT = tsigma;
-}
-
-// -----------------------------------------------------------------------------
-template <class VoxelType>
-void GaussianBlurring<VoxelType>::RunT()
-{
-  const double xsigma = _SigmaX;
-  const double ysigma = _SigmaY;
-  const double zsigma = _SigmaZ;
-  const double tsigma = _SigmaT;
-
-  _SigmaX = _SigmaY = _SigmaZ = .0;
-  if (_SigmaT == .0) _SigmaT = _SigmaX;
-  this->Run();
-
-  _SigmaX = xsigma;
-  _SigmaY = ysigma;
-  _SigmaZ = zsigma;
-  _SigmaT = tsigma;
+  // Set kernels
+  this->_KernelX = _GaussianKernel[0].get();
+  this->_KernelY = _GaussianKernel[1].get();
+  this->_KernelZ = _GaussianKernel[2].get();
+  this->_KernelT = _GaussianKernel[3].get();
 }
 
 // =============================================================================

--- a/Modules/Image/src/GaussianBlurringWithPadding.cc
+++ b/Modules/Image/src/GaussianBlurringWithPadding.cc
@@ -20,12 +20,6 @@
 
 #include "mirtk/GaussianBlurringWithPadding.h"
 
-#include "mirtk/Memory.h"
-#include "mirtk/GenericImage.h"
-#include "mirtk/Profiling.h"
-#include "mirtk/Parallel.h"
-#include "mirtk/ConvolutionFunction.h"
-
 
 namespace mirtk {
 
@@ -38,8 +32,7 @@ namespace mirtk {
 template <class VoxelType> GaussianBlurringWithPadding<VoxelType>
 ::GaussianBlurringWithPadding(double sigma, VoxelType padding_value)
 :
-  GaussianBlurring<VoxelType>(sigma),
-  _PaddingValue(padding_value)
+  GaussianBlurringWithPadding<VoxelType>(sigma, sigma, sigma, sigma, padding_value)
 {
 }
 
@@ -47,8 +40,7 @@ template <class VoxelType> GaussianBlurringWithPadding<VoxelType>
 template <class VoxelType> GaussianBlurringWithPadding<VoxelType>
 ::GaussianBlurringWithPadding(double xsigma, double ysigma, VoxelType padding_value)
 :
-  GaussianBlurring<VoxelType>(xsigma, ysigma, .0, .0),
-  _PaddingValue(padding_value)
+  GaussianBlurringWithPadding<VoxelType>(xsigma, ysigma, 0., 0., padding_value)
 {
 }
 
@@ -56,8 +48,7 @@ template <class VoxelType> GaussianBlurringWithPadding<VoxelType>
 template <class VoxelType> GaussianBlurringWithPadding<VoxelType>
 ::GaussianBlurringWithPadding(double xsigma, double ysigma, double zsigma, VoxelType padding_value)
 :
-  GaussianBlurring<VoxelType>(xsigma, ysigma, zsigma, .0),
-  _PaddingValue(padding_value)
+  GaussianBlurringWithPadding<VoxelType>(xsigma, ysigma, zsigma, 0., padding_value)
 {
 }
 
@@ -65,91 +56,12 @@ template <class VoxelType> GaussianBlurringWithPadding<VoxelType>
 template <class VoxelType> GaussianBlurringWithPadding<VoxelType>
 ::GaussianBlurringWithPadding(double xsigma, double ysigma, double zsigma, double tsigma, VoxelType padding_value)
 :
-  GaussianBlurring<VoxelType>(xsigma, ysigma, zsigma, tsigma),
-  _PaddingValue(padding_value)
+  GaussianBlurring<VoxelType>(xsigma, ysigma, zsigma, tsigma)
 {
-}
-
-// =============================================================================
-// Execution
-// =============================================================================
-
-// -----------------------------------------------------------------------------
-template <class VoxelType>
-void GaussianBlurringWithPadding<VoxelType>::Run()
-{
-  MIRTK_START_TIMING();
-
-  // Do the initial set up
-  this->Initialize();
-
-  GenericImage<VoxelType> *input  = const_cast<GenericImage<VoxelType> *>(this->Input());
-  GenericImage<VoxelType> *output = this->Output();
-
-  const ImageAttributes &attr = input->Attributes();
-  const int N = (AreEqual(attr._dt, 0.) ? attr._t : 1);
-
-  // Blur along x axis
-  if (!AreEqual(this->_SigmaX, 0.) && input->X() > 1) {
-    if (output == this->Input()) output = new GenericImage<VoxelType>(attr);
-    this->InitializeKernel(this->_SigmaX / input->XSize());
-    typedef ConvolutionFunction::ConvolveTruncatedForegroundInX<RealPixel> Conv;
-    for (int n = 0; n < N; ++n) {
-      Conv conv(input, _PaddingValue, this->_Kernel->Data(), this->_Kernel->X(), true, n);
-      ParallelForEachVoxel(attr, input, output, conv);
-    }
-    swap(input, output);
-  }
-
-  // Blur along y axis
-  if (!AreEqual(this->_SigmaY, 0.) && input->Y() > 1) {
-    if (output == this->Input()) output = new GenericImage<VoxelType>(attr);
-    this->InitializeKernel(this->_SigmaY / input->YSize());
-    typedef ConvolutionFunction::ConvolveTruncatedForegroundInY<RealPixel> Conv;
-    for (int n = 0; n < N; ++n) {
-      Conv conv(input, _PaddingValue, this->_Kernel->Data(), this->_Kernel->X(), true, n);
-      ParallelForEachVoxel(attr, input, output, conv);
-    }
-    swap(input, output);
-  }
-
-  // Blur along z axis
-  if (!AreEqual(this->_SigmaZ, 0.) && input->Z() > 1) {
-    if (output == this->Input()) output = new GenericImage<VoxelType>(attr);
-    this->InitializeKernel(this->_SigmaZ / input->ZSize());
-    typedef ConvolutionFunction::ConvolveTruncatedForegroundInZ<RealPixel> Conv;
-    for (int n = 0; n < N; ++n) {
-      Conv conv(input, _PaddingValue, this->_Kernel->Data(), this->_Kernel->X(), true, n);
-      ParallelForEachVoxel(attr, input, output, conv);
-    }
-    swap(input, output);
-  }
-
-  // Blur along t axis
-  if (!AreEqual(this->_SigmaT, 0.) && input->T() > 1) {
-    if (output == this->Input()) output = new GenericImage<VoxelType>(attr);
-    this->InitializeKernel(this->_SigmaT / input->TSize());
-    typedef ConvolutionFunction::ConvolveTruncatedForegroundInT<RealPixel> Conv;
-    Conv conv(input, _PaddingValue, this->_Kernel->Data(), this->_Kernel->X(), true);
-    ParallelForEachVoxel(attr, input, output, conv);
-    swap(input, output);
-  }
-
-  // Copy result if last output (i.e., after swap input pointer) was not filter
-  // output image and delete possibly additionally allocated image
-  if (input != output) {
-    if (input == this->Output()) {
-      if (output != this->Input()) Delete(output);
-    } else {
-      this->Output()->CopyFrom(input->Data());
-      if (input != this->Input()) Delete(input);
-    }
-  }
-
-  // Do the final cleaning up
-  this->Finalize();
-
-  MIRTK_DEBUG_TIMING(5, this->NameOfClass());
+  this->_UseBackgroundMask  = false;
+  this->_UseBackgroundValue = false;
+  this->_UsePaddingValue    = true;
+  this->_PaddingValue       = padding_value;
 }
 
 // =============================================================================

--- a/Modules/Image/src/SeparableConvolution.cc
+++ b/Modules/Image/src/SeparableConvolution.cc
@@ -1,0 +1,359 @@
+/*
+ * Medical Image Registration ToolKit (MIRTK)
+ *
+ * Copyright 2017 Imperial College London
+ * Copyright 2017 Andreas Schuh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mirtk/SeparableConvolution.h"
+
+#include "mirtk/ConvolutionFunction.h"
+#include "mirtk/Profiling.h"
+
+
+namespace mirtk {
+
+
+// -----------------------------------------------------------------------------
+template <class TVoxel, class TKernel>
+SeparableConvolution<TVoxel, TKernel>::SeparableConvolution(const KernelType *k)
+:
+  SeparableConvolution<TVoxel, TKernel>(k, k, k, k)
+{
+}
+
+// -----------------------------------------------------------------------------
+template <class TVoxel, class TKernel>
+SeparableConvolution<TVoxel, TKernel>
+::SeparableConvolution(const KernelType *kx, const KernelType *ky, const KernelType *kz, const KernelType *kt)
+:
+  _KernelX(kx),
+  _KernelY(ky),
+  _KernelZ(kz),
+  _KernelT(kt),
+  _Normalize(true),
+  _UseBackgroundMask(false),
+  _UseBackgroundValue(false),
+  _UsePaddingValue(false),
+  _PaddingValue(NaN)
+{
+}
+
+// -----------------------------------------------------------------------------
+template <class TVoxel, class TKernel>
+SeparableConvolution<TVoxel, TKernel>::~SeparableConvolution()
+{
+}
+
+// -----------------------------------------------------------------------------
+template <class TVoxel, class TKernel>
+void SeparableConvolution<TVoxel, TKernel>::Kernel(const KernelType *k)
+{
+  _KernelX = _KernelY = _KernelZ = _KernelT = k;
+}
+
+// -----------------------------------------------------------------------------
+template <class TVoxel, class TKernel>
+bool SeparableConvolution<TVoxel, TKernel>::CheckKernel(const KernelType *k) const
+{
+  if (k == nullptr) return false;
+  if (k->NumberOfVoxels() == 0) return false;
+  return (k->Y() == 1 || k->Z() == 1 || k->T() == 1);
+}
+
+// -----------------------------------------------------------------------------
+template <class TVoxel, class TKernel>
+void SeparableConvolution<TVoxel, TKernel>::Initialize()
+{
+  // Initialize base class
+  ImageToImage<TVoxel>::Initialize();
+
+  // Check arguments
+  if (_KernelX && !CheckKernel(_KernelX)) {
+    Throw(ERR_InvalidArgument, __FUNCTION__, "Convolution kernel along x axis is invalid");
+  }
+  if (_KernelY && !CheckKernel(_KernelY)) {
+    Throw(ERR_InvalidArgument, __FUNCTION__, "Convolution kernel along y axis is invalid");
+  }
+  if (_KernelZ && !CheckKernel(_KernelZ)) {
+    Throw(ERR_InvalidArgument, __FUNCTION__, "Convolution kernel along z axis is invalid");
+  }
+  if (_KernelT && !CheckKernel(_KernelT)) {
+    Throw(ERR_InvalidArgument, __FUNCTION__, "Convolution kernel along t axis is invalid");
+  }
+}
+
+// -----------------------------------------------------------------------------
+template <class TVoxel, class TKernel>
+void SeparableConvolution<TVoxel, TKernel>::Run()
+{
+  MIRTK_START_TIMING();
+
+  // Do the initial set up
+  this->Initialize();
+
+  ImageType *input  = const_cast<ImageType *>(this->Input());
+  ImageType *output = this->Output();
+
+  const ImageAttributes &attr = input->Attributes();
+
+  // Number of vector components
+  int N = 1;
+  if (attr._t == 1) {
+    if (attr._z > 1 && AreEqual(attr._dz, 0.)) {
+      N = attr._z;
+    }
+  } else if (attr._t > 1 && AreEqual(attr._dt, 0.)) {
+    N = attr._t;
+  }
+
+  int    padmode = 0;
+  double padding = _PaddingValue;
+  if (_UseBackgroundMask && input->HasMask()) {
+    padmode = 1;
+  } else if (_UseBackgroundValue && input->HasBackgroundValue()) {
+    padding = input->GetBackgroundValueAsDouble();
+    padmode = 2;
+  } else if (_UsePaddingValue) {
+    padmode = 2;
+  }
+
+  // Convolve along x axis
+  if (_KernelX && input->X() > 1) {
+    if (output == this->Input()) {
+      output = new ImageType(attr);
+    }
+    for (int n = 0; n < N; ++n) {
+      switch (padmode) {
+        case 1: {
+          typedef ConvolutionFunction::ConvolveForegroundInX<TKernel> ConvFunc;
+          ConvFunc conv(input, _KernelX->Data(), _KernelX->X(), _Normalize, n);
+          ParallelForEachVoxel(attr, input, output, conv);
+        } break;
+        case 2: {
+          typedef ConvolutionFunction::ConvolveTruncatedForegroundInX<TKernel> ConvFunc;
+          ConvFunc conv(input, padding, _KernelX->Data(), _KernelX->X(), _Normalize, n);
+          ParallelForEachVoxel(attr, input, output, conv);
+        } break;
+        default: {
+          typedef ConvolutionFunction::ConvolveInX<TKernel> ConvFunc;
+          ConvFunc conv(input, _KernelX->Data(), _KernelX->X(), _Normalize, n);
+          ParallelForEachVoxel(attr, input, output, conv);
+        } break;
+      }
+    }
+    swap(input, output);
+  }
+
+  // Convolve along y axis
+  if (_KernelY && input->Y() > 1) {
+    if (output == this->Input()) {
+      output = new ImageType(attr);
+    }
+    for (int n = 0; n < N; ++n) {
+      switch (padmode) {
+        case 1: {
+          typedef ConvolutionFunction::ConvolveForegroundInY<TKernel> ConvFunc;
+          ConvFunc conv(input, _KernelY->Data(), _KernelY->X(), _Normalize, n);
+          ParallelForEachVoxel(attr, input, output, conv);
+        } break;
+        case 2: {
+          typedef ConvolutionFunction::ConvolveTruncatedForegroundInY<TKernel> ConvFunc;
+          ConvFunc conv(input, padding, _KernelY->Data(), _KernelY->X(), _Normalize, n);
+          ParallelForEachVoxel(attr, input, output, conv);
+        } break;
+        default: {
+          typedef ConvolutionFunction::ConvolveInY<TKernel> ConvFunc;
+          ConvFunc conv(input, _KernelY->Data(), _KernelY->X(), _Normalize, n);
+          ParallelForEachVoxel(attr, input, output, conv);
+        } break;
+      }
+    }
+    swap(input, output);
+  }
+
+  // Convolve along z axis
+  if (_KernelZ && input->Z() > 1 && !AreEqual(input->ZSize(), 0.)) {
+    if (output == this->Input()) {
+      output = new ImageType(attr);
+    }
+    for (int n = 0; n < N; ++n) {
+      switch (padmode) {
+        case 1: {
+          typedef ConvolutionFunction::ConvolveForegroundInZ<TKernel> ConvFunc;
+          ConvFunc conv(input, _KernelZ->Data(), _KernelZ->X(), _Normalize, n);
+          ParallelForEachVoxel(attr, input, output, conv);
+        } break;
+        case 2: {
+          typedef ConvolutionFunction::ConvolveTruncatedForegroundInZ<TKernel> ConvFunc;
+          ConvFunc conv(input, padding, _KernelZ->Data(), _KernelZ->X(), _Normalize, n);
+          ParallelForEachVoxel(attr, input, output, conv);
+        } break;
+        default: {
+          typedef ConvolutionFunction::ConvolveInZ<TKernel> ConvFunc;
+          ConvFunc conv(input, _KernelZ->Data(), _KernelZ->X(), _Normalize, n);
+          ParallelForEachVoxel(attr, input, output, conv);
+        } break;
+      }
+    }
+    swap(input, output);
+  }
+
+  // Convolve along t axis
+  if (_KernelT && input->T() > 1 && !AreEqual(input->TSize(), 0.)) {
+    if (output == this->Input()) {
+      output = new ImageType(attr);
+    }
+    switch (padmode) {
+      case 1: {
+        typedef ConvolutionFunction::ConvolveForegroundInT<TKernel> ConvFunc;
+        ConvFunc conv(input, _KernelT->Data(), _KernelT->X(), _Normalize);
+        ParallelForEachVoxel(attr, input, output, conv);
+      } break;
+      case 2: {
+        typedef ConvolutionFunction::ConvolveTruncatedForegroundInT<TKernel> ConvFunc;
+        ConvFunc conv(input, padding, _KernelT->Data(), _KernelT->X(), _Normalize);
+        ParallelForEachVoxel(attr, input, output, conv);
+      } break;
+      default: {
+        typedef ConvolutionFunction::ConvolveInT<TKernel> ConvFunc;
+        ConvFunc conv(input, _KernelT->Data(), _KernelT->X(), _Normalize);
+        ParallelForEachVoxel(attr, input, output, conv);
+      } break;
+    }
+    swap(input, output);
+  }
+
+  // Copy result if last output (i.e., after swap input pointer) was not filter
+  // output image and delete possibly additionally allocated image
+  if (input != output) {
+    if (input == this->Output()) {
+      if (output != this->Input()) {
+        Delete(output);
+      }
+    } else {
+      this->Output()->CopyFrom(input->Data());
+      if (input != this->Input()) {
+        Delete(input);
+      }
+    }
+  }
+
+  // Do the final cleaning up
+  this->Finalize();
+
+  MIRTK_DEBUG_TIMING(5, this->NameOfClass());
+}
+
+// -----------------------------------------------------------------------------
+template <class TVoxel, class TKernel>
+void SeparableConvolution<TVoxel, TKernel>::Finalize()
+{
+  // Finalize base class
+  ImageToImage<TVoxel>::Finalize();
+
+  // Copy background information
+  if (this->Input() != this->Output()) {
+    if (this->Input()->HasBackgroundValue()) {
+      this->Output()->PutBackgroundValueAsDouble(this->Input()->GetBackgroundValueAsDouble());
+    }
+    if (this->Input()->HasMask()) {
+      this->Output()->PutMask(new BinaryImage(*this->Input()->GetMask()), true);
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+template <class TVoxel, class TKernel>
+void SeparableConvolution<TVoxel, TKernel>::RunX()
+{
+  const KernelType * const ky = _KernelY;
+  const KernelType * const kz = _KernelZ;
+  const KernelType * const kt = _KernelT;
+  _KernelY = _KernelZ = _KernelT = nullptr;
+
+  this->Run();
+
+  _KernelY = ky;
+  _KernelZ = kz;
+  _KernelT = kt;
+}
+
+// -----------------------------------------------------------------------------
+template <class TVoxel, class TKernel>
+void SeparableConvolution<TVoxel, TKernel>::RunY()
+{
+  const KernelType * const kx = _KernelX;
+  const KernelType * const kz = _KernelZ;
+  const KernelType * const kt = _KernelT;
+  _KernelX = _KernelZ = _KernelT = nullptr;
+
+  this->Run();
+
+  _KernelX = kx;
+  _KernelZ = kz;
+  _KernelT = kt;
+}
+
+// -----------------------------------------------------------------------------
+template <class TVoxel, class TKernel>
+void SeparableConvolution<TVoxel, TKernel>::RunZ()
+{
+  const KernelType * const kx = _KernelX;
+  const KernelType * const ky = _KernelY;
+  const KernelType * const kt = _KernelT;
+  _KernelX = _KernelY = _KernelT = nullptr;
+
+  this->Run();
+
+  _KernelX = kx;
+  _KernelY = ky;
+  _KernelT = kt;
+}
+
+// -----------------------------------------------------------------------------
+template <class TVoxel, class TKernel>
+void SeparableConvolution<TVoxel, TKernel>::RunT()
+{
+  const KernelType * const kx = _KernelX;
+  const KernelType * const ky = _KernelY;
+  const KernelType * const kz = _KernelZ;
+  _KernelX = _KernelY = _KernelZ = nullptr;
+
+  this->Run();
+
+  _KernelX = kx;
+  _KernelY = ky;
+  _KernelZ = kz;
+}
+
+// =============================================================================
+// Explicit template instantiations
+// =============================================================================
+
+template class SeparableConvolution<unsigned char, float>;
+template class SeparableConvolution<short, float>;
+template class SeparableConvolution<unsigned short, float>;
+template class SeparableConvolution<float, float>;
+template class SeparableConvolution<double, float>;
+
+template class SeparableConvolution<unsigned char, double>;
+template class SeparableConvolution<short, double>;
+template class SeparableConvolution<unsigned short, double>;
+template class SeparableConvolution<float, double>;
+template class SeparableConvolution<double, double>;
+
+
+} // namespace mirtk

--- a/Modules/Transformation/include/mirtk/BSplineFreeFormTransformation3D.h
+++ b/Modules/Transformation/include/mirtk/BSplineFreeFormTransformation3D.h
@@ -58,6 +58,9 @@ public:
 
 protected:
 
+  /// Whether to compute parametric gradient using cubic B-spline convolution
+  mirtkPublicAttributeMacro(bool, UseCubicBSplineConvolution);
+
   /// Interpolates control point values at arbitrary lattice locations
   Interpolator _FFD;
 
@@ -95,6 +98,18 @@ public:
 
   /// Destructor
   virtual ~BSplineFreeFormTransformation3D();
+
+  // ---------------------------------------------------------------------------
+  // Parameters (non-DoFs)
+
+  // Import other Parameter overloads
+  using FreeFormTransformation3D::Parameter;
+
+  /// Set named (non-DoF) parameter from value as string
+  virtual bool Set(const char *, const char *);
+
+  /// Get (non-DoF) parameters as key/value as string map
+  virtual ParameterList Parameter() const;
 
   // ---------------------------------------------------------------------------
   // Approximation/Interpolation
@@ -265,6 +280,7 @@ public:
   using FreeFormTransformation3D::LocalJacobian;
   using FreeFormTransformation3D::LocalHessian;
   using FreeFormTransformation3D::JacobianDOFs;
+  using FreeFormTransformation3D::ParametricGradient;
 
   /// Calculates the Jacobian of the transformation w.r.t either control point displacements or velocities
   virtual void FFDJacobianWorld(Matrix &, double, double, double, double = 0, double = NaN) const;
@@ -283,6 +299,13 @@ public:
 
   /// Calculates the derivative of the Jacobian of the transformation (w.r.t. world coordinates) w.r.t. a transformation parameter
   virtual void DeriveJacobianWrtDOF(Matrix &, int, double, double, double, double = 0, double = NaN) const;
+
+    /// Applies the chain rule to convert spatial non-parametric gradient
+  /// to a gradient w.r.t the parameters of this transformation
+  virtual void ParametricGradient(const GenericImage<double> *, double *,
+                                  const WorldCoordsImage *,
+                                  const WorldCoordsImage *,
+                                  double = NaN, double = 1) const;
 
   // ---------------------------------------------------------------------------
   // Properties

--- a/Modules/Transformation/include/mirtk/BSplineFreeFormTransformation3D.h
+++ b/Modules/Transformation/include/mirtk/BSplineFreeFormTransformation3D.h
@@ -53,13 +53,24 @@ public:
   typedef GenericFastCubicBSplineInterpolateImageFunction3D<CPImage> Interpolator;
   typedef Interpolator::Kernel                                       Kernel;
 
+  /// Options for parametric gradient calculation
+  enum ParametricGradientType
+  {
+    PG_Default,       ///< Default gradient computation.
+    PG_Analytic,      ///< Analytic derivation w.r.t. DoFs.
+    PG_Convolution,   ///< Convolution with cubic B-spline filter.
+    PG_Approximation  ///< Approximate voxel-wise non-parametric gradient
+                      ///< field with cubic B-spline function, also known
+                      ///< as "directly manipulated FFD (DMFFD)".
+  };
+
   // ---------------------------------------------------------------------------
   // Attributes
 
 protected:
 
   /// Whether to compute parametric gradient using cubic B-spline convolution
-  mirtkPublicAttributeMacro(bool, UseCubicBSplineConvolution);
+  mirtkPublicAttributeMacro(ParametricGradientType, ParametricGradientCalculation);
 
   /// Interpolates control point values at arbitrary lattice locations
   Interpolator _FFD;
@@ -113,6 +124,14 @@ public:
 
   // ---------------------------------------------------------------------------
   // Approximation/Interpolation
+
+  /// Approximate displacements: This function takes a set of points and a set
+  /// of displacements and finds !new! parameters such that the resulting
+  /// transformation approximates the displacements as good as possible.
+  /// These parameters are added to the given coefficients using specified weight.
+  void AddApproximateSplineCoefficients(const double *, const double *, const double *,
+                                        const double *, const double *, const double *,
+                                        int, double *, double = 1., bool = false) const;
 
   /// Approximate displacements: This function takes a set of points and a set
   /// of displacements and finds !new! parameters such that the resulting
@@ -343,6 +362,44 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 // Inline definitions
 ////////////////////////////////////////////////////////////////////////////////
+
+// =============================================================================
+// String conversion of enum values
+// =============================================================================
+
+// ----------------------------------------------------------------------------
+template <>
+inline string ToString(const BSplineFreeFormTransformation3D::ParametricGradientType &value, int w, char c, bool left)
+{
+  const char *str;
+  switch (value) {
+    case BSplineFreeFormTransformation3D::PG_Default:       str = "Default";       break;
+    case BSplineFreeFormTransformation3D::PG_Analytic:      str = "Analytic";      break;
+    case BSplineFreeFormTransformation3D::PG_Convolution:   str = "Convolution";   break;
+    case BSplineFreeFormTransformation3D::PG_Approximation: str = "Approximation"; break;
+    default:                                                str = "Unknown";       break;
+  }
+  return ToString(str, w, c, left);
+}
+
+// ----------------------------------------------------------------------------
+template <>
+inline bool FromString(const char *str, BSplineFreeFormTransformation3D::ParametricGradientType &value)
+{
+  string lstr = ToLower(str);
+  if (lstr == "default") {
+    value = BSplineFreeFormTransformation3D::PG_Default;
+  } else if (lstr == "analytic") {
+    value = BSplineFreeFormTransformation3D::PG_Analytic;
+  } else if (lstr == "convolution") {
+    value = BSplineFreeFormTransformation3D::PG_Convolution;
+  } else if (lstr == "dmffd" || lstr == "directlymanipulated" || lstr == "directly manipulated" || lstr == "approximation") {
+    value = BSplineFreeFormTransformation3D::PG_Approximation;
+  } else {
+    return false;
+  }
+  return true;
+}
 
 // =============================================================================
 // Evaluation

--- a/Modules/Transformation/src/FreeFormTransformation.cc
+++ b/Modules/Transformation/src/FreeFormTransformation.cc
@@ -447,7 +447,7 @@ bool FreeFormTransformation::Set(const char *name, const char *value)
 // -----------------------------------------------------------------------------
 ParameterList FreeFormTransformation::Parameter() const
 {
-  ParameterList params;
+  ParameterList params = Transformation::Parameter();
   Insert(params, "Transformation extrapolation", ToString(_ExtrapolationMode));
   Insert(params, "Speedup factor",               ToString(_SpeedupFactor));
   return params;


### PR DESCRIPTION
- New `ConvolutionFilter` base class used also for `GaussianBlurring`.
- Implements FFD gradient calculation using cubic B-spline convolution filter.
- Implements the "Directly manipulated FFD" scheme, where the parametric gradient is obtained by directly approximating the voxel-wise (non-parametric) gradient field by a spline function.