### PR TITLE
fix: Revert to Ubuntu 14.04 for build of AppImage with older glibc and libstdc++

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: trusty
 sudo: required
 
 language: cpp
@@ -19,7 +19,7 @@ env:
   # versions of VTK for each OS
   # - On Ubuntu, use default version installed by apt-get
   # - On macOS, build recent VTK version from sources and cache installation
-  - LINUX_VTK_VERSION=6.2.0
+  - LINUX_VTK_VERSION=6.0.0
   - MACOS_VTK_VERSION=8.1.0
   - WITH_CCACHE=ON    # speed up MIRTK build itself using ccache
   - WITH_ARPACK=OFF   # requires time consuming build of gcc on macOS

--- a/Applications/src/random-dof.cc
+++ b/Applications/src/random-dof.cc
@@ -114,6 +114,7 @@ NewTransformation(const char *type,
   if (!attr) {
     return nullptr;
   }
+  UniquePtr<Transformation> dof;
   if (ltype == "ffd" || ltype == "bsplineffd" || ltype == "mffd") {
     UniquePtr<FreeFormTransformation> affd;
     if (ndim < 4) {
@@ -124,20 +125,22 @@ NewTransformation(const char *type,
     if (ltype == "mffd") {
       auto mffd = NewUnique<MultiLevelFreeFormTransformation>();
       mffd->PushLocalTransformation(affd.release());
-      return mffd;
+      dof.reset(mffd.release());
+    } else {
+      dof.reset(affd.release());
     }
-    return affd;
   }
   if (ltype == "svffd" || ltype == "bsplinesvffd" || ltype == "msvffd") {
     auto affd = NewUnique<BSplineFreeFormTransformationSV>(attr, sx, sy, sz);
     if (ltype == "msvffd") {
       auto mffd = NewUnique<MultiLevelFreeFormTransformation>();
       mffd->PushLocalTransformation(affd.release());
-      return mffd;
+      dof.reset(mffd.release());
+    } else {
+      dof.reset(affd.release());
     }
-    return affd;
   }
-  return nullptr;
+  return dof;
 }
 
 // =============================================================================

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -67,8 +67,14 @@ for module in ${modules[@]}; do
   cmake_args=(${cmake_args[@]} -D MODULE_${module}=ON)
 done
 
+if [ -x /opt/cmake-3.12.4/bin/cmake ]; then
+  cmake_cmd="/opt/cmake-3.12.4/bin/cmake"
+else
+  cmake_cmd="cmake"
+fi
+
 mkdir Build && cd Build
-run cmake \
+run "$cmake_cmd" \
       -D CMAKE_INSTALL_PREFIX=/usr \
       -D CMAKE_BUILD_TYPE=Release \
       -D BUILD_SHARED_LIBS=ON \


### PR DESCRIPTION
Trying to run AppImage on CentOS 7 in particular. Still require CMake >=3.4, however, which is easy to install on older Linux systems. Partially reverts #707 and previous fix-up #719.