### PR TITLE
Revert to C++11 and provide alternative NewUnique

### DIFF
--- a/BasisProject.cmake
+++ b/BasisProject.cmake
@@ -60,7 +60,7 @@ basis_project (
   LICENSE      "Apache License Version 2.0"
   CONTACT      "Andreas Schuh <andreas.schuh.84@gmail.com>"
   TEMPLATE     "with-basis-submodule/1.0"
-  LANGUAGES    C CXX-14
+  LANGUAGES    C CXX-11
  
   # --------------------------------------------------------------------------
   # directories

--- a/Modules/Common/include/mirtk/Memory.h
+++ b/Modules/Common/include/mirtk/Memory.h
@@ -41,28 +41,20 @@ using SharedPtr = std::shared_ptr<T>;
 template <class T>
 using WeakPtr = std::weak_ptr<T>;
 
-template <class T>
-UniquePtr<T> MakeUnique()
-{
-  return std::make_unique<T>();
-}
-
 template <class T, class... Args>
-UniquePtr<T> MakeUnique(Args&&... args)
+UniquePtr<T> NewUnique(Args&&... args)
 {
-  return std::make_unique<T>(args...);
-}
-
-template <class T>
-SharedPtr<T> NewShared()
-{
-  return std::make_shared<T>();
+  #if __cplusplus == 201103L
+    return UniquePtr<T>(new T(std::forward<Args>(args)...));
+  #else
+    return std::make_unique<T>(std::forward<Args>(args)...);
+  #endif
 }
 
 template <class T, class... Args>
 SharedPtr<T> NewShared(Args&&... args)
 {
-  return std::make_shared<T>(args...);
+  return std::make_shared<T>(std::forward<Args>(args)...);
 }
 
 using std::memset;


### PR DESCRIPTION
Given that not many C++14 features are intended to be used just yet, C++11 is still sufficient. Also renamed recently added MakeUnique to NewUnique in alignment with NewShared and removed unnecessary overloaded versions of NewUnique and NewShared without arguments. Can't remember why this seemed necessary (maybe will fail with older compilers?!?...). Use `std::forward` to preserve move semantics when using NewUnique or NewShared helpers.

See also discussion of commit d693ef95e3d07959455cbb5ef5cc30661a57f646.

CC @jcupitt 