### PR TITLE
Spatially varying weight mask for Jacobian penalty terms

### DIFF
--- a/Applications/src/register.cc
+++ b/Applications/src/register.cc
@@ -254,16 +254,30 @@ void PrintHelp(const char* name)
   cout << "      \"Linear energy weight\" of free-form deformation. (default: 0)\n";
   cout << "  -tp <w>\n";
   cout << "      \"Topology preservation weight\" of free-form deformation. (default: 0)\n";
-  cout << "  -vp <w>\n";
+  cout << "  -tp-mask <file>\n";
+  cout << "      \"Topology preservation mask\" with spatially varying weights. (default: none)\n";
+  cout << "  -vp <w> [<file>]\n";
   cout << "      \"Volume preservation weight\" of free-form deformation. (default: 0)\n";
-  cout << "  -lj, -jl, -log-jac, -jac <w>\n";
+  cout << "  -vp-mask <file>\n";
+  cout << "      \"Volume preservation mask\" with spatially varying weights. (default: none)\n";
+  cout << "  -lj, -jl, -log-jac, -jac <w> [<file>]\n";
   cout << "      \"LogJac penalty weight\" of free-form deformation. For a classic FFD transformation model\n";
   cout << "      this penalty term is equivalent to the volume preservation term. When applied to the SVFFD\n";
-  cout << "      model, however, this penalty applies to the Jacobian determinant of the velocity field. (default: 0)\n";
-  cout << "  -nj, -neg-jac <w>\n";
+  cout << "      model, however, this penalty applies to the Jacobian determinant of the velocity field.\n";
+  cout << "      Optionally, an image file with spatially varying weights can be given as second argument.\n";
+  cout << "      The contribution of the penalty at each voxel is multiplied by both, global and local, weights.\n";
+  cout << "      (default: 0)\n";
+  cout << "  -lj-mask, -jl-mask, -log-jac-mask, -jac-mask <file>\n";
+  cout << "      \"LogJac penalty mask\" with spatially varying weights. (default: none)\n";
+  cout << "  -nj, -neg-jac <w> [<file>]\n";
   cout << "      \"NegJac penalty weight\" of free-form deformation. For a classic FFD transformation model\n";
   cout << "      this penalty term is equivalent to the volume preservation term. When applied to the SVFFD\n";
-  cout << "      model, however, this penalty applies to the Jacobian determinant of the velocity field. (default: 0)\n";
+  cout << "      model, however, this penalty applies to the Jacobian determinant of the velocity field.\n";
+  cout << "      Optionally, an image file with spatially varying weights can be given as second argument.\n";
+  cout << "      The contribution of the penalty at each voxel is multiplied by both, global and local, weights.\n";
+  cout << "      (default: 0)\n";
+  cout << "  -nj-mask, -neg-jac-mask <file>\n";
+  cout << "      \"NegJac penalty mask\" with spatially varying weights. (default: none)\n";
   cout << "  -parout <file>\n";
   cout << "      Write parameters to the named configuration file. Note that after initialization of\n";
   cout << "      the registration, an interim configuration file is written. This file is overwritten\n";
@@ -847,20 +861,32 @@ int main(int argc, char **argv)
       PARSE_ARGUMENT(w);
       Insert(params, "Volume preservation weight", w);
     }
+    else if (OPTION("-vp-mask")) {
+      Insert(params, "Volume preservation mask", ARGUMENT);
+    }
     else if (OPTION("-tp")) {
       double w;
       PARSE_ARGUMENT(w);
       Insert(params, "Topology preservation weight", w);
+    }
+    else if (OPTION("-tp-mask")) {
+      Insert(params, "Topology preservation mask", ARGUMENT);
     }
     else if (OPTION("-lj") || OPTION("-jl") || OPTION("-logjac") || OPTION("-log-jac") || OPTION("-jac")) {
       double w;
       PARSE_ARGUMENT(w);
       Insert(params, "LogJac penalty weight", w);
     }
+    else if (OPTION("-lj-mask") || OPTION("-jl-mask") || OPTION("-logjac-mask") || OPTION("-log-jac-mask") || OPTION("-jac-mask")) {
+      Insert(params, "LogJac penalty mask", ARGUMENT);
+    }
     else if (OPTION("-nj") || OPTION("-negjac") || OPTION("-neg-jac")) {
       double w;
       PARSE_ARGUMENT(w);
       Insert(params, "NegJac penalty weight", w);
+    }
+    else if (OPTION("-nj-mask") || OPTION("-negjac-mask") || OPTION("-neg-jac-mask")) {
+      Insert(params, "NegJac penalty mask", ARGUMENT);
     }
     else if (OPTION("-padding") || OPTION("-bg") || OPTION("-background")) {
       double v;

--- a/Modules/Transformation/include/mirtk/JacobianConstraint.h
+++ b/Modules/Transformation/include/mirtk/JacobianConstraint.h
@@ -58,11 +58,28 @@ public:
     SD_Shifted  ///< Evaluate penalty in-between control points
   };
 
+  /// Type of spatially varying penalty weight image
+  typedef GenericImage<float> WeightImage;
+
   // ---------------------------------------------------------------------------
   // Attributes
 
   /// Sub-domain on which to evaluate penalty
   mirtkPublicAttributeMacro(SubDomainEnum, SubDomain);
+
+  /// File path of image with spatially varying penalty weights
+  mirtkPublicAttributeMacro(string, MaskFileName);
+
+  /// Standard deviation of Gaussian kernel used for downsampling of mask image
+  ///
+  /// This value must be in units of the fraction between downsampled domain on which
+  /// the penalty is being evaluated and the input mask. If the domain on which the
+  /// penalty is evaluated has smaller or similar spacing than the input mask, no
+  /// smoothing is applied along the respective image axis for which this is the case.
+  mirtkPublicAttributeMacro(double, MaskBlurring);
+
+  /// Image of spatially varying penalty weights
+  mirtkPublicAttributeMacro(WeightImage, Mask);
 
   /// Whether to always apply constraint to Jacobian of FFD spline function
   ///
@@ -90,6 +107,7 @@ protected:
   Array<Matrix> _MatW2L; ///< World to sub-domain lattice coordinates
   Array<Matrix> _MatL2W; ///< Sub-domain lattice coordinates to world
   Array<ImageAttributes> _SubDomains; ///< Discrete sub-domain over which to integrate penalty
+  Array<WeightImage>     _Masks;      ///< Spatially varying weight image for each sub-domain
 
   // ---------------------------------------------------------------------------
   // Construction/destruction

--- a/Modules/Transformation/src/LogJacobianConstraint.cc
+++ b/Modules/Transformation/src/LogJacobianConstraint.cc
@@ -37,7 +37,7 @@ LogJacobianConstraint::LogJacobianConstraint(const char *name, bool constrain_sp
   JacobianConstraint(name, constrain_spline),
   _Epsilon(.005)
 {
-  _ParameterPrefix.push_back("Jacobian penalty ");
+  _ParameterPrefix.push_back("LogJac penalty ");
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Transformation/src/NegJacobianConstraint.cc
+++ b/Modules/Transformation/src/NegJacobianConstraint.cc
@@ -37,6 +37,7 @@ NegJacobianConstraint::NegJacobianConstraint(const char *name, bool constrain_sp
   JacobianConstraint(name, constrain_spline),
   _Epsilon(.01), _Gamma(.5), _Power(2)
 {
+  _ParameterPrefix.push_back("NegJac penalty ");
   _SubDomain = SD_Shifted;
 }
 

--- a/Modules/Transformation/src/TopologyPreservationConstraint.cc
+++ b/Modules/Transformation/src/TopologyPreservationConstraint.cc
@@ -37,6 +37,8 @@ TopologyPreservationConstraint::TopologyPreservationConstraint(const char *name)
 :
   NegJacobianConstraint(name, false)
 {
+  _ParameterPrefix.resize(1);
+  _ParameterPrefix[0] = "Topology preservation ";
 }
 
 // -----------------------------------------------------------------------------

--- a/Modules/Transformation/src/VolumePreservationConstraint.cc
+++ b/Modules/Transformation/src/VolumePreservationConstraint.cc
@@ -36,7 +36,8 @@ VolumePreservationConstraint::VolumePreservationConstraint(const char *name)
 :
   LogJacobianConstraint(name, false)
 {
-  _ParameterPrefix.clear();
+  _ParameterPrefix.resize(1);
+  _ParameterPrefix[0] = "Volume preservation ";
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Add options to `register` command which enable user to specify an input image with spatially varying weights for a given Jacobian determinant based penalty term.