### PR TITLE
Build AppImage on Ubuntu 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: xenial
 sudo: required
 
 language: cpp
@@ -19,7 +19,7 @@ env:
   # versions of VTK for each OS
   # - On Ubuntu, use default version installed by apt-get
   # - On macOS, build recent VTK version from sources and cache installation
-  - LINUX_VTK_VERSION=7.1.1
+  - LINUX_VTK_VERSION=6.2.0
   - MACOS_VTK_VERSION=8.1.0
   - WITH_CCACHE=ON    # speed up MIRTK build itself using ccache
   - WITH_ARPACK=OFF   # requires time consuming build of gcc on macOS


### PR DESCRIPTION
Otherwise AppImage requires more recent glibc and can only run on Ubuntu 18.04 or similar recent Linux distro.