### PR TITLE
Update to Ubuntu 18.04, C++14, and CMake 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 sudo: required
 
 language: cpp
@@ -19,7 +19,7 @@ env:
   # versions of VTK for each OS
   # - On Ubuntu, use default version installed by apt-get
   # - On macOS, build recent VTK version from sources and cache installation
-  - LINUX_VTK_VERSION=6.2.0
+  - LINUX_VTK_VERSION=7.1.1
   - MACOS_VTK_VERSION=8.1.0
   - WITH_CCACHE=ON    # speed up MIRTK build itself using ccache
   - WITH_ARPACK=OFF   # requires time consuming build of gcc on macOS

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: required
 
 language: cpp
@@ -19,7 +19,7 @@ env:
   # versions of VTK for each OS
   # - On Ubuntu, use default version installed by apt-get
   # - On macOS, build recent VTK version from sources and cache installation
-  - LINUX_VTK_VERSION=6.0.0
+  - LINUX_VTK_VERSION=6.2.0
   - MACOS_VTK_VERSION=8.1.0
   - WITH_CCACHE=ON    # speed up MIRTK build itself using ccache
   - WITH_ARPACK=OFF   # requires time consuming build of gcc on macOS

--- a/BasisProject.cmake
+++ b/BasisProject.cmake
@@ -1,8 +1,8 @@
 # ============================================================================
 # Medical Image Registration ToolKit (MIRTK)
 #
-# Copyright 2013-2017 Imperial College London
-# Copyright 2013-2018 Andreas Schuh
+# Copyright 2013-2019 Imperial College London
+# Copyright 2013-2019 Andreas Schuh
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -56,11 +56,11 @@ basis_project (
   SOVERSION    "0"     # API yet unstable
   AUTHORS      "Andreas Schuh"
   DESCRIPTION  "Medical Image Registration ToolKit"
-  COPYRIGHT    "2013-2018 Imperial College London, Andreas Schuh"
+  COPYRIGHT    "2013-2019 Imperial College London, Andreas Schuh"
   LICENSE      "Apache License Version 2.0"
   CONTACT      "Andreas Schuh <andreas.schuh.84@gmail.com>"
   TEMPLATE     "with-basis-submodule/1.0"
-  LANGUAGES    C CXX-11
+  LANGUAGES    C CXX-14
  
   # --------------------------------------------------------------------------
   # directories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 # ============================================================================
 # Medical Image Registration ToolKit (MIRTK)
 #
-# Copyright 2013-2016 Imperial College London
-# Copyright 2013-2016 Andreas Schuh
+# Copyright 2013-2019 Imperial College London
+# Copyright 2013-2019 Andreas Schuh
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
 
 # ----------------------------------------------------------------------------
 # Minimum required CMake version
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
 
 # ----------------------------------------------------------------------------
 # Include BASIS policies, settings, macros, and functions
@@ -97,11 +97,7 @@ if (WITH_CCACHE)
     message(STATUS "Using ccache for compilation of C++ code")
     mark_as_advanced(CCACHE_COMMAND)
     # For Unix Makefiles and Ninja generators
-    if (CMAKE_VERSION VERSION_LESS 3.4)
-      set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_COMMAND}")
-    else ()
-      set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_COMMAND}")
-    endif ()
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_COMMAND}")
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       add_compile_options("-Qunused-arguments")
     endif ()

--- a/Docker/Ubuntu/Dockerfile
+++ b/Docker/Ubuntu/Dockerfile
@@ -13,9 +13,9 @@
 ##
 ## https://hub.docker.com/r/biomedia/ubuntu/
 
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
-MAINTAINER Andreas Schuh <andreas.schuh.84@gmail.com>
+LABEL Maintainer="Andreas Schuh <andreas.schuh.84@gmail.com>"
 LABEL Description="Ubuntu with prerequisits for MIRTK installed" Vendor="BioMedIA"
 
 # No. of threads to use for build (--build-arg THREADS=8)
@@ -23,32 +23,28 @@ LABEL Description="Ubuntu with prerequisits for MIRTK installed" Vendor="BioMedI
 # set the number of CPUs in the VirtualBox VM Settings.
 ARG THREADS
 
-# When VTK_VERSION='', the official libvtk6-dev package is used.
+# When VTK_VERSION='', the official libvtk7-dev package is used.
 # Note, however, that this results in a Docker image that is about twice
 # the size of the image when a custom VTK build without Qt, wrappers,
 # and unused VTK modules is used instead!
-ARG VTK_VERSION=7.0.0
+ARG VTK_VERSION=8.2.0
 
-ARG EIGEN_VERSION=3.2.8
+ARG EIGEN_VERSION=3.3.7
+
+ARG CXX_STANDARD=c++14
 
 # Install prerequisites for MIRTK build
-#
-# The bzindovic/suitesparse-bugfix-1319687 PPA is required for building
-# shared libraries which link with the static SuiteSparse libraries due
-# to a bug in the official Ubuntu package:
-# https://bugs.launchpad.net/ubuntu/+source/suitesparse/+bug/1333214
 RUN NUM_CPUS=${THREADS:-`cat /proc/cpuinfo | grep processor | wc -l`} \
     && echo "Maximum number of build threads = $NUM_CPUS" \
     && apt-get update && apt-get install -y --no-install-recommends \
       software-properties-common \
-    && add-apt-repository -y ppa:bzindovic/suitesparse-bugfix-1319687 \
     && apt-get update && apt-get install -y --no-install-recommends \
       wget \
       gcc \
       g++ \
       make \
       cmake \
-      python \
+      python3 \
       freeglut3-dev \
       libarpack2-dev \
       libboost-math-dev \
@@ -77,13 +73,13 @@ RUN NUM_CPUS=${THREADS:-`cat /proc/cpuinfo | grep processor | wc -l`} \
       && wget -O archive.tar.bz2 http://bitbucket.org/eigen/eigen/get/${EIGEN_VERSION}.tar.bz2 \
       && tar vxjf archive.tar.bz2 --strip 1 \
       && mv signature_of_eigen3_matrix_library Eigen /usr/include/eigen3/ \
-      && mv cmake/FindEigen3.cmake /usr/share/cmake-2.8/Modules/ \
+      && mv cmake/FindEigen3.cmake /usr/share/cmake-3.10/Modules/ \
       && cd /usr/src \
       && rm -rf ${EIGEN_SOURCE_DIR}; \
     fi \
     && \
     if [ -z ${VTK_VERSION} ]; then \
-      apt-get install -y libvtk6-dev; \
+      apt-get install -y libvtk7-dev; \
     else \
       VTK_RELEASE=`echo ${VTK_VERSION} | sed s/\.[0-9]*$//` \
       && cd /usr/src \
@@ -95,7 +91,7 @@ RUN NUM_CPUS=${THREADS:-`cat /proc/cpuinfo | grep processor | wc -l`} \
       && cmake \
         -D CMAKE_INSTALL_PREFIX=/usr/local \
         -D CMAKE_BUILD_TYPE=Release \
-        -D CMAKE_CXX_FLAGS=-std=c++11 \
+        -D CMAKE_CXX_STANDARD=${CXX_STANDARD} \
         -D VTK_USE_SYSTEM_PNG=ON \
         -D VTK_USE_SYSTEM_ZLIB=ON \
         -D BUILD_SHARED_LIBS=ON \

--- a/Docker/Ubuntu/Dockerfile
+++ b/Docker/Ubuntu/Dockerfile
@@ -15,8 +15,9 @@
 
 FROM ubuntu:18.04
 
-LABEL Maintainer="Andreas Schuh <andreas.schuh.84@gmail.com>"
-LABEL Description="Ubuntu with prerequisits for MIRTK installed" Vendor="BioMedIA"
+LABEL Maintainer="Andreas Schuh <andreas.schuh.84@gmail.com>" \
+      Description="Ubuntu with prerequisits for MIRTK installed" \
+      Vendor="BioMedIA"
 
 # No. of threads to use for build (--build-arg THREADS=8)
 # By default, all available CPUs are used. When a Docker Machine is used,

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,15 +20,15 @@
 # Pre-made Ubuntu system with all MIRTK dependencies installed
 FROM biomedia/ubuntu:18.04-mirtk
 
-LABEL Maintainer="Andreas Schuh <andreas.schuh.84@gmail.com>"
-LABEL Description="Medical Image Registration ToolKit (MIRTK)"
-LABEL Vendor="BioMedIA"
+LABEL Maintainer="Andreas Schuh <andreas.schuh.84@gmail.com>" \
+      Description="Medical Image Registration ToolKit (MIRTK)" \
+      Vendor="BioMedIA"
 
 # Git repository and commit SHA from which this Docker image was built
 # (see https://microbadger.com/#/labels)
 ARG VCS_REF
-LABEL org.label-schema.vcs-ref=$VCS_REF
-LABEL org.label-schema.vcs-url="https://github.com/BioMedIA/MIRTK"
+LABEL org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/BioMedIA/MIRTK"
 
 # No. of threads to use for build (--build-arg THREADS=8)
 # By default, all available CPUs are used. When a Docker Machine is used,

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,13 +21,14 @@
 FROM biomedia/ubuntu:18.04-mirtk
 
 LABEL Maintainer="Andreas Schuh <andreas.schuh.84@gmail.com>"
-LABEL Description="Medical Image Registration ToolKit (MIRTK)" Vendor="BioMedIA"
+LABEL Description="Medical Image Registration ToolKit (MIRTK)"
+LABEL Vendor="BioMedIA"
 
 # Git repository and commit SHA from which this Docker image was built
 # (see https://microbadger.com/#/labels)
 ARG VCS_REF
-LABEL org.label-schema.vcs-ref=$VCS_REF \
-      org.label-schema.vcs-url="https://github.com/BioMedIA/MIRTK"
+LABEL org.label-schema.vcs-ref=$VCS_REF
+LABEL org.label-schema.vcs-url="https://github.com/BioMedIA/MIRTK"
 
 # No. of threads to use for build (--build-arg THREADS=8)
 # By default, all available CPUs are used. When a Docker Machine is used,
@@ -64,7 +65,7 @@ RUN ls /usr/src/mirtk \
       -D MODULE_DrawEM=ON \
       -D MODULE_Mapping=ON \
       -D MODULE_Scripting=ON \
-      -D MODULE_Viewer=ON \
+      -D MODULE_Viewer=OFF \
       -D WITH_ARPACK=ON \
       -D WITH_FLANN=ON \
       -D WITH_MATLAB=OFF \
@@ -82,7 +83,7 @@ RUN ls /usr/src/mirtk \
     && rm -rf /usr/src/mirtk
 
 # Make "mirtk" the default executable for application containers
-ENTRYPOINT ["python3", "/usr/local/bin/mirtk"]
+ENTRYPOINT ["/usr/bin/python3", "/usr/local/bin/mirtk"]
 CMD ["help"]
 
 # Assume user data volume to be mounted at /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,9 @@
 ## https://hub.docker.com/r/biomedia/mirtk/
 
 # Pre-made Ubuntu system with all MIRTK dependencies installed
-FROM biomedia/ubuntu:mirtk
+FROM biomedia/ubuntu:18.04-mirtk
 
-MAINTAINER Andreas Schuh <andreas.schuh.84@gmail.com>
+LABEL Maintainer="Andreas Schuh <andreas.schuh.84@gmail.com>"
 LABEL Description="Medical Image Registration ToolKit (MIRTK)" Vendor="BioMedIA"
 
 # Git repository and commit SHA from which this Docker image was built
@@ -39,12 +39,12 @@ ARG THREADS
 ARG BUILD_TESTING=OFF
 
 # Build and install MIRTK
-COPY . /usr/src/MIRTK
-RUN ls /usr/src/MIRTK \
+COPY . /usr/src/mirtk
+RUN ls /usr/src/mirtk \
     && NUM_CPUS=${THREADS:-`cat /proc/cpuinfo | grep processor | wc -l`} \
     && echo "Maximum number of build threads = $NUM_CPUS" \
-    && mkdir /usr/src/MIRTK/Build \
-    && cd /usr/src/MIRTK/Build \
+    && mkdir /usr/src/mirtk/Build \
+    && cd /usr/src/mirtk/Build \
     && cmake \
       -D CMAKE_INSTALL_PREFIX=/usr/local \
       -D CMAKE_BUILD_TYPE=Release \
@@ -64,6 +64,7 @@ RUN ls /usr/src/MIRTK \
       -D MODULE_DrawEM=ON \
       -D MODULE_Mapping=ON \
       -D MODULE_Scripting=ON \
+      -D MODULE_Viewer=ON \
       -D WITH_ARPACK=ON \
       -D WITH_FLANN=ON \
       -D WITH_MATLAB=OFF \
@@ -78,10 +79,10 @@ RUN ls /usr/src/MIRTK \
     && if [ ${BUILD_TESTING} = ON ]; then make -j $NUM_CPUS && make test; fi \
     && make -j $NUM_CPUS install \
     && cd /usr/src \
-    && rm -rf /usr/src/MIRTK
+    && rm -rf /usr/src/mirtk
 
 # Make "mirtk" the default executable for application containers
-ENTRYPOINT ["python", "/usr/local/bin/mirtk"]
+ENTRYPOINT ["python3", "/usr/local/bin/mirtk"]
 CMD ["help"]
 
 # Assume user data volume to be mounted at /data

--- a/Documentation/install.rst
+++ b/Documentation/install.rst
@@ -17,7 +17,7 @@ the Cross-platform Make tool named CMake_ is needed. The minimum required versio
 for Linux and OS X is 2.8.12, while version 3.4 or newer is needed on Windows.
 
 For the compilation of the MIRTK source code, a C++ compiler with support for the
-`C++11`_ standard is required. On Windows, the minimum required Visual Studio compiler
+`C++14`_ standard is required. On Windows, the minimum required Visual Studio compiler
 version is 18.0. A compatible compiler is shipped with Visual Studio 2013 or newer.
 For Unix operation systems, we recommend the use of the `GNU Compiler Collection`_ (GCC).
 

--- a/Scripts/install_depends.sh
+++ b/Scripts/install_depends.sh
@@ -89,7 +89,7 @@ if [ $os = linux ] || [ $os = Linux ]; then
     fi
     if [ "$DISTRIB_CODENAME" = "trusty" ]; then
       if [ -z "$VTK_VERSION" ] || [ $VTK_VERSION = '6.0.0' ]; then
-        deps=(${deps[@]} libvtk6-dev python-vtk6)
+        deps=(${deps[@]} libvtk6-dev)
         VTK_VERSION=''
       fi
     elif [ "$DISTRIB_CODENAME" = "xenial" ]; then
@@ -99,14 +99,14 @@ if [ $os = linux ] || [ $os = Linux ]; then
       fi
     elif [ "$DISTRIB_CODENAME" = "bionic" ]; then
       if [ $VTK_VERSION = '6.3.0' ]; then
-        deps=(${deps[@]} libvtk6-dev python-vtk6)
+        deps=(${deps[@]} libvtk6-dev)
         VTK_VERSION=''
       elif [ -z "$VTK_VERSION" ] || [ $VTK_VERSION = '7.1.1' ]; then
-        deps=(${deps[@]} libvtk7-dev python3-vtk7)
+        deps=(${deps[@]} libvtk7-dev)
         VTK_VERSION=''
       fi
     elif [ -z "$VTK_VERSION" ]; then
-      deps=(${deps[@]} libvtk7-dev python3-vtk7)
+      deps=(${deps[@]} libvtk7-dev)
     fi
     if [ $WITH_FLTK = ON ]; then
       deps=(${deps[@]} libxi-dev libxmu-dev libxinerama-dev libxcursor-dev libcairo-dev libfltk1.3-dev)

--- a/Scripts/install_depends.sh
+++ b/Scripts/install_depends.sh
@@ -89,6 +89,7 @@ if [ $os = linux ] || [ $os = Linux ]; then
       elif [ "$DISTRIB_CODENAME" = "xenial" ]; then
         if [ -z "$VTK_VERSION" ] || [ $VTK_VERSION = '6.2.0' ]; then
           deps=(${deps[@]} libvtk6-dev)
+          deps=(${deps[@]} python-vtk6)  # cf. https://forum.freecadweb.org/viewtopic.php?t=16453
           VTK_VERSION=''
         fi
       elif [ "$DISTRIB_CODENAME" = "bionic" ]; then

--- a/Scripts/install_depends.sh
+++ b/Scripts/install_depends.sh
@@ -89,25 +89,24 @@ if [ $os = linux ] || [ $os = Linux ]; then
     fi
     if [ "$DISTRIB_CODENAME" = "trusty" ]; then
       if [ -z "$VTK_VERSION" ] || [ $VTK_VERSION = '6.0.0' ]; then
-        deps=(${deps[@]} libvtk6-dev)
+        deps=(${deps[@]} libvtk6-dev python-vtk6)
         VTK_VERSION=''
       fi
     elif [ "$DISTRIB_CODENAME" = "xenial" ]; then
       if [ -z "$VTK_VERSION" ] || [ $VTK_VERSION = '6.2.0' ]; then
-        deps=(${deps[@]} libvtk6-dev)
-        deps=(${deps[@]} python-vtk6)  # cf. https://forum.freecadweb.org/viewtopic.php?t=16453
+        deps=(${deps[@]} libvtk6-dev python-vtk6)
         VTK_VERSION=''
       fi
     elif [ "$DISTRIB_CODENAME" = "bionic" ]; then
       if [ $VTK_VERSION = '6.3.0' ]; then
-        deps=(${deps[@]} libvtk6-dev)
+        deps=(${deps[@]} libvtk6-dev python-vtk6)
         VTK_VERSION=''
       elif [ -z "$VTK_VERSION" ] || [ $VTK_VERSION = '7.1.1' ]; then
-        deps=(${deps[@]} libvtk7-dev)
+        deps=(${deps[@]} libvtk7-dev python3-vtk7)
         VTK_VERSION=''
       fi
     elif [ -z "$VTK_VERSION" ]; then
-      deps=(${deps[@]} libvtk7-dev)
+      deps=(${deps[@]} libvtk7-dev python3-vtk7)
     fi
     if [ $WITH_FLTK = ON ]; then
       deps=(${deps[@]} libxi-dev libxmu-dev libxinerama-dev libxcursor-dev libcairo-dev libfltk1.3-dev)

--- a/Scripts/install_depends.sh
+++ b/Scripts/install_depends.sh
@@ -68,21 +68,14 @@ if [ $os = linux ] || [ $os = Linux ]; then
     libboost-math-dev \
     libboost-random-dev \
     libeigen3-dev \
-    libnifti-dev
+    libnifti-dev \
+    libpng-dev \
   )
-
-  if [ "$DISTRIB_CODENAME" = "trusty" ] || [ "$DISTRIB_CODENAME" = "xenial" ]; then
-    deps=(${deps[@]} libpng12-dev)
-  else
-    deps=(${deps[@]} libpng16-dev)
-  fi
 
   [ $TESTING = OFF ] || deps=(${deps[@]} libgtest-dev)
   [ $WITH_TBB = OFF ] || deps=(${deps[@]} libtbb-dev)
   [ $WITH_FLANN = OFF ] || deps=(${deps[@]} libflann-dev)
   [ $WITH_ARPACK = OFF ] || deps=(${deps[@]} libarpack2-dev)
-
-  
 
   if [ $WITH_UMFPACK = ON ]; then
     # see https://bugs.launchpad.net/ubuntu/+source/suitesparse/+bug/1333214


### PR DESCRIPTION
Update the CMakeLists.txt files to require CMake 3.4 and C++14 compiler. Use Python 3 as entrypoint of Docker image. Base Docker image on Ubuntu 18.04 (instead of 14.04). Also use Ubuntu 18.04 for Travis CI Linux tests.