### PR TITLE
fix: SurfaceCollisions::GetCollisionType(vtkIdType)

### DIFF
--- a/Modules/PointSet/include/mirtk/SurfaceCollisions.h
+++ b/Modules/PointSet/include/mirtk/SurfaceCollisions.h
@@ -296,8 +296,10 @@ public:
   /// Get type of cell collision
   CollisionType GetCollisionType(int) const;
 
+#ifdef VTK_USE_64BIT_IDS
   /// Get type of cell collision
   CollisionType GetCollisionType(vtkIdType) const;
+#endif // VTK_USE_64BIT_IDS
 
   /// Set of intersections of other faces with the specified cell
   /// \note Use only when intersection tests enabled.

--- a/Modules/PointSet/src/SurfaceCollisions.cc
+++ b/Modules/PointSet/src/SurfaceCollisions.cc
@@ -520,10 +520,12 @@ SurfaceCollisions::CollisionType SurfaceCollisions::GetCollisionType(int cellId)
 }
 
 // -----------------------------------------------------------------------------
+#ifdef VTK_USE_64BIT_IDS
 SurfaceCollisions::CollisionType SurfaceCollisions::GetCollisionType(vtkIdType cellId) const
 {
   return static_cast<CollisionType>(static_cast<int>(GetCollisionTypeArray()->GetComponent(cellId, 0)));
 }
+#endif // VTK_USE_64BIT_IDS
 
 // =============================================================================
 // Execution


### PR DESCRIPTION
If VTK_USE_64BIT_IDS is not defined, vtkIdType is an alias for `int`. Hence, `SurfaceCollisions::GetCollisionType(int)` is the same as `SurfaceCollisions::GetCollisionType(vtkIdType)`. In this case, get rid of the redundant definition.

Closes #676. 