### PR TITLE
Add -mod, -floor, -ceil, -round options to calculate-element-wise command

### DIFF
--- a/Applications/src/calculate-element-wise.cc
+++ b/Applications/src/calculate-element-wise.cc
@@ -220,6 +220,12 @@ void PrintHelp(const char *name)
   cout << "      Compute logarithm to base 10, alias for :option:`-log` with base 10.\n";
   cout << "  -mod, -fmod <denominator>\n";
   cout << "      Compute modulo division of each value with specified denominator.\n";
+  cout << "  -floor\n";
+  cout << "      Round floating point values to largest integer value that is not greater.\n";
+  cout << "  -ceil\n";
+  cout << "      Round floating point values to smallest integer value that is greater.\n";
+  cout << "  -round\n";
+  cout << "      Round floating point values to the nearest integer value, away from zero for halfway cases.\n";
   cout << "\n";
   cout << "Data output options:\n";
   cout << "  -out, -o, -output <file> [<type>] [<name>]\n";
@@ -884,6 +890,12 @@ int main(int argc, char **argv)
         exit(1);
       }
       ops.push_back(UniquePtr<Op>(new Mod(denominator)));
+    } else if (OPTION("-floor")) {
+      ops.push_back(UniquePtr<Op>(new Floor()));
+    } else if (OPTION("-ceil")) {
+      ops.push_back(UniquePtr<Op>(new Ceil()));
+    } else if (OPTION("-round")) {
+      ops.push_back(UniquePtr<Op>(new Round()));
     } else if (OPTION("=")) {
       const char *fname = ARGUMENT;
       #if MIRTK_Image_WITH_VTK

--- a/Applications/src/calculate-element-wise.cc
+++ b/Applications/src/calculate-element-wise.cc
@@ -218,6 +218,8 @@ void PrintHelp(const char *name)
   cout << "      Compute natural logarithm, alias for :option:`-log` with base e.\n";
   cout << "  -lg, -log10 [<threshold>]\n";
   cout << "      Compute logarithm to base 10, alias for :option:`-log` with base 10.\n";
+  cout << "  -mod, -fmod <denominator>\n";
+  cout << "      Compute modulo division of each value with specified denominator.\n";
   cout << "\n";
   cout << "Data output options:\n";
   cout << "  -out, -o, -output <file> [<type>] [<name>]\n";
@@ -874,6 +876,14 @@ int main(int argc, char **argv)
         op = new Ln(a);
       }
       ops.push_back(UniquePtr<Op>(op));
+    } else if (OPTION("-mod") || OPTION("-fmod")) {
+      const char *arg = ARGUMENT;
+      double denominator;
+      if (!FromString(arg, denominator) || abs(denominator) < 1e-12) {
+        cerr << "Invalid -mod value, must be a non-zero number!" << endl;
+        exit(1);
+      }
+      ops.push_back(UniquePtr<Op>(new Mod(denominator)));
     } else if (OPTION("=")) {
       const char *fname = ARGUMENT;
       #if MIRTK_Image_WITH_VTK

--- a/Modules/Image/include/mirtk/DataFunctions.h
+++ b/Modules/Image/include/mirtk/DataFunctions.h
@@ -491,6 +491,30 @@ public:
 };
 
 // -----------------------------------------------------------------------------
+/// Compute element-wise modulo division
+class Mod : public ElementWiseUnaryOp
+{
+  mirtkPublicAttributeMacro(double, Denominator);
+
+public:
+
+  Mod(double denominator) : _Denominator(denominator) {}
+
+  /// Transform data value and/or mask data value by setting *mask = false
+  virtual double Op(double value, bool &) const
+  {
+    return fmod(value, _Denominator);
+  }
+
+  /// Process given data (not thread-safe!)
+  virtual void Process(int n, double *data, bool *mask = NULL)
+  {
+    ElementWiseUnaryOp::Process(n, data, mask);
+    parallel_for(blocked_range<int>(0, n), *this);
+  }
+};
+
+// -----------------------------------------------------------------------------
 /// Element-wise addition
 class Add : public ElementWiseBinaryOp
 {

--- a/Modules/Image/include/mirtk/DataFunctions.h
+++ b/Modules/Image/include/mirtk/DataFunctions.h
@@ -515,6 +515,66 @@ public:
 };
 
 // -----------------------------------------------------------------------------
+/// Element-wise floor
+class Floor : public ElementWiseUnaryOp
+{
+public:
+
+  /// Transform data value and/or mask data value by setting *mask = false
+  virtual double Op(double value, bool &) const
+  {
+    return floor(value);
+  }
+
+  /// Process given data (not thread-safe!)
+  virtual void Process(int n, double *data, bool *mask = NULL)
+  {
+    ElementWiseUnaryOp::Process(n, data, mask);
+    parallel_for(blocked_range<int>(0, n), *this);
+  }
+};
+
+// -----------------------------------------------------------------------------
+/// Element-wise ceil
+class Ceil : public ElementWiseUnaryOp
+{
+public:
+
+  /// Transform data value and/or mask data value by setting *mask = false
+  virtual double Op(double value, bool &) const
+  {
+    return ceil(value);
+  }
+
+  /// Process given data (not thread-safe!)
+  virtual void Process(int n, double *data, bool *mask = NULL)
+  {
+    ElementWiseUnaryOp::Process(n, data, mask);
+    parallel_for(blocked_range<int>(0, n), *this);
+  }
+};
+
+// -----------------------------------------------------------------------------
+/// Element-wise round
+class Round : public ElementWiseUnaryOp
+{
+public:
+
+  /// Transform data value and/or mask data value by setting *mask = false
+  virtual double Op(double value, bool &) const
+  {
+    return round(value);
+  }
+
+  /// Process given data (not thread-safe!)
+  virtual void Process(int n, double *data, bool *mask = NULL)
+  {
+    ElementWiseUnaryOp::Process(n, data, mask);
+    parallel_for(blocked_range<int>(0, n), *this);
+  }
+};
+
+// -----------------------------------------------------------------------------
 /// Element-wise addition
 class Add : public ElementWiseBinaryOp
 {


### PR DESCRIPTION
CC @soundray.

```
$ mirtk calculate-element-wise seg95.nii.gz -extrema -mod 5 -extrema
Extrema = [0, 95]
Extrema = [0, 4]
$ mirtk calculate-element-wise seg95.nii.gz -extrema -mod 10.4 -extrema -mod 5 -extrema
Extrema = [0, 95]
Extrema = [0, 10.4]
Extrema = [0, 5]
mirtk calculate-element-wise seg95.nii.gz -extrema -mod 10.4 -extrema -abs -mod 5 -extrema
Extrema = [0, 95]
Extrema = [0, 10.4]
Extrema = [0, 5]
mirtk calculate-element-wise seg95.nii.gz -extrema -div 2 -mod 5 -extrema
Extrema = [0, 95]
Extrema = [0, 4.5]
mirtk calculate-element-wise seg95.nii.gz -extrema -div 2 -round -mod 5 -extrema
Extrema = [0, 95]
Extrema = [0, 4]
```