### PR TITLE
fix: merge-surfaces creation of small holes at label boundary

### DIFF
--- a/Scripts/install_depends.sh
+++ b/Scripts/install_depends.sh
@@ -118,7 +118,7 @@ if [ $os = linux ] || [ $os = Linux ]; then
         deps=(${deps[@]} libvtk6-dev python-vtk6)
         VTK_VERSION=''
       fi
-    elif [ "$DISTRIB_CODENAME" = "bionic" ]; then
+    elif [ "$DISTRIB_CODENAME" = "bionic" ] || [ "$DISTRIB_CODENAME" = "focal" ] || [ "$DISTRIB_CODENAME" = "groovy" ]; then
       if [ $VTK_VERSION = '6.3.0' ]; then
         deps=(${deps[@]} libvtk6-dev)
         VTK_VERSION=''


### PR DESCRIPTION
This PR patches change #744 to only introduce a single hole in each surface to be merged for each (largest) connected component of the label boundary. It also avoids removing cells when this would leave surface triangles that are only connected by a single vertex but not an edge.

With this PR, `mirtk recon-neonatal-cortex` should no longer produce the error:
```
Exception: Merged surface is non-closed, no. of boundaries: N
```
At the intersection where the cortical surfaces are merged.

<img width="808" alt="Screen Shot 2020-11-22 at 3 34 21 AM" src="https://user-images.githubusercontent.com/975451/99921261-1f771280-2d21-11eb-9dea-9a89eb230a15.png">
<img width="812" alt="Screen Shot 2020-11-22 at 3 31 33 AM" src="https://user-images.githubusercontent.com/975451/99921264-230a9980-2d21-11eb-9e73-828472e25bea.png">

CC @jcupitt @amakropoulos 