### PR TITLE
fix: clean surface and split polydata before merging

### DIFF
--- a/Applications/src/merge-surfaces.cc
+++ b/Applications/src/merge-surfaces.cc
@@ -2325,6 +2325,16 @@ AddClosedIntersectionDivider(vtkPolyData *surface, vtkPolyData *cut, double tol 
     WritePolyData(fname, divider);
   }
 
+  vtkNew<vtkCleanPolyData> surface_cleaner;
+  SetVTKInput(surface_cleaner, surface);
+  surface_cleaner->Update();
+  surface = surface_cleaner->GetOutput();
+
+  vtkNew<vtkCleanPolyData> split_cleaner;
+  SetVTKInput(split_cleaner, split);
+  split_cleaner->Update();
+  split = split_cleaner->GetOutput();
+
   // Merge surface with intersected cells and tesselated divider polygon
   vtkNew<vtkAppendPolyData> appender;
   AddVTKInput(appender, surface);


### PR DESCRIPTION
This PR cleans the polydata of 2 surfaces (surface with intersected cells, tesselated divider polygon) that are being merged prior to merging.

If we don't do that we end up with an error in merging when iterating the points of the surfaces e.g.
```2020-10-28 12:17:34.043 (  57.500s) [        121FCE80]vtkAOSDataArrayTemplate:325    ERR| vtkFloatArray (0x55bdbe7836d0): Source array too small, requested tuple at index 168986, but there are only 168701 tuples in the array.```
This happens because the surfaces have not been properly updated.