### PR TITLE
enh: Add BASIS_UNINSTALLER option which is OFF by default

### DIFF
--- a/CMake/Basis/BasisSettings.cmake
+++ b/CMake/Basis/BasisSettings.cmake
@@ -833,6 +833,10 @@ mark_as_advanced (BASIS_DEBUG)
 option (BASIS_BUILD_ONLY "Request configuration of software build only, skipping steps related to packaging and installation." OFF)
 mark_as_advanced (BASIS_BUILD_ONLY)
 
+## @brief Request generation of package uninstaller script upon installation.
+option (BASIS_UNINSTALLER "Request generation of default package uninstall script upon installation." OFF)
+mark_as_advanced (BASIS_UNINSTALLER)
+
 # ============================================================================
 # build configuration
 # ============================================================================

--- a/CMake/Basis/ProjectTools.cmake
+++ b/CMake/Basis/ProjectTools.cmake
@@ -2670,7 +2670,9 @@ macro (basis_project_end)
       # Attention: add_uninstall must be called last in a separate file via an
       #            add_subdirectory call. This ensures that the code is executed
       #            at the end of the root cmake_install.cmake file.
-      add_subdirectory ("${BASIS_MODULE_PATH}/uninstall" "${PROJECT_BINARY_DIR}/uninstall")
+      if (BASIS_UNINSTALLER)
+        add_subdirectory ("${BASIS_MODULE_PATH}/uninstall" "${PROJECT_BINARY_DIR}/uninstall")
+      endif ()
     endif ()
 
   endif ()


### PR DESCRIPTION
Add new BASIS_UNINSTALLER option which can be used to request installation of `uninstall-mirtk` script. By default, no uninstall script is being installed any longer as this script makes the installation no longer relocatable.

Closes #674 .