### PR TITLE
fix: Prefer “libarpack” over “libparpack” in FindARPACK

### DIFF
--- a/CMake/Modules/FindARPACK.cmake
+++ b/CMake/Modules/FindARPACK.cmake
@@ -1,5 +1,5 @@
 find_library(ARPACK_LIBRARY
-  NAMES parpack arpack
+  NAMES arpack parpack
   PATHS ${ARPACK_DIR}/lib
 )
 


### PR DESCRIPTION
When using libparpack installed with Homebrew, undefined symbols were encountered. Use of libarpack fixed it.