### PR TITLE
Add viewer module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "Packages/Scripting"]
 	path = Packages/Scripting
 	url = https://github.com/MIRTK/Scripting.git
+[submodule "Packages/Viewer"]
+	path = Packages/Viewer
+	url = https://github.com/MIRTK/Viewer.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
   - WITH_UMFPACK=OFF  # ARPACK & UMFPACK dependencies come in pairs
   - WITH_TBB=ON       # build with TBB is always recommended
   - WITH_FLANN=ON     # build with FLANN is optional, but requires only little extra build time
+  - WITH_FLTK=ON      # build with FLTK-based Viewer when WITH_VTK is turned ON
   # build and deployment of AppImage for Linux
   - AppImage_BUILD=${AppImage_BUILD:-ON}
   - AppImage_BRANCH=${AppImage_BRANCH:-master}

--- a/Applications/lib/python/mirtk/subprocess.py.in
+++ b/Applications/lib/python/mirtk/subprocess.py.in
@@ -91,9 +91,9 @@ def path(argv, quiet=False):
                 break
     if not quiet:
         if not fpath:
-            sys.stderr.write('Error: Missing execuable for command: ' + command)
+            sys.stderr.write('Error: Missing executable for command: ' + command + '\n')
         elif not os.access(fpath, os.X_OK):
-            sys.stderr.write('Error: Insufficient permissions to execute command: ' + fpath)
+            sys.stderr.write('Error: Insufficient permissions to execute command: ' + fpath + '\n')
     return fpath
 
 

--- a/Applications/tools/mirtk.py
+++ b/Applications/tools/mirtk.py
@@ -93,7 +93,7 @@ if __name__ == '__main__':
     else:
         if verbose > 1:
             print('\nHost: ' + socket.gethostname() + '\n')
-        exit_code = mirtk.call(argv, verbose=verbose);
+        exit_code = mirtk.call(argv, verbose=verbose)
         if exit_code != 0:
             sys.stderr.write('Error: ' + command + ' command returned non-zero exit status ' + str(exit_code) + '\n')
         sys.exit(exit_code)

--- a/BasisProject.cmake
+++ b/BasisProject.cmake
@@ -75,6 +75,7 @@ basis_project (
     Packages/Mapping
     Packages/DrawEM
     Packages/Scripting
+    Packages/Viewer
 
   # --------------------------------------------------------------------------
   # list of modules enabled by default
@@ -93,6 +94,7 @@ basis_project (
     Mapping
     DrawEM
     Scripting
+    Viewer
 
   # --------------------------------------------------------------------------
   # dependencies

--- a/Documentation/CMakeLists.txt
+++ b/Documentation/CMakeLists.txt
@@ -102,6 +102,8 @@ if (BUILD_DOCUMENTATION_SOURCES)
     list(REMOVE_ITEM COMMANDS
       convert-mris
       padding
+      display
+      view
     )
   endif ()
 

--- a/Documentation/getstarted.rst
+++ b/Documentation/getstarted.rst
@@ -36,7 +36,7 @@ Linux system with a compatible minimum glibc version (>=2.15). With this AppImag
 actual need for an installation. Simply download the file, make it executable, and copy it to
 a directory that is in your PATH, e.g.,::
 
-  wget -O mirtk https://bintray.com/schuhschuh/AppImages/download_file?file_path=MIRTK%2Bview-latest-x86_64-glibc2.15.AppImage
+  wget -O mirtk https://bintray.com/schuhschuh/AppImages/download_file?file_path=MIRTK-latest-x86_64-glibc2.14.AppImage
   chmod a+x mirtk
   sudo mv mirtk /usr/bin
 

--- a/Scripts/install_depends.sh
+++ b/Scripts/install_depends.sh
@@ -106,16 +106,14 @@ if [ $os = osx ] || [ $os = Darwin ]; then
 
   brew_install()
   {
-    set -x
     for dep in $@; do
-      if $(brew ls --version $dep &> /dev/null) ; then
+      if $(brew ls $dep &> /dev/null); then
         brew unlink $dep && brew link $dep
         [ $? -eq 0 ] || exit 1
       else
         brew install $dep
       fi
     done
-    set +x
   }
 
   brew update > /dev/null || exit 1

--- a/Scripts/install_depends.sh
+++ b/Scripts/install_depends.sh
@@ -106,6 +106,7 @@ if [ $os = osx ] || [ $os = Darwin ]; then
 
   brew_install()
   {
+    set -x
     for dep in $@; do
       if $(brew ls --version $dep &> /dev/null) ; then
         brew unlink $dep && brew link $dep
@@ -114,6 +115,7 @@ if [ $os = osx ] || [ $os = Darwin ]; then
         brew install $dep
       fi
     done
+    set +x
   }
 
   brew update > /dev/null || exit 1

--- a/Scripts/install_depends.sh
+++ b/Scripts/install_depends.sh
@@ -80,7 +80,7 @@ if [ $os = linux ] || [ $os = Linux ]; then
       VTK_VERSION=''
     fi
     if [ $WITH_FLTK = ON ]; then
-      deps=(${deps[@]} libfltk1.3-dev libxinerama-dev)
+      deps=(${deps[@]} libxi-dev libxmu-dev libxinerama-dev libxcursor-dev libcairo-dev libfltk1.3-dev)
     fi
   fi
 

--- a/Scripts/install_depends.sh
+++ b/Scripts/install_depends.sh
@@ -80,7 +80,7 @@ if [ $os = linux ] || [ $os = Linux ]; then
       VTK_VERSION=''
     fi
     if [ $WITH_FLTK = ON ]; then
-      deps=(${deps[@]} libfltk1.3-dev)
+      deps=(${deps[@]} libfltk1.3-dev libxinerama-dev)
     fi
   fi
 

--- a/Scripts/install_depends.sh
+++ b/Scripts/install_depends.sh
@@ -67,7 +67,7 @@ if [ $os = linux ] || [ $os = Linux ]; then
 
   if [ $WITH_UMFPACK = ON ]; then
     # see https://bugs.launchpad.net/ubuntu/+source/suitesparse/+bug/1333214
-    sudo add-apt-repository -y ppa:bzindovic/suitesparse-bugfix-1319687 || exit 1
+    # sudo add-apt-repository -y ppa:bzindovic/suitesparse-bugfix-1319687 || exit 1
     deps=(${deps[@]} libsuitesparse-dev)
   fi
 

--- a/Scripts/install_depends.sh
+++ b/Scripts/install_depends.sh
@@ -20,6 +20,7 @@ WITH_UMFPACK=`norm_option_value "$WITH_UMFPACK" OFF`
 WITH_VTK=`norm_option_value "$WITH_VTK" OFF`
 WITH_TBB=`norm_option_value "$WITH_TBB" ON`
 WITH_FLANN=`norm_option_value "$WITH_FLANN" ON`
+WITH_FLTK=`norm_option_value "$WITH_FLTK" OFF`
 WITH_CCACHE=`norm_option_value "$WITH_CCACHE" OFF`
 BUILD_DEPS_WITH_CCACHE=`norm_option_value "$BUILD_DEPS_WITH_CCACHE" OFF`
 FORCE_REBUILD_DEPS=`norm_option_value "$FORCE_REBUILD_DEPS" OFF`
@@ -78,6 +79,9 @@ if [ $os = linux ] || [ $os = Linux ]; then
       deps=(${deps[@]} libvtk6-dev)
       VTK_VERSION=''
     fi
+    if [ $WITH_FLTK = ON ]; then
+      deps=(${deps[@]} libfltk1.3-dev)
+    fi
   fi
 
   sudo apt-get update -qq || exit 1
@@ -128,6 +132,9 @@ if [ $os = osx ] || [ $os = Darwin ]; then
     if [ -z "$VTK_VERSION" ]; then
       echo "Installing VTK using Homebrew"
       brew_install vtk --without-python
+    fi
+    if [ $WITH_FLTK = ON ]; then
+      brew_install fltk
     fi
   fi
 

--- a/Scripts/install_mirtk_appimage.sh
+++ b/Scripts/install_mirtk_appimage.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-WITH_VIEWER=true
 INSTALL_PREFIX="$HOME/opt/mirtk-appimage"
 SUDO=''  # set to empty string if prefix is writable by $USER
 
@@ -16,10 +15,8 @@ Consider building MIRTK from source code or use the Docker container.
 See also: http://mirtk.github.io/getstarted.html#install-the-software
 EOF
     exit 1
-  elif [ $WITH_VIEWER != true ] || [ $GLIBC_VERSION_MAJOR -eq 2 -a $GLIBC_VERSION_MINOR -eq 14 ]; then
-    APPIMAGE=MIRTK-latest-x86_64-glibc2.14.AppImage
   else
-    APPIMAGE=MIRTK%2Bview-latest-x86_64-glibc2.15.AppImage
+    APPIMAGE=MIRTK-latest-x86_64-glibc2.14.AppImage
   fi
 else
   name="$(basename "$APPIMAGE")"

--- a/Scripts/make_appimage.sh
+++ b/Scripts/make_appimage.sh
@@ -29,7 +29,6 @@ TRAVIS=`norm_option_value "$TRAVIS" OFF`
 WITH_VTK=`norm_option_value "$WITH_VTK" OFF`
 TRANSFER=`norm_option_value "$TRANSFER_AppImage" OFF`
 AppImage_DEVEL=`norm_option_value "$AppImage_DEVEL" OFF`
-AppImage_VIEWER=`norm_option_value "$AppImage_VIEWER" OFF`
 AppImage_LATEST=`norm_option_value "$AppImage_LATEST" OFF`
 PYTHON="/usr/bin/env python"  # target system Python interpreter
 
@@ -77,21 +76,6 @@ cd "$APPDIR/.."
 wget -q https://github.com/probonopd/AppImages/raw/master/functions.sh -O ./functions.sh
 . ./functions.sh
 cd "$APPDIR"
-
-########################################################################
-# Include pre-built binary MIRTK view command (source not included)
-########################################################################
-
-if [ $AppImage_VIEWER = ON ]; then
-  sudo apt-get install -y libgsl0ldbl
-  wget -O view https://bintray.com/schuhschuh/generic/download_file?file_path=ubuntu-14.04%2Fview
-  chmod a+x view
-  if [ -d usr/lib/mirtk/tools ]; then
-    mv view usr/lib/mirtk/tools/
-  else
-    mv view usr/lib/tools/
-  fi
-fi
 
 ########################################################################
 # Copy in dependencies that may not be available on all target systems
@@ -184,7 +168,7 @@ tree -a 2> /dev/null || true
 ########################################################################
 
 echo
-echo "Generating AppImages..."
+echo "Generating AppImage..."
 APPIMAGES=()
 
 cd "$APPDIR/.."
@@ -192,31 +176,6 @@ mkdir -p "$OUTDIR"
 wget "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-${ARCH}.AppImage"
 chmod a+x appimagetool-${ARCH}.AppImage
 
-if [ $AppImage_VIEWER = ON ]; then
-  echo "Generating AppImage including view binary..."
-  APPIMAGE="$APP+view-$RELEASE-$ARCH"
-  GLIBC_VERSION=$(glibc_needed)
-  [ -z "$GLIBC_VERSION" ] || APPIMAGE="$APPIMAGE-glibc$GLIBC_VERSION"
-  APPIMAGE="$APPIMAGE.AppImage"
-  rm -f "$OUTDIR/$APPIMAGE" 2> /dev/null || true
-  ./appimagetool-${ARCH}.AppImage -n -v "$APPDIR" "$OUTDIR/$APPIMAGE"
-  APPIMAGES=("${APPIMAGES[@]}" "$APPIMAGE")
-  echo "Generating AppImage including view binary... done"
-
-  cd "$APPDIR/usr/lib"
-  rm -f tools/view \
-        libgsl* \
-        libGL* \
-        libX* \
-        libxcb* \
-        libxshmfence* \
-        libfreetype* \
-        libglapi* \
-  rm -rf mesa || true
-  cd "$APPDIR/.."
-fi
-
-echo "Generating AppImage excluding view binary..."
 APPIMAGE="$APP-$RELEASE-$ARCH"
 GLIBC_VERSION=$(glibc_needed)
 [ -z "$GLIBC_VERSION" ] || APPIMAGE="$APPIMAGE-glibc$GLIBC_VERSION"
@@ -224,9 +183,8 @@ APPIMAGE="$APPIMAGE.AppImage"
 rm -f "$OUTDIR/$APPIMAGE" 2> /dev/null || true
 ./appimagetool-${ARCH}.AppImage -n -v "$APPDIR" "$OUTDIR/$APPIMAGE"
 APPIMAGES=("${APPIMAGES[@]}" "$APPIMAGE")
-echo "Generating AppImage excluding view binary... done"
 
-echo "Generating AppImages... done"
+echo "Generating AppImage... done"
 
 ########################################################################
 # Clean up

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -34,6 +34,7 @@ WITH_UMFPACK=`norm_option_value "$WITH_UMFPACK" OFF`
 WITH_VTK=`norm_option_value "$WITH_VTK" OFF`
 WITH_TBB=`norm_option_value "$WITH_TBB" ON`
 WITH_FLANN=`norm_option_value "$WITH_FLANN" ON`
+WITH_FLTK=`norm_option_value "$WITH_FLTK" OFF`
 WITH_CCACHE=`norm_option_value "$WITH_CCACHE" OFF`
 
 if [ $TRAVIS = ON ]; then
@@ -52,6 +53,9 @@ fi
 modules=(Common Numerics Image IO Transformation Registration DrawEM)
 if [ $WITH_VTK = ON ]; then
   modules=(${modules[@]} PointSet Deformable Mapping)
+  if [ $WITH_FLTK = ON ]; then
+    modules=(${modules[@]} Viewer)
+  fi
 fi
 
 cmake_args=


### PR DESCRIPTION
The MIRTK/Viewer package provides the `display` and `view` commands.

- [x] Build `view` command as part of MIRTK when `MODULE_Viewer=ON`.
- [x] Don't use `view` binary from Bintray when creating AppImage.
- [x] Remove mention of AppImage +view from documentation. Viewer always part of AppImage.