### PR TITLE
Fix and extend SurfaceCollisions filter

### DIFF
--- a/Applications/src/evaluate-surface-mesh.cc
+++ b/Applications/src/evaluate-surface-mesh.cc
@@ -226,6 +226,7 @@ int main(int argc, char *argv[])
   double min_frontface_dist  = 1e-2;
   double min_backface_dist   = 1e-2;
   double max_collision_angle = 20.0;
+  bool adjacent_collision_test = true;
   bool fast_collision_test = false;
 
   double value;
@@ -310,6 +311,7 @@ int main(int argc, char *argv[])
         min_frontface_dist = min_backface_dist = 1e-2;
       }
     }
+    else HANDLE_BOOLEAN_OPTION("adjacent-collision-test", adjacent_collision_test);
     else HANDLE_BOOLEAN_OPTION("fast-collision-test", fast_collision_test);
     else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
@@ -598,6 +600,7 @@ int main(int argc, char *argv[])
 
         SurfaceCollisions collisions;
         collisions.Input(surface);
+        collisions.AdjacentCollisionTest(adjacent_collision_test);
         collisions.FastCollisionTest(fast_collision_test);
         collisions.MinFrontfaceDistance(min_frontface_dist);
         collisions.MinBackfaceDistance(min_backface_dist);

--- a/Applications/src/evaluate-surface-mesh.cc
+++ b/Applications/src/evaluate-surface-mesh.cc
@@ -223,8 +223,10 @@ int main(int argc, char *argv[])
   int         select_comp = 0;
 
   Array<MeshProperty> measures;
-  double              min_frontface_dist = 1e-2;
-  double              min_backface_dist  = 1e-2;
+  double min_frontface_dist  = 1e-2;
+  double min_backface_dist   = 1e-2;
+  double max_collision_angle = 20.0;
+  bool fast_collision_test = false;
 
   double value;
   for (ALL_OPTIONS) {
@@ -295,14 +297,20 @@ int main(int argc, char *argv[])
     }
     else if (OPTION("-collisions") || OPTION("-self-intersections") || OPTION("-coll")) {
       measures.push_back(MESH_Collisions);
+      max_collision_angle = 20.0;
       if (HAS_ARGUMENT) {
         PARSE_ARGUMENT(min_frontface_dist);
-        if (HAS_ARGUMENT) PARSE_ARGUMENT(min_backface_dist);
-        else min_backface_dist = min_frontface_dist;
+        if (HAS_ARGUMENT) {
+          PARSE_ARGUMENT(min_backface_dist);
+          if (HAS_ARGUMENT) PARSE_ARGUMENT(max_collision_angle);
+        } else {
+          min_backface_dist = min_frontface_dist;
+        }
       } else {
         min_frontface_dist = min_backface_dist = 1e-2;
       }
     }
+    else HANDLE_BOOLEAN_OPTION("fast-collision-test", fast_collision_test);
     else HANDLE_COMMON_OR_UNKNOWN_OPTION();
   }
   if (measures.empty()) {
@@ -590,9 +598,10 @@ int main(int argc, char *argv[])
 
         SurfaceCollisions collisions;
         collisions.Input(surface);
+        collisions.FastCollisionTest(fast_collision_test);
         collisions.MinFrontfaceDistance(min_frontface_dist);
         collisions.MinBackfaceDistance(min_backface_dist);
-        collisions.MaxAngle(20.0);
+        collisions.MaxAngle(max_collision_angle);
         collisions.AdjacentIntersectionTestOn();
         collisions.NonAdjacentIntersectionTestOn();
         collisions.FrontfaceCollisionTestOn();

--- a/Modules/PointSet/include/mirtk/SurfaceCollisions.h
+++ b/Modules/PointSet/include/mirtk/SurfaceCollisions.h
@@ -220,6 +220,9 @@ private:
   mirtkPublicAttributeMacro(double, MaxAngle);
 
   /// Whether to perform intersection tests between adjacent triangles
+  mirtkPublicAttributeMacro(bool, AdjacentCollisionTest);
+
+  /// Whether to perform intersection tests between adjacent triangles
   mirtkPublicAttributeMacro(bool, AdjacentIntersectionTest);
 
   /// Whether to perform intersection tests between non-adjacent triangles

--- a/Modules/PointSet/src/SurfaceCollisions.cc
+++ b/Modules/PointSet/src/SurfaceCollisions.cc
@@ -296,10 +296,8 @@ public:
     bool   intersect, same_side;
 
     vtkIdType cellId1, cellId2;
-    vtkIdType ntriPtIds1, ntriPtIds2;
-    const vtkIdType *triPtIds1, *triPtIds2;
     UnorderedSet<vtkIdType> nearbyCellIds;
-    vtkNew<vtkIdList> cellIds, ptIds;
+    vtkNew<vtkIdList> cellIds, ptIds, triPtIds1, triPtIds2;
   
     IntersectionInfo intersection;
     CollisionInfo collision;
@@ -315,11 +313,11 @@ public:
       }
 
       // Get vertices and normal of this triangle
-      surface->GetCellPoints(cellId1, ntriPtIds1, triPtIds1);
-      mirtkAssert(ntriPtIds1 == 3, "surface is triangular mesh");
-      surface->GetPoint(triPtIds1[0], tri1[0]);
-      surface->GetPoint(triPtIds1[1], tri1[1]);
-      surface->GetPoint(triPtIds1[2], tri1[2]);
+      surface->GetCellPoints(cellId1, triPtIds1.GetPointer());
+      mirtkAssert(triPtIds1->GetNumberOfIds() == 3, "surface is triangular mesh");
+      surface->GetPoint(triPtIds1->GetId(0), tri1[0]);
+      surface->GetPoint(triPtIds1->GetId(1), tri1[1]);
+      surface->GetPoint(triPtIds1->GetId(2), tri1[2]);
       vtkTriangle::ComputeNormal(tri1[0], tri1[1], tri1[2], n1);
 
       // Get bounding sphere
@@ -342,17 +340,18 @@ public:
       for (const auto cellId2 : nearbyCellIds) {
 
         // Get vertex positions of nearby candidate triangle
-        surface->GetCellPoints(cellId2, ntriPtIds2, triPtIds2);
-        surface->GetPoint(triPtIds2[0], tri2[0]);
-        surface->GetPoint(triPtIds2[1], tri2[1]);
-        surface->GetPoint(triPtIds2[2], tri2[2]);
+        surface->GetCellPoints(cellId2, triPtIds2.GetPointer());
+        mirtkAssert(triPtIds2->GetNumberOfIds() == 3, "surface is triangular mesh");
+        surface->GetPoint(triPtIds2->GetId(0), tri2[0]);
+        surface->GetPoint(triPtIds2->GetId(1), tri2[1]);
+        surface->GetPoint(triPtIds2->GetId(2), tri2[2]);
         vtkTriangle::ComputeNormal(tri2[0], tri2[1], tri2[2], n2);
 
         // Get corresponding indices of shared vertices
         for (i1 = 0; i1 < 3; ++i1) {
           tri12[i1] = -1;
           for (i2 = 0; i2 < 3; ++i2) {
-            if (triPtIds1[i1] == triPtIds2[i2]) {
+            if (triPtIds1->GetId(i1) == triPtIds2->GetId(i2)) {
               tri12[i1] = i2;
               break;
             }

--- a/Modules/PointSet/src/SurfaceCollisions.cc
+++ b/Modules/PointSet/src/SurfaceCollisions.cc
@@ -78,19 +78,18 @@ public:
   /// Compute bounding spheres of specified range of cells
   void operator ()(const blocked_range<vtkIdType> &re) const
   {
-    vtkIdType npts;
-    const vtkIdType *pts;
+    vtkNew<vtkIdList> pts;
     double a[3], b[3], c[3], origin[3], radius;
 
     for (vtkIdType cellId = re.begin(); cellId != re.end(); ++cellId) {
       // Get triangle vertices
-      _Surface->GetCellPoints(cellId, npts, pts);
-      mirtkAssert(npts == 3, "surface is triangular mesh");
+      _Surface->GetCellPoints(cellId, pts.GetPointer());
+      mirtkAssert(pts->GetNumberOfIds() == 3, "surface is triangular mesh");
 
       // Get triangle vertex positions
-      _Surface->GetPoint(pts[0], a);
-      _Surface->GetPoint(pts[1], b);
-      _Surface->GetPoint(pts[2], c);
+      _Surface->GetPoint(pts->GetId(0), a);
+      _Surface->GetPoint(pts->GetId(1), b);
+      _Surface->GetPoint(pts->GetId(2), c);
 
       // Get center of bounding sphere
       vtkTriangle::TriangleCenter(a, b, c, origin);


### PR DESCRIPTION
This change fixes mistakes in the `SurfaceCollisions` filter. A related issue is #753, and both should be merged together.

The projection of triangles with a shared edge to 2D in order to check if both other vertices are on the same side of this edge was implemented incorrectly. Both triangles were projected to a different 2D plane. After initially fixing this, I eventually figured to simply compute the inner product between the vectors from the edge midpoint to each of the two other triangle vertices. An angle of less than 90 degrees means that triangles are folding onto each other.

Similarly, I've added a near-miss collision check for adjacent triangles, which either share an edge or a single vertex. Previously, the `SurfaceCollisions` filter would only detect intersections in these cases, but not report any collisions.

The current collision detection is somewhat an heuristic still. An algorithm which projects one triangle onto the other and computes the clipped convex overlap polygon would presumably be better. Will look into this later this week or in Dec.

**Attention:** This change results in slightly different surfaces on the dHCP data than previously. Option `adjacent_collision_test` exists to disable the added test of near-miss collisions between adjacent triangles, but the changes (bugfix) with respect to the adjacent intersection test remain.