### PR TITLE
fix: Internal compiler error when compiling GenericImage::GetMinMax with MSVC 2017

### DIFF
--- a/Modules/Image/src/GenericImage.cc
+++ b/Modules/Image/src/GenericImage.cc
@@ -1129,8 +1129,9 @@ BinaryImage GenericImage<VoxelType>::operator!=(VoxelType pixel) const
 template <class VoxelType>
 void GenericImage<VoxelType>::GetMinMax(VoxelType &min, VoxelType &max) const
 {
-  min = max = VoxelType();
-  
+  min = VoxelType();
+  max = VoxelType();
+ 
   const VoxelType *ptr   = this->Data();
   bool             first = true;
   
@@ -1163,7 +1164,8 @@ template <> void GenericImage<double3x3>::GetMinMax(VoxelType &, VoxelType &) co
 template <class VoxelType>
 void GenericImage<VoxelType>::GetMinMax(VoxelType &min, VoxelType &max, VoxelType pad) const
 {
-  min = max = VoxelType();
+  min = VoxelType();
+  max = VoxelType();
 
   const VoxelType *ptr   = this->Data();
   bool             first = true;


### PR DESCRIPTION
Too many explicit template instantiations in single compilation unit result in "internal compiler error" with newer Microsoft compilers, in particular toolset "v141" of Visual Studio 2017.